### PR TITLE
Move data dir to `benchmarks`

### DIFF
--- a/.github/workflows/benchmark-tags.yml
+++ b/.github/workflows/benchmark-tags.yml
@@ -69,6 +69,6 @@ jobs:
           output-file-path: sdk/trace/build/jmh-result.json
           gh-pages-branch: benchmarks
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          benchmark-data-dir-path: ""
+          benchmark-data-dir-path: "benchmarks"
           auto-push: true
           ref: ${{ matrix.tag-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,5 +39,5 @@ jobs:
           output-file-path: sdk/trace/build/jmh-result.json
           gh-pages-branch: benchmarks
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          benchmark-data-dir-path: ""
+          benchmark-data-dir-path: "benchmarks"
           auto-push: true


### PR DESCRIPTION
This is more consistent with other repos and allows us to include other things in the future without breaking urls.

A separate PR to move the existing data to that folder: #5875