### PR TITLE
Target kotlin 1.4 in kotlin extension

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of  against 
-No changes.
+===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.extension.kotlin.ContextExtensionsKt  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED ANNOTATION: kotlin.Metadata
+		---  REMOVED ELEMENT: xi=48 (-)
+		***  MODIFIED ELEMENT: mv=1,4,3 (<- 1,9,0)
+		===  UNCHANGED ELEMENT: k=2
+		===  UNCHANGED ELEMENT: d1=��&#xA;�&#xA;���&#xA;���&#xA;���&#xA;����&#xA;����0�*�0��&#xA;����0�*�0��&#xA;����0�*�0�¨��
+		===  UNCHANGED ELEMENT: d2=asContextElement,Lkotlin/coroutines/CoroutineContext;,Lio/opentelemetry/context/Context;,Lio/opentelemetry/context/ImplicitContextKeyed;,getOpenTelemetryContext,opentelemetry-extension-kotlin
+		+++  NEW ELEMENT: bv=1,0,3 (+)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-extension-kotlin.txt
@@ -2,9 +2,8 @@ Comparing source compatibility of  against
 ===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.extension.kotlin.ContextExtensionsKt  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	***  MODIFIED ANNOTATION: kotlin.Metadata
-		---  REMOVED ELEMENT: xi=48 (-)
-		***  MODIFIED ELEMENT: mv=1,4,3 (<- 1,9,0)
+		===  UNCHANGED ELEMENT: xi=48
+		***  MODIFIED ELEMENT: mv=1,6,0 (<- 1,9,0)
 		===  UNCHANGED ELEMENT: k=2
 		===  UNCHANGED ELEMENT: d1=��&#xA;�&#xA;���&#xA;���&#xA;���&#xA;����&#xA;����0�*�0��&#xA;����0�*�0��&#xA;����0�*�0�¨��
 		===  UNCHANGED ELEMENT: d2=asContextElement,Lkotlin/coroutines/CoroutineContext;,Lio/opentelemetry/context/Context;,Lio/opentelemetry/context/ImplicitContextKeyed;,getOpenTelemetryContext,opentelemetry-extension-kotlin
-		+++  NEW ELEMENT: bv=1,0,3 (+)

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -48,6 +48,7 @@ tasks {
   withType(KotlinCompile::class) {
     kotlinOptions {
       jvmTarget = "1.8"
+      languageVersion = "1.4"
     }
   }
 

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -48,8 +48,7 @@ tasks {
   withType(KotlinCompile::class) {
     kotlinOptions {
       jvmTarget = "1.8"
-      // earliest version supported by kotlin 1.9
-      languageVersion = "1.4"
+      languageVersion = "1.6"
     }
   }
 

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -48,6 +48,7 @@ tasks {
   withType(KotlinCompile::class) {
     kotlinOptions {
       jvmTarget = "1.8"
+      // earliest version supported by kotlin 1.9
       languageVersion = "1.4"
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java/issues/5903
1.4 should be the earliest supported version for 1.9 compiler, probably we'll have to bump this with the next kotlin version