### PR TITLE
Adding a tag to identify OkHttp calls made from OTel exporters

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -23,6 +23,8 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
+import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
+
 import io.opentelemetry.exporter.internal.RetryUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcResponse;
@@ -50,8 +52,6 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
-import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
 
 /**
  * A {@link GrpcSender} which uses OkHttp instead of grpc-java.

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -51,6 +51,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
+
 /**
  * A {@link GrpcSender} which uses OkHttp instead of grpc-java.
  *
@@ -107,7 +109,7 @@ public final class OkHttpGrpcSender<T extends Marshaler> implements GrpcSender<T
 
   @Override
   public void send(T request, Runnable onSuccess, BiConsumer<GrpcResponse, Throwable> onError) {
-    Request.Builder requestBuilder = new Request.Builder().url(url).headers(headers);
+    Request.Builder requestBuilder = newRequestBuilder().url(url).headers(headers);
 
     RequestBody requestBody = new GrpcRequestBody(request, compressionEnabled);
     requestBuilder.post(requestBody);

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
+import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
+
 import io.opentelemetry.exporter.internal.RetryUtil;
 import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.http.HttpSender;
@@ -30,8 +32,6 @@ import okhttp3.ResponseBody;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-
-import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
 
 /**
  * {@link HttpSender} which is backed by OkHttp.

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
@@ -31,6 +31,8 @@ import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
 
+import static io.opentelemetry.exporter.sender.okhttp.internal.OkHttpUtil.newRequestBuilder;
+
 /**
  * {@link HttpSender} which is backed by OkHttp.
  *
@@ -91,7 +93,7 @@ public final class OkHttpHttpSender implements HttpSender {
       int contentLength,
       Consumer<Response> onResponse,
       Consumer<Throwable> onError) {
-    Request.Builder requestBuilder = new Request.Builder().url(url);
+    Request.Builder requestBuilder = newRequestBuilder().url(url);
     headerSupplier.get().forEach(requestBuilder::addHeader);
     RequestBody body = new RawRequestBody(marshaler, contentLength, mediaType);
     if (compressionEnabled) {

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
@@ -10,6 +10,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Dispatcher;
+import okhttp3.Request;
 
 /**
  * Utilities for OkHttp.
@@ -29,6 +30,14 @@ public final class OkHttpUtil {
             TimeUnit.SECONDS,
             new SynchronousQueue<>(),
             new DaemonThreadFactory("okhttp-dispatch")));
+  }
+
+  /**
+   * Returns a {@link Request.Builder} with a tag to identify a request created by OTel. The tag can
+   * later be checked by an automatic instrumentation to avoid tracing OTel exporter's calls.
+   */
+  public static Request.Builder newRequestBuilder() {
+    return new Request.Builder().tag("suppress_instrumentation");
   }
 
   private OkHttpUtil() {}


### PR DESCRIPTION
Related to #5886

After deciding to use an internal solution in the previous SIG, and also raising concerns about the usage of a Context key due to performance penalties, I believe this approach is the most straightforward and stable way to identify OTel's OkHttp calls for internal, automatic instrumentation purposes, since it doesn't need to use Context keys, nor does it need to rely on Thread's values propagation or intercepting threads that OkHttp will use for async calls (in case of using ThreadLocals) or relying on the thread's name, since it seems like [it's being changed](https://github.com/square/okhttp/blob/bffc4cb555b1b03fd64874dca8a5f48b54fccdfa/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt#L539) before running OkHttp's interceptors, which is where the automatic traces are created.