### PR TITLE
Ignore javadoc.io links

### DIFF
--- a/.github/config/markdown-link-check-config.json
+++ b/.github/config/markdown-link-check-config.json
@@ -3,5 +3,10 @@
   "aliveStatusCodes": [
     200,
     403
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://(www\\.)?javadoc\\.io"
+    }
   ]
 }


### PR DESCRIPTION
https://github.com/maxcellent/javadoc.io/issues/180 javadoc.io has been down for the whole day. Creating a pr to exclude it from link checks in case we need to get the build passing before it gets fixed.