### PR TITLE
Add Benchmark workflows

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -54,6 +54,14 @@ Same settings as above for `main`, except:
 
   (So that bot PR branches can be deleted)
 
+### `benchmarks`
+
+- Everything UNCHECKED
+
+  (This branch is currently only used for directly pushing benchmarking results from the
+  [overhead benchmark](https://github.com/open-telemetry/opentelemetry-java/actions/workflows/benchmark.yml)
+  job)
+
 ## Secrets and variables > Actions
 
 * `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password

--- a/.github/workflows/benchmark-tags.yml
+++ b/.github/workflows/benchmark-tags.yml
@@ -1,0 +1,74 @@
+name: Benchmark Tags
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sdk-benchmark:
+    name: Benchmark SDK
+    runs-on: self-hosted
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        tag-version:
+          - v1.6.0
+          - v1.7.0
+          - v1.7.1
+          - v1.10.0
+          - v1.10.1
+          - v1.11.0
+          - v1.12.0
+          - v1.13.0
+          - v1.14.0
+          - v1.15.0
+          - v1.16.0
+          - v1.17.0
+          - v1.18.0
+          - v1.19.0
+          - v1.21.0
+          - v1.22.0
+          - v1.23.0
+          - v1.23.1
+          - v1.24.0
+          - v1.25.0
+          - v1.26.0
+          - v1.27.0
+          - v1.28.0
+          - v1.29.0
+          - v1.30.0
+          - v1.30.1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.tag-version }}
+
+      - id: setup-java
+        name: Set up Java for build
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            jmhJar
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      - name: Run Benchmark
+        run: |
+          cd sdk/trace/build
+          java -jar libs/opentelemetry-sdk-trace-*-jmh.jar -rf json SpanBenchmark SpanPipelineBenchmark ExporterBenchmark
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'jmh'
+          output-file-path: sdk/trace/build/jmh-result.json
+          gh-pages-branch: benchmarks
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          benchmark-data-dir-path: ""
+          auto-push: true
+          ref: ${{ matrix.tag-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,43 @@
+name: Benchmark Main
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  sdk-benchmark:
+    name: Benchmark SDK
+    runs-on: self-hosted
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup-java
+        name: Set up Java for build
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            jmhJar
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      - name: Run Benchmark
+        run: |
+          cd sdk/trace/build
+          java -jar libs/opentelemetry-sdk-trace-*-jmh.jar -rf json SpanBenchmark SpanPipelineBenchmark ExporterBenchmark
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'jmh'
+          output-file-path: sdk/trace/build/jmh-result.json
+          gh-pages-branch: benchmarks
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          benchmark-data-dir-path: ""
+          auto-push: true


### PR DESCRIPTION
These workflows run a few JMH benchmarks and publish the results to a `benchmarks` branch. The expectation is that the branch would be published via github pages.

`benchmark-tags.yml` is intended to run manually as needed to populate benchmark data from historical versions. This works because the benchmarks being run have been in place for a long time. If we needed a new benchmark, methodologies would need to change.

In order for this to work, a new github pages branch needs to be created (assuming `benchmarks`):
```shell
git checkout --orphan benchmarks
git commit --allow-empty -m "Init"
git push origin benchmarks
```
(not tested, but something to this effect.)

Note: this won't actually work until the org-level self-hosted runner is configured to allow these workflows.