### PR TITLE
Keeping initial path while appending the grpc path

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
+import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.appendPathToUri;
+
 import io.grpc.Channel;
 import io.opentelemetry.exporter.internal.grpc.GrpcSender;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
@@ -40,7 +42,7 @@ public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
       @Nullable SSLContext sslContext,
       @Nullable X509TrustManager trustManager) {
     return new OkHttpGrpcSender<>(
-        endpoint.resolve(endpointPath).toString(),
+        appendPathToUri(endpoint, endpointPath).toString(),
         compressionEnabled,
         timeoutNanos,
         headers,

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
 import io.opentelemetry.sdk.internal.DaemonThreadFactory;
+import java.net.URI;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,16 @@ public final class OkHttpUtil {
             TimeUnit.SECONDS,
             new SynchronousQueue<>(),
             new DaemonThreadFactory("okhttp-dispatch")));
+  }
+
+  /**
+   * Appends a path to the provided {@link URI} without removing the existing uri's path.
+   *
+   * @param target The provided URI to append the path to.
+   * @param pathToAppend The path to append.
+   */
+  public static URI appendPathToUri(URI target, String pathToAppend) {
+    return target.resolve(target.getPath() + "/" + pathToAppend).normalize();
   }
 
   private OkHttpUtil() {}

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
@@ -39,14 +39,14 @@ public final class OkHttpUtil {
    * @param pathToAppend The path to append.
    */
   public static URI appendPathToUri(URI target, String pathToAppend) {
-    return target.resolve(combinePaths(target.getPath(), pathToAppend)).normalize();
-  }
-
-  private static String combinePaths(String first, String second) {
-    if (first.isEmpty()) {
-      return second;
-    }
-    return first + "/" + second;
+    return URI.create(
+            target.getScheme()
+                + "://"
+                + target.getAuthority()
+                + target.getPath()
+                + "/"
+                + pathToAppend)
+        .normalize();
   }
 
   private OkHttpUtil() {}

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
@@ -39,7 +39,14 @@ public final class OkHttpUtil {
    * @param pathToAppend The path to append.
    */
   public static URI appendPathToUri(URI target, String pathToAppend) {
-    return target.resolve(target.getPath() + "/" + pathToAppend).normalize();
+    return target.resolve(combinePaths(target.getPath(), pathToAppend)).normalize();
+  }
+
+  private static String combinePaths(String first, String second) {
+    if (first.isEmpty()) {
+      return second;
+    }
+    return first + "/" + second;
   }
 
   private OkHttpUtil() {}

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtilTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtilTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.sender.okhttp.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class OkHttpUtilTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "https://one.name/existing/path,extra,https://one.name/existing/path/extra",
+    "https://one.name,extra,https://one.name/extra",
+    "https://one.name/path/with/slash/,extra,https://one.name/path/with/slash/extra",
+    "https://one.name/path/with/slash/,extra/segment,https://one.name/path/with/slash/extra/segment",
+    "https://one.name/path/with/slash/,/absoluteextra,https://one.name/path/with/slash/absoluteextra",
+  })
+  void appendPathToUri(String original, String path, String expected) {
+    URI target = URI.create(original);
+    assertEquals(expected, OkHttpUtil.appendPathToUri(target, path).toString());
+  }
+}

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtilTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtilTest.java
@@ -17,9 +17,12 @@ class OkHttpUtilTest {
   @CsvSource({
     "https://one.name/existing/path,extra,https://one.name/existing/path/extra",
     "https://one.name,extra,https://one.name/extra",
+    "http://one.name:60794,extra,http://one.name:60794/extra",
     "https://one.name/path/with/slash/,extra,https://one.name/path/with/slash/extra",
     "https://one.name/path/with/slash/,extra/segment,https://one.name/path/with/slash/extra/segment",
     "https://one.name/path/with/slash/,/absoluteextra,https://one.name/path/with/slash/absoluteextra",
+    "https://one.name,/absoluteextra,https://one.name/absoluteextra",
+    "https://one.name.slash/,/absoluteextra,https://one.name.slash/absoluteextra",
   })
   void appendPathToUri(String original, String path, String expected) {
     URI target = URI.create(original);


### PR DESCRIPTION
A [user needs](https://github.com/elastic/apm-agent-android/issues/187) to provide an export endpoint with an initial path, however, the gRPC exporter replaces the existing path in the provided endpoint at the moment.

I'm not sure if this is an expected behavior, however, if that's not the case then I believe the changes provided here should help prevent that from happening, by appending the grpc path on top of the existing one (if any).