### PR TITLE
Fix flaky MetricExporterConfigurationTest

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfigurationTest.java
@@ -34,8 +34,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class MetricExporterConfigurationTest {
 
-  private static final ConfigProperties EMPTY =
-      DefaultConfigProperties.createFromMap(Collections.emptyMap());
+  private static final ConfigProperties CONFIG_PROPERTIES =
+      DefaultConfigProperties.createFromMap(
+          Collections.singletonMap("otel.exporter.prometheus.port", "0"));
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
@@ -48,7 +49,7 @@ class MetricExporterConfigurationTest {
 
     MetricReader reader =
         MetricExporterConfiguration.configureReader(
-            "prometheus", EMPTY, spiHelper, (a, b) -> a, closeables);
+            "prometheus", CONFIG_PROPERTIES, spiHelper, (a, b) -> a, closeables);
     cleanup.addCloseables(closeables);
 
     assertThat(reader).isInstanceOf(PrometheusHttpServer.class);
@@ -60,7 +61,7 @@ class MetricExporterConfigurationTest {
   void configureExporter_KnownSpiExportersOnClasspath(
       String exporterName, Class<? extends Closeable> expectedExporter) {
     NamedSpiManager<MetricExporter> spiExportersManager =
-        MetricExporterConfiguration.metricExporterSpiManager(EMPTY, spiHelper);
+        MetricExporterConfiguration.metricExporterSpiManager(CONFIG_PROPERTIES, spiHelper);
 
     MetricExporter metricExporter =
         MetricExporterConfiguration.configureExporter(exporterName, spiExportersManager);
@@ -81,7 +82,7 @@ class MetricExporterConfigurationTest {
   void configureMetricReader_KnownSpiExportersOnClasspath(
       String exporterName, Class<? extends Closeable> expectedExporter) {
     NamedSpiManager<MetricReader> spiMetricReadersManager =
-        MetricExporterConfiguration.metricReadersSpiManager(EMPTY, spiHelper);
+        MetricExporterConfiguration.metricReadersSpiManager(CONFIG_PROPERTIES, spiHelper);
 
     MetricReader metricReader =
         MetricExporterConfiguration.configureMetricReader(exporterName, spiMetricReadersManager);


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java/issues/5866
My guess is that `configureMetricReader_KnownSpiExportersOnClasspath` fails with `java.net.BindException: Address already in use` because `configureReader_PrometheusOnClasspath`, which is the only test that also starts `PrometheusHttpServer` in `MetricExporterConfigurationTest` had not yet shut down `PrometheusHttpServer`. Shutting down `PrometheusHttpServer` https://github.com/open-telemetry/opentelemetry-java/blob/5ccc7fccb3fd0bdfa902bfea7bcee43384cdcf3e/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java#L164 waits for 10s for the server to shut down, running time of `configureReader_PrometheusOnClasspath` is 10.104s. So it think it is plausible that `configureMetricReader_KnownSpiExportersOnClasspath` started before `PrometheusHttpServer` from previous test was shut down. Also there is a 10s wait in shutting down of `PrometheusHttpServer` https://github.com/open-telemetry/opentelemetry-java/blob/5ccc7fccb3fd0bdfa902bfea7bcee43384cdcf3e/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java#L144-L160 Alternatively reducing that could make test more stable.