### PR TITLE
POC: More simply set attribute on exemplar spans

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoir.java
@@ -26,11 +26,12 @@ abstract class FixedSizeExemplarReservoir<T extends ExemplarData> implements Exe
   FixedSizeExemplarReservoir(
       Clock clock,
       int size,
+      boolean overwriteCellValue,
       ReservoirCellSelector reservoirCellSelector,
       BiFunction<ReservoirCell, Attributes, T> mapAndResetCell) {
     this.storage = new ReservoirCell[size];
     for (int i = 0; i < size; ++i) {
-      this.storage[i] = new ReservoirCell(clock);
+      this.storage[i] = new ReservoirCell(clock, overwriteCellValue);
     }
     this.reservoirCellSelector = reservoirCellSelector;
     this.mapAndResetCell = mapAndResetCell;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java
@@ -19,6 +19,7 @@ class HistogramExemplarReservoir extends FixedSizeExemplarReservoir<DoubleExempl
     super(
         clock,
         boundaries.size() + 1,
+        /* overwriteCellValue= */ false,
         new HistogramCellSelector(boundaries),
         ReservoirCell::getAndResetDouble);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/RandomFixedSizeExemplarReservoir.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/RandomFixedSizeExemplarReservoir.java
@@ -33,7 +33,12 @@ class RandomFixedSizeExemplarReservoir<T extends ExemplarData>
       int size,
       Supplier<Random> randomSupplier,
       BiFunction<ReservoirCell, Attributes, T> mapAndResetCell) {
-    super(clock, size, new RandomCellSelector(randomSupplier), mapAndResetCell);
+    super(
+        clock,
+        size,
+        /* overwriteCellValue= */ true,
+        new RandomCellSelector(randomSupplier),
+        mapAndResetCell);
   }
 
   static RandomFixedSizeExemplarReservoir<LongExemplarData> createLong(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
@@ -40,9 +40,11 @@ class ReservoirCell {
   // Cell stores either long or double values, but must not store both
   private long longValue;
   private double doubleValue;
+  private final boolean overwriteValue;
 
-  ReservoirCell(Clock clock) {
+  ReservoirCell(Clock clock, boolean overwriteValue) {
     this.clock = clock;
+    this.overwriteValue = overwriteValue;
   }
 
   /**
@@ -53,7 +55,7 @@ class ReservoirCell {
    * #getAndResetDouble(Attributes)} must not be used when a cell is recording longs.
    */
   synchronized void recordLongMeasurement(long value, Attributes attributes, Context context) {
-    if (isEmpty()) {
+    if (shouldWrite()) {
       this.longValue = value;
       offerMeasurement(attributes, context);
     }
@@ -67,7 +69,7 @@ class ReservoirCell {
    * must not be used when a cell is recording longs.
    */
   synchronized void recordDoubleMeasurement(double value, Attributes attributes, Context context) {
-    if (isEmpty()) {
+    if (shouldWrite()) {
       this.doubleValue = value;
       offerMeasurement(attributes, context);
     }
@@ -130,8 +132,8 @@ class ReservoirCell {
     this.recordTime = 0;
   }
 
-  boolean isEmpty() {
-    return recordTime == 0;
+  boolean shouldWrite() {
+    return overwriteValue || recordTime == 0;
   }
 
   /** Returns filtered attributes for exemplars. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
@@ -66,8 +66,7 @@ class ReservoirCell {
    * #recordLongMeasurement(long, Attributes, Context)} and {@link #getAndResetLong(Attributes)}
    * must not be used when a cell is recording longs.
    */
-  synchronized void recordDoubleMeasurement(
-      double value, Attributes attributes, Context context) {
+  synchronized void recordDoubleMeasurement(double value, Attributes attributes, Context context) {
     if (isEmpty()) {
       this.doubleValue = value;
       offerMeasurement(attributes, context);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
@@ -6,10 +6,16 @@
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -17,6 +23,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.internal.RandomSupplier;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.testing.time.TestClock;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.time.Duration;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -138,5 +145,19 @@ class DoubleRandomFixedSizeExemplarReservoirTest {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
               assertThat(exemplar.getValue()).isEqualTo(2);
             });
+  }
+
+  @Test
+  public void multiMeasurement_setSpanAttributeOnFirstMeasurement() {
+    SpanBuilder spanBuilder = SdkTracerProvider.builder().build().get("").spanBuilder("");
+    Span span = spy(spanBuilder.startSpan());
+    Context ctx = Context.root().with(span);
+    TestClock clock = TestClock.create();
+    ExemplarReservoir<DoubleExemplarData> reservoir =
+        RandomFixedSizeExemplarReservoir.createDouble(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerLongMeasurement(1, Attributes.empty(), ctx);
+    verify(span).setAttribute(AttributeKey.booleanKey("otel.exemplar"), true);
+    reservoir.offerLongMeasurement(2, Attributes.empty(), ctx);
+    verify(span, never()).setAttribute(any(), anyBoolean());
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
@@ -6,9 +6,7 @@
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -139,16 +137,16 @@ class DoubleRandomFixedSizeExemplarReservoirTest {
         .satisfiesExactlyInAnyOrder(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(1);
+              assertThat(exemplar.getValue()).isEqualTo(2);
             },
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(2);
+              assertThat(exemplar.getValue()).isEqualTo(3);
             });
   }
 
   @Test
-  public void multiMeasurement_setSpanAttributeOnFirstMeasurement() {
+  public void multiMeasurement_setSpanAttributeOnBothMeasurements() {
     SpanBuilder spanBuilder = SdkTracerProvider.builder().build().get("").spanBuilder("");
     Span span = spy(spanBuilder.startSpan());
     Context ctx = Context.root().with(span);
@@ -157,7 +155,8 @@ class DoubleRandomFixedSizeExemplarReservoirTest {
         RandomFixedSizeExemplarReservoir.createDouble(clock, 1, RandomSupplier.platformDefault());
     reservoir.offerLongMeasurement(1, Attributes.empty(), ctx);
     verify(span).setAttribute(AttributeKey.booleanKey("otel.exemplar"), true);
+    reset(span);
     reservoir.offerLongMeasurement(2, Attributes.empty(), ctx);
-    verify(span, never()).setAttribute(any(), anyBoolean());
+    verify(span).setAttribute(AttributeKey.booleanKey("otel.exemplar"), true);
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/DoubleRandomFixedSizeExemplarReservoirTest.java
@@ -132,11 +132,11 @@ class DoubleRandomFixedSizeExemplarReservoirTest {
         .satisfiesExactlyInAnyOrder(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(2);
+              assertThat(exemplar.getValue()).isEqualTo(1);
             },
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(3);
+              assertThat(exemplar.getValue()).isEqualTo(2);
             });
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoirTest.java
@@ -60,7 +60,7 @@ class HistogramExemplarReservoirTest {
         .satisfiesExactly(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(4);
+              assertThat(exemplar.getValue()).isEqualTo(3);
               assertThat(exemplar.getFilteredAttributes()).isEmpty();
             });
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
@@ -132,11 +132,11 @@ class LongRandomFixedSizeExemplarReservoirTest {
         .satisfiesExactlyInAnyOrder(
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(2);
+              assertThat(exemplar.getValue()).isEqualTo(1);
             },
             exemplar -> {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
-              assertThat(exemplar.getValue()).isEqualTo(3);
+              assertThat(exemplar.getValue()).isEqualTo(2);
             });
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/exemplar/LongRandomFixedSizeExemplarReservoirTest.java
@@ -6,10 +6,16 @@
 package io.opentelemetry.sdk.metrics.internal.exemplar;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -17,6 +23,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.internal.RandomSupplier;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.testing.time.TestClock;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.time.Duration;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
@@ -106,7 +113,7 @@ class LongRandomFixedSizeExemplarReservoirTest {
   }
 
   @Test
-  public void multiMeasurements_preservesLatestSamples() {
+  public void multiMeasurements_preservesFirstSamples() {
     AttributeKey<Long> key = AttributeKey.longKey("K");
     // We cannot mock random in latest jdk, so we create an override.
     Random mockRandom =
@@ -138,5 +145,19 @@ class LongRandomFixedSizeExemplarReservoirTest {
               assertThat(exemplar.getEpochNanos()).isEqualTo(clock.now());
               assertThat(exemplar.getValue()).isEqualTo(2);
             });
+  }
+
+  @Test
+  public void multiMeasurement_setSpanAttributeOnFirstMeasurement() {
+    SpanBuilder spanBuilder = SdkTracerProvider.builder().build().get("").spanBuilder("");
+    Span span = spy(spanBuilder.startSpan());
+    Context ctx = Context.root().with(span);
+    TestClock clock = TestClock.create();
+    ExemplarReservoir<LongExemplarData> reservoir =
+        RandomFixedSizeExemplarReservoir.createLong(clock, 1, RandomSupplier.platformDefault());
+    reservoir.offerLongMeasurement(1, Attributes.empty(), ctx);
+    verify(span).setAttribute(AttributeKey.booleanKey("otel.exemplar"), true);
+    reservoir.offerLongMeasurement(2, Attributes.empty(), ctx);
+    verify(span, never()).setAttribute(any(), anyBoolean());
   }
 }


### PR DESCRIPTION
Proof of Concept for a way to support metric exemplars and tail-based sampling at the same time. Hopefully this will spur discussion on how we want to support this use-case.

This is a simpler version of https://github.com/open-telemetry/opentelemetry-java/pull/5915

Relevant issue: https://github.com/open-telemetry/opentelemetry-specification/issues/2922

This makes a few big changes:
- `HistogramExemplarReservoir` and `RandomFixedSizeExemplarReservoir` now collect the `first` instead of the `last` exemplar sample they see. This lets us know whether or not a span will be used as an exemplar while it is still current.
- Suggest `otel.exemplar` as a potential new attribute that, when set to `true` means the sample is being used as an exemplar.

This approach allows tail-based samplers to ensure that all traces containing spans with `otel.exemplar == true` are kept, while the rest can be sampled without accidentally dropping a span used as an exemplar.