### PR TITLE
POC: Set attribute on span if used as exemplar

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
@@ -82,14 +82,10 @@ public interface ExemplarReservoir<T extends ExemplarData> {
     return new SpanUpdatingExemplarReservoir<>(original);
   }
 
-  /**
-   * Offers a {@code double} measurement to be sampled.
-   */
+  /** Offers a {@code double} measurement to be sampled. */
   boolean offerDoubleMeasurement(double value, Attributes attributes, Context context);
 
-  /**
-   * Offers a {@code long} measurement to be sampled.
-   */
+  /** Offers a {@code long} measurement to be sampled. */
   boolean offerLongMeasurement(long value, Attributes attributes, Context context);
 
   /**

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java
@@ -77,11 +77,20 @@ public interface ExemplarReservoir<T extends ExemplarData> {
     return new HistogramExemplarReservoir(clock, boundaries);
   }
 
-  /** Offers a {@code double} measurement to be sampled. */
-  void offerDoubleMeasurement(double value, Attributes attributes, Context context);
+  static <T extends ExemplarData> ExemplarReservoir<T> spanUpdatingReservoir(
+      ExemplarReservoir<T> original) {
+    return new SpanUpdatingExemplarReservoir<>(original);
+  }
 
-  /** Offers a {@code long} measurement to be sampled. */
-  void offerLongMeasurement(long value, Attributes attributes, Context context);
+  /**
+   * Offers a {@code double} measurement to be sampled.
+   */
+  boolean offerDoubleMeasurement(double value, Attributes attributes, Context context);
+
+  /**
+   * Offers a {@code long} measurement to be sampled.
+   */
+  boolean offerLongMeasurement(long value, Attributes attributes, Context context);
 
   /**
    * Returns an immutable list of Exemplars for exporting from the current reservoir.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoir.java
@@ -37,21 +37,23 @@ abstract class FixedSizeExemplarReservoir<T extends ExemplarData> implements Exe
   }
 
   @Override
-  public void offerLongMeasurement(long value, Attributes attributes, Context context) {
+  public boolean offerLongMeasurement(long value, Attributes attributes, Context context) {
     int bucket = reservoirCellSelector.reservoirCellIndexFor(storage, value, attributes, context);
-    if (bucket != -1) {
-      this.storage[bucket].recordLongMeasurement(value, attributes, context);
+    if (bucket != -1 && storage[bucket].recordLongMeasurement(value, attributes, context)) {
       this.hasMeasurements = true;
+      return true;
     }
+    return false;
   }
 
   @Override
-  public void offerDoubleMeasurement(double value, Attributes attributes, Context context) {
+  public boolean offerDoubleMeasurement(double value, Attributes attributes, Context context) {
     int bucket = reservoirCellSelector.reservoirCellIndexFor(storage, value, attributes, context);
-    if (bucket != -1) {
-      this.storage[bucket].recordDoubleMeasurement(value, attributes, context);
+    if (bucket != -1 && storage[bucket].recordDoubleMeasurement(value, attributes, context)) {
       this.hasMeasurements = true;
+      return true;
     }
+    return false;
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
@@ -24,8 +24,8 @@ class HistogramExemplarReservoir extends FixedSizeExemplarReservoir<DoubleExempl
   }
 
   @Override
-  public void offerLongMeasurement(long value, Attributes attributes, Context context) {
-    super.offerDoubleMeasurement((double) value, attributes, context);
+  public boolean offerLongMeasurement(long value, Attributes attributes, Context context) {
+    return super.offerDoubleMeasurement((double) value, attributes, context);
   }
 
   static class HistogramCellSelector implements ReservoirCellSelector {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/NoopExemplarReservoir.java
@@ -24,13 +24,15 @@ class NoopExemplarReservoir<T extends ExemplarData> implements ExemplarReservoir
   private NoopExemplarReservoir() {}
 
   @Override
-  public void offerDoubleMeasurement(double value, Attributes attributes, Context context) {
+  public boolean offerDoubleMeasurement(double value, Attributes attributes, Context context) {
     // Do nothing
+    return false;
   }
 
   @Override
-  public void offerLongMeasurement(long value, Attributes attributes, Context context) {
+  public boolean offerLongMeasurement(long value, Attributes attributes, Context context) {
     // Do nothing
+    return false;
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
@@ -66,7 +66,8 @@ class ReservoirCell {
    * #recordLongMeasurement(long, Attributes, Context)} and {@link #getAndResetLong(Attributes)}
    * must not be used when a cell is recording longs.
    */
-  synchronized boolean recordDoubleMeasurement(double value, Attributes attributes, Context context) {
+  synchronized boolean recordDoubleMeasurement(
+      double value, Attributes attributes, Context context) {
     if (hasValue()) {
       return false;
     } else {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
@@ -49,9 +49,14 @@ class ReservoirCell {
    * #recordDoubleMeasurement(double, Attributes, Context)} and {@link
    * #getAndResetDouble(Attributes)} must not be used when a cell is recording longs.
    */
-  synchronized void recordLongMeasurement(long value, Attributes attributes, Context context) {
-    this.longValue = value;
-    offerMeasurement(attributes, context);
+  synchronized boolean recordLongMeasurement(long value, Attributes attributes, Context context) {
+    if (hasValue()) {
+      return false;
+    } else {
+      this.longValue = value;
+      offerMeasurement(attributes, context);
+      return true;
+    }
   }
 
   /**
@@ -61,9 +66,14 @@ class ReservoirCell {
    * #recordLongMeasurement(long, Attributes, Context)} and {@link #getAndResetLong(Attributes)}
    * must not be used when a cell is recording longs.
    */
-  synchronized void recordDoubleMeasurement(double value, Attributes attributes, Context context) {
-    this.doubleValue = value;
-    offerMeasurement(attributes, context);
+  synchronized boolean recordDoubleMeasurement(double value, Attributes attributes, Context context) {
+    if (hasValue()) {
+      return false;
+    } else {
+      this.doubleValue = value;
+      offerMeasurement(attributes, context);
+      return true;
+    }
   }
 
   private void offerMeasurement(Attributes attributes, Context context) {
@@ -118,6 +128,10 @@ class ReservoirCell {
     this.doubleValue = 0;
     this.spanContext = SpanContext.getInvalid();
     this.recordTime = 0;
+  }
+
+  private boolean hasValue() {
+    return recordTime != 0;
   }
 
   /** Returns filtered attributes for exemplars. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoir.java
@@ -13,7 +13,8 @@ import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.List;
 
 public class SpanUpdatingExemplarReservoir<T extends ExemplarData> implements ExemplarReservoir<T> {
-  private static final AttributeKey<Boolean> KEY_EXEMPLAR = AttributeKey.booleanKey("otel.exemplar");
+  private static final AttributeKey<Boolean> KEY_EXEMPLAR =
+      AttributeKey.booleanKey("otel.exemplar");
   private final ExemplarReservoir<T> reservoir;
 
   SpanUpdatingExemplarReservoir(ExemplarReservoir<T> reservoir) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoir.java
@@ -5,35 +5,40 @@
 
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import java.util.List;
 
-/** A reservoir that has a pre-filter on measurements. */
-class FilteredExemplarReservoir<T extends ExemplarData> implements ExemplarReservoir<T> {
-  private final ExemplarFilter filter;
+public class SpanUpdatingExemplarReservoir<T extends ExemplarData> implements ExemplarReservoir<T> {
+  private static final AttributeKey<Boolean> KEY_EXEMPLAR = AttributeKey.booleanKey("otel.exemplar");
   private final ExemplarReservoir<T> reservoir;
 
-  FilteredExemplarReservoir(ExemplarFilter filter, ExemplarReservoir<T> reservoir) {
-    this.filter = filter;
+  SpanUpdatingExemplarReservoir(ExemplarReservoir<T> reservoir) {
     this.reservoir = reservoir;
   }
 
   @Override
   public boolean offerDoubleMeasurement(double value, Attributes attributes, Context context) {
-    return filter.shouldSampleMeasurement(value, attributes, context)
-        && reservoir.offerDoubleMeasurement(value, attributes, context);
+    return updateSpan(reservoir.offerDoubleMeasurement(value, attributes, context), context);
   }
 
   @Override
   public boolean offerLongMeasurement(long value, Attributes attributes, Context context) {
-    return filter.shouldSampleMeasurement(value, attributes, context)
-        && reservoir.offerLongMeasurement(value, attributes, context);
+    return updateSpan(reservoir.offerLongMeasurement(value, attributes, context), context);
   }
 
   @Override
   public List<T> collectAndReset(Attributes pointAttributes) {
     return reservoir.collectAndReset(pointAttributes);
+  }
+
+  private static boolean updateSpan(boolean success, Context context) {
+    if (success) {
+      Span.fromContext(context).setAttribute(KEY_EXEMPLAR, true);
+    }
+    return success;
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/Base2ExponentialHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/Base2ExponentialHistogramAggregation.java
@@ -71,12 +71,12 @@ public final class Base2ExponentialHistogramAggregation implements Aggregation, 
         new DoubleBase2ExponentialHistogramAggregator(
             () ->
                 ExemplarReservoir.spanUpdatingReservoir(
-                  ExemplarReservoir.filtered(
-                      exemplarFilter,
-                      ExemplarReservoir.doubleFixedSizeReservoir(
-                          Clock.getDefault(),
-                          Runtime.getRuntime().availableProcessors(),
-                          RandomSupplier.platformDefault()))),
+                    ExemplarReservoir.filtered(
+                        exemplarFilter,
+                        ExemplarReservoir.doubleFixedSizeReservoir(
+                            Clock.getDefault(),
+                            Runtime.getRuntime().availableProcessors(),
+                            RandomSupplier.platformDefault()))),
             maxBuckets,
             maxScale);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/Base2ExponentialHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/Base2ExponentialHistogramAggregation.java
@@ -70,12 +70,13 @@ public final class Base2ExponentialHistogramAggregation implements Aggregation, 
     return (Aggregator<T, U>)
         new DoubleBase2ExponentialHistogramAggregator(
             () ->
-                ExemplarReservoir.filtered(
-                    exemplarFilter,
-                    ExemplarReservoir.doubleFixedSizeReservoir(
-                        Clock.getDefault(),
-                        Runtime.getRuntime().availableProcessors(),
-                        RandomSupplier.platformDefault())),
+                ExemplarReservoir.spanUpdatingReservoir(
+                  ExemplarReservoir.filtered(
+                      exemplarFilter,
+                      ExemplarReservoir.doubleFixedSizeReservoir(
+                          Clock.getDefault(),
+                          Runtime.getRuntime().availableProcessors(),
+                          RandomSupplier.platformDefault()))),
             maxBuckets,
             maxScale);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
@@ -56,10 +56,10 @@ public final class ExplicitBucketHistogramAggregation implements Aggregation, Ag
             bucketBoundaryArray,
             () ->
                 ExemplarReservoir.spanUpdatingReservoir(
-                  ExemplarReservoir.filtered(
-                      exemplarFilter,
-                      ExemplarReservoir.histogramBucketReservoir(
-                          Clock.getDefault(), bucketBoundaries))));
+                    ExemplarReservoir.filtered(
+                        exemplarFilter,
+                        ExemplarReservoir.histogramBucketReservoir(
+                            Clock.getDefault(), bucketBoundaries))));
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java
@@ -55,10 +55,11 @@ public final class ExplicitBucketHistogramAggregation implements Aggregation, Ag
         new DoubleExplicitBucketHistogramAggregator(
             bucketBoundaryArray,
             () ->
-                ExemplarReservoir.filtered(
-                    exemplarFilter,
-                    ExemplarReservoir.histogramBucketReservoir(
-                        Clock.getDefault(), bucketBoundaries)));
+                ExemplarReservoir.spanUpdatingReservoir(
+                  ExemplarReservoir.filtered(
+                      exemplarFilter,
+                      ExemplarReservoir.histogramBucketReservoir(
+                          Clock.getDefault(), bucketBoundaries))));
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
@@ -46,12 +46,12 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
           Supplier<ExemplarReservoir<LongExemplarData>> reservoirFactory =
               () ->
                   ExemplarReservoir.spanUpdatingReservoir(
-                    ExemplarReservoir.filtered(
-                        exemplarFilter,
-                        ExemplarReservoir.longFixedSizeReservoir(
-                            Clock.getDefault(),
-                            Runtime.getRuntime().availableProcessors(),
-                            RandomSupplier.platformDefault())));
+                      ExemplarReservoir.filtered(
+                          exemplarFilter,
+                          ExemplarReservoir.longFixedSizeReservoir(
+                              Clock.getDefault(),
+                              Runtime.getRuntime().availableProcessors(),
+                              RandomSupplier.platformDefault())));
           return (Aggregator<T, U>) new LongSumAggregator(instrumentDescriptor, reservoirFactory);
         }
       case DOUBLE:
@@ -59,12 +59,12 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
           Supplier<ExemplarReservoir<DoubleExemplarData>> reservoirFactory =
               () ->
                   ExemplarReservoir.spanUpdatingReservoir(
-                    ExemplarReservoir.filtered(
-                        exemplarFilter,
-                        ExemplarReservoir.doubleFixedSizeReservoir(
-                            Clock.getDefault(),
-                            Runtime.getRuntime().availableProcessors(),
-                            RandomSupplier.platformDefault())));
+                      ExemplarReservoir.filtered(
+                          exemplarFilter,
+                          ExemplarReservoir.doubleFixedSizeReservoir(
+                              Clock.getDefault(),
+                              Runtime.getRuntime().availableProcessors(),
+                              RandomSupplier.platformDefault())));
           return (Aggregator<T, U>) new DoubleSumAggregator(instrumentDescriptor, reservoirFactory);
         }
     }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
@@ -45,24 +45,26 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
         {
           Supplier<ExemplarReservoir<LongExemplarData>> reservoirFactory =
               () ->
-                  ExemplarReservoir.filtered(
-                      exemplarFilter,
-                      ExemplarReservoir.longFixedSizeReservoir(
-                          Clock.getDefault(),
-                          Runtime.getRuntime().availableProcessors(),
-                          RandomSupplier.platformDefault()));
+                  ExemplarReservoir.spanUpdatingReservoir(
+                    ExemplarReservoir.filtered(
+                        exemplarFilter,
+                        ExemplarReservoir.longFixedSizeReservoir(
+                            Clock.getDefault(),
+                            Runtime.getRuntime().availableProcessors(),
+                            RandomSupplier.platformDefault())));
           return (Aggregator<T, U>) new LongSumAggregator(instrumentDescriptor, reservoirFactory);
         }
       case DOUBLE:
         {
           Supplier<ExemplarReservoir<DoubleExemplarData>> reservoirFactory =
               () ->
-                  ExemplarReservoir.filtered(
-                      exemplarFilter,
-                      ExemplarReservoir.doubleFixedSizeReservoir(
-                          Clock.getDefault(),
-                          Runtime.getRuntime().availableProcessors(),
-                          RandomSupplier.platformDefault()));
+                  ExemplarReservoir.spanUpdatingReservoir(
+                    ExemplarReservoir.filtered(
+                        exemplarFilter,
+                        ExemplarReservoir.doubleFixedSizeReservoir(
+                            Clock.getDefault(),
+                            Runtime.getRuntime().availableProcessors(),
+                            RandomSupplier.platformDefault())));
           return (Aggregator<T, U>) new DoubleSumAggregator(instrumentDescriptor, reservoirFactory);
         }
     }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
@@ -132,11 +132,11 @@ class DoubleRandomFixedSizeExemplarReservoirTest {
         .satisfiesExactlyInAnyOrder(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(2);
+              assertThat(exemplar.getValue()).isEqualTo(1);
             },
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(3);
+              assertThat(exemplar.getValue()).isEqualTo(2);
             });
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoirTest.java
@@ -60,7 +60,7 @@ class HistogramExemplarReservoirTest {
         .satisfiesExactly(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(4);
+              assertThat(exemplar.getValue()).isEqualTo(3);
               assertThat(exemplar.getFilteredAttributes()).isEmpty();
             });
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
@@ -132,11 +132,11 @@ class LongRandomFixedSizeExemplarReservoirTest {
         .satisfiesExactlyInAnyOrder(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(2);
+              assertThat(exemplar.getValue()).isEqualTo(1);
             },
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(3);
+              assertThat(exemplar.getValue()).isEqualTo(2);
             });
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoirTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SpanUpdatingExemplarReservoirTest {
+  private static final AttributeKey<Boolean> KEY = AttributeKey.booleanKey("otel.exemplar");
+  private static final SpanBuilder spanBuilder =
+    SdkTracerProvider.builder().build().get("").spanBuilder("");
+  @Mock ExemplarReservoir<DoubleExemplarData> doubleParent;
+  @Mock ExemplarReservoir<LongExemplarData> longParent;
+  @Spy Span span = spanBuilder.startSpan();
+
+  @Test
+  void offerDoubleMeasurement_parentRefused() {
+    when(doubleParent.offerDoubleMeasurement(anyDouble(), any(), any())).thenReturn(false);
+    SpanUpdatingExemplarReservoir<DoubleExemplarData> reservoir =
+        new SpanUpdatingExemplarReservoir<>(doubleParent);
+    assertThat(reservoir.offerDoubleMeasurement(1.0, Attributes.empty(), Context.root().with(span)))
+        .isFalse();
+
+    verify(span, never()).setAttribute(any(), anyBoolean());
+  }
+
+  @Test
+  void offerDoubleMeasurement_parentAccepted() {
+    doReturn(true).when(doubleParent).offerDoubleMeasurement(anyDouble(), any(), any());
+    SpanUpdatingExemplarReservoir<DoubleExemplarData> reservoir =
+        new SpanUpdatingExemplarReservoir<>(doubleParent);
+    assertThat(reservoir.offerDoubleMeasurement(1.0, Attributes.empty(), Context.root().with(span)))
+        .isTrue();
+
+    verify(span).setAttribute(KEY, true);
+  }
+
+  @Test
+  void offerLongMeasurement_parentRefused() {
+    when(longParent.offerLongMeasurement(anyLong(), any(), any())).thenReturn(false);
+    SpanUpdatingExemplarReservoir<LongExemplarData> reservoir =
+        new SpanUpdatingExemplarReservoir<>(longParent);
+    assertThat(reservoir.offerLongMeasurement(1L, Attributes.empty(), Context.root().with(span)))
+        .isFalse();
+
+    verify(span, never()).setAttribute(any(), anyBoolean());
+  }
+
+  @Test
+  void offerLongMeasurement_parentAccepted() {
+    doReturn(true).when(longParent).offerLongMeasurement(anyLong(), any(), any());
+    SpanUpdatingExemplarReservoir<LongExemplarData> reservoir =
+        new SpanUpdatingExemplarReservoir<>(longParent);
+    assertThat(reservoir.offerLongMeasurement(1L, Attributes.empty(), Context.root().with(span)))
+        .isTrue();
+
+    verify(span).setAttribute(KEY, true);
+  }
+
+  @Test
+  void collectAndReset() {
+    SpanUpdatingExemplarReservoir<LongExemplarData> reservoir =
+        new SpanUpdatingExemplarReservoir<>(longParent);
+    Attributes attributes = Attributes.of(AttributeKey.stringKey("test"), "!");
+    List<LongExemplarData> data = Arrays.asList(
+        ImmutableLongExemplarData.create(Attributes.empty(), 123L, SpanContext.getInvalid(), 456L));
+    doReturn(data).when(longParent).collectAndReset(attributes);
+    assertThat(reservoir.collectAndReset(attributes))
+        .isEqualTo(data);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/SpanUpdatingExemplarReservoirTest.java
@@ -37,7 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SpanUpdatingExemplarReservoirTest {
   private static final AttributeKey<Boolean> KEY = AttributeKey.booleanKey("otel.exemplar");
   private static final SpanBuilder spanBuilder =
-    SdkTracerProvider.builder().build().get("").spanBuilder("");
+      SdkTracerProvider.builder().build().get("").spanBuilder("");
   @Mock ExemplarReservoir<DoubleExemplarData> doubleParent;
   @Mock ExemplarReservoir<LongExemplarData> longParent;
   @Spy Span span = spanBuilder.startSpan();
@@ -91,10 +91,11 @@ class SpanUpdatingExemplarReservoirTest {
     SpanUpdatingExemplarReservoir<LongExemplarData> reservoir =
         new SpanUpdatingExemplarReservoir<>(longParent);
     Attributes attributes = Attributes.of(AttributeKey.stringKey("test"), "!");
-    List<LongExemplarData> data = Arrays.asList(
-        ImmutableLongExemplarData.create(Attributes.empty(), 123L, SpanContext.getInvalid(), 456L));
+    List<LongExemplarData> data =
+        Arrays.asList(
+            ImmutableLongExemplarData.create(
+                Attributes.empty(), 123L, SpanContext.getInvalid(), 456L));
     doReturn(data).when(longParent).collectAndReset(attributes);
-    assertThat(reservoir.collectAndReset(attributes))
-        .isEqualTo(data);
+    assertThat(reservoir.collectAndReset(attributes)).isEqualTo(data);
   }
 }


### PR DESCRIPTION
Proof of Concept for a way to support metric exemplars and tail-based sampling at the same time. Hopefully this will spur discussion on how we want to support this use-case.

Relevant issue: https://github.com/open-telemetry/opentelemetry-specification/issues/2922

This makes a few big changes:
- `HistogramExemplarReservoir` and `RandomFixedSizeExemplarReservoir` now collect the `first` instead of the `last` exemplar sample they see. This lets us know whether or not a span will be used as an exemplar while it is still current.
- `ExemplarReservoir.offerXXXMeasurement` now returns `boolean` so callers know whether or not the span is being used as an exemplar.
- Suggest `otel.exemplar` as a potential new attribute that, when set to `true` means the sample is being used as an exemplar.

This approach allows tail-based samplers to ensure that all traces containing spans with `otel.exemplar == true` are kept, while the rest can be sampled without accidentally dropping a span used as an exemplar.