### PR TITLE
Add env var substitution support to file configuration

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationFactory.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -33,6 +34,9 @@ public final class ConfigurationFactory {
   /**
    * Parse the {@code inputStream} YAML to {@link OpenTelemetryConfiguration} and interpret the
    * model to create {@link OpenTelemetrySdk} instance corresponding to the configuration.
+   *
+   * <p>Before parsing, environment variable substitution is performed as described in {@link
+   * ConfigurationReader#substituteEnvVariables(InputStream, Map)}.
    *
    * @param inputStream the configuration YAML
    * @return the {@link OpenTelemetrySdk}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationFactory.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -36,7 +35,7 @@ public final class ConfigurationFactory {
    * model to create {@link OpenTelemetrySdk} instance corresponding to the configuration.
    *
    * <p>Before parsing, environment variable substitution is performed as described in {@link
-   * ConfigurationReader#substituteEnvVariables(InputStream, Map)}.
+   * ConfigurationReader.EnvSubstitutionConstructor}.
    *
    * @param inputStream the configuration YAML
    * @return the {@link OpenTelemetrySdk}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationReader.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ConfigurationReader.java
@@ -8,25 +8,104 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfiguration;
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 
 final class ConfigurationReader {
 
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper()
-          // Create empty object instances for keys which are present but have null values
-          .setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));
+  private static final Pattern ENV_VARIABLE_REFERENCE =
+      Pattern.compile("\\$\\{env:([a-zA-Z_]+[a-zA-Z0-9_]*)}");
+
+  private static final ObjectMapper MAPPER;
+
+  static {
+    MAPPER =
+        new ObjectMapper()
+            // Create empty object instances for keys which are present but have null values
+            .setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));
+    // Boxed primitives which are present but have null values should be set to null, rather than
+    // empty instances
+    MAPPER.configOverride(String.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.SET));
+    MAPPER.configOverride(Integer.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.SET));
+    MAPPER.configOverride(Double.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.SET));
+    MAPPER.configOverride(Boolean.class).setSetterInfo(JsonSetter.Value.forValueNulls(Nulls.SET));
+  }
 
   private ConfigurationReader() {}
 
-  /** Parse the {@code configuration} YAML and return the {@link OpenTelemetryConfiguration}. */
+  /**
+   * Parse the {@code configuration} YAML and return the {@link OpenTelemetryConfiguration}.
+   *
+   * <p>Before parsing, environment variable substitution is performed as described in {@link
+   * #substituteEnvVariables(InputStream, Map)}.
+   */
   static OpenTelemetryConfiguration parse(InputStream configuration) {
+    return parse(configuration, System.getenv());
+  }
+
+  // Visible for testing
+  static OpenTelemetryConfiguration parse(
+      InputStream configuration, Map<String, String> environmentVariables) {
+    Object yamlObj = loadYaml(configuration, environmentVariables);
+    return MAPPER.convertValue(yamlObj, OpenTelemetryConfiguration.class);
+  }
+
+  static Object loadYaml(InputStream inputStream, Map<String, String> environmentVariables) {
     LoadSettings settings = LoadSettings.builder().build();
     Load yaml = new Load(settings);
-    Object yamlObj = yaml.loadFromInputStream(configuration);
-    return MAPPER.convertValue(yamlObj, OpenTelemetryConfiguration.class);
+    String withEnvironmentVariablesSubstituted =
+        substituteEnvVariables(inputStream, environmentVariables);
+    return yaml.loadFromString(withEnvironmentVariablesSubstituted);
+  }
+
+  /**
+   * Read the input and substitute any environment variables.
+   *
+   * <p>Environment variables follow the syntax {@code ${env:VARIABLE}}, where {@code VARIABLE} is
+   * an environment variable matching the regular expression {@code [a-zA-Z_]+[a-zA-Z0-9_]*}.
+   *
+   * <p>If a referenced environment variable is not defined, it is replaced with {@code ""}.
+   *
+   * @return the string contents of the {@code inputStream} with environment variables substituted
+   */
+  static String substituteEnvVariables(
+      InputStream inputStream, Map<String, String> environmentVariables) {
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+      StringBuilder stringBuilder = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        Matcher matcher = ENV_VARIABLE_REFERENCE.matcher(line);
+        if (matcher.find()) {
+          int offset = 0;
+          StringBuilder newLine = new StringBuilder();
+          do {
+            MatchResult matchResult = matcher.toMatchResult();
+            String replacement = environmentVariables.getOrDefault(matcher.group(1), "");
+            newLine.append(line, offset, matchResult.start()).append(replacement);
+            offset = matchResult.end();
+          } while (matcher.find());
+          if (offset != line.length()) {
+            newLine.append(line, offset, line.length());
+          }
+          line = newLine.toString();
+        }
+        stringBuilder.append(line).append(System.lineSeparator());
+      }
+      return stringBuilder.toString();
+    } catch (IOException e) {
+      throw new ConfigurationException("Error reading input stream", e);
+    }
   }
 }


### PR DESCRIPTION
Environment variable substitution was one of the key parts of file configuration described in the [original OTEP](https://github.com/open-telemetry/oteps/blob/main/text/0225-configuration.md#environment-variable-substitution).

I've been holding off defining it in the [file configuration spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md) because I've been trying to define the key [parse / create operations](https://github.com/open-telemetry/opentelemetry-specification/pull/3437), and it makes sense to describe environment variable substitution as a requirement of `parse`.

So while this isn't part of the spec yet, I will be trying to get it added as soon as possible. I think the syntax of environment variables (i.e. `${env:VARIABLE_NAME}`) is the most likely thing the spec lands on since its the syntax the collector uses and it will be hard to argue that an alternative new syntax would trump consistency with the collector.