### PR TITLE
Allow events to be emitted with timestamp

### DIFF
--- a/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
@@ -22,4 +22,42 @@ class DefaultEventEmitter implements EventEmitter {
 
   @Override
   public void emit(String eventName, Attributes attributes) {}
+
+  @Override
+  public EventBuilder builder() {
+    return NoOpEventBuilder.INSTANCE;
+  }
+
+  @Override
+  public EventBuilder builder(String eventName) {
+    return NoOpEventBuilder.INSTANCE;
+  }
+
+  @Override
+  public EventBuilder builder(String eventName, Attributes attributes) {
+    return NoOpEventBuilder.INSTANCE;
+  }
+
+  private static class NoOpEventBuilder implements EventBuilder {
+
+    public static final EventBuilder INSTANCE = new NoOpEventBuilder();
+
+    @Override
+    public EventBuilder setEventName(String eventName) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setAttributes(Attributes attributes) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setTimestamp(long epochNanos) {
+      return this;
+    }
+
+    @Override
+    public void emit() {}
+  }
 }

--- a/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.api.events;
 
 import io.opentelemetry.api.common.Attributes;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 class DefaultEventEmitter implements EventEmitter {
 
@@ -16,9 +18,6 @@ class DefaultEventEmitter implements EventEmitter {
   static EventEmitter getInstance() {
     return INSTANCE;
   }
-
-  @Override
-  public void emit(long epochNanos, String eventName, Attributes attributes) {}
 
   @Override
   public void emit(String eventName, Attributes attributes) {}
@@ -33,7 +32,12 @@ class DefaultEventEmitter implements EventEmitter {
     public static final EventBuilder INSTANCE = new NoOpEventBuilder();
 
     @Override
-    public EventBuilder setTimestamp(long epochNanos) {
+    public EventBuilder setTimestamp(long timestamp, TimeUnit unit) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setTimestamp(Instant instant) {
       return this;
     }
 

--- a/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
@@ -24,16 +24,6 @@ class DefaultEventEmitter implements EventEmitter {
   public void emit(String eventName, Attributes attributes) {}
 
   @Override
-  public EventBuilder builder() {
-    return NoOpEventBuilder.INSTANCE;
-  }
-
-  @Override
-  public EventBuilder builder(String eventName) {
-    return NoOpEventBuilder.INSTANCE;
-  }
-
-  @Override
   public EventBuilder builder(String eventName, Attributes attributes) {
     return NoOpEventBuilder.INSTANCE;
   }
@@ -41,16 +31,6 @@ class DefaultEventEmitter implements EventEmitter {
   private static class NoOpEventBuilder implements EventBuilder {
 
     public static final EventBuilder INSTANCE = new NoOpEventBuilder();
-
-    @Override
-    public EventBuilder setEventName(String eventName) {
-      return this;
-    }
-
-    @Override
-    public EventBuilder setAttributes(Attributes attributes) {
-      return this;
-    }
 
     @Override
     public EventBuilder setTimestamp(long epochNanos) {

--- a/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitter.java
@@ -18,5 +18,8 @@ class DefaultEventEmitter implements EventEmitter {
   }
 
   @Override
+  public void emit(long epochNanos, String eventName, Attributes attributes) {}
+
+  @Override
   public void emit(String eventName, Attributes attributes) {}
 }

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.events;
+
+import io.opentelemetry.api.common.Attributes;
+
+/** The EventBuilder is used to emit() events. */
+public interface EventBuilder {
+
+  /** Set the name of the event. */
+  EventBuilder setEventName(String eventName);
+
+  /** Set the attributes to attach to the event. */
+  EventBuilder setAttributes(Attributes attributes);
+
+  /** Sets the timestamp for the event. */
+  EventBuilder setTimestamp(long epochNanos);
+
+  /** Emit an event. */
+  void emit();
+}

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
@@ -5,16 +5,8 @@
 
 package io.opentelemetry.api.events;
 
-import io.opentelemetry.api.common.Attributes;
-
 /** The EventBuilder is used to emit() events. */
 public interface EventBuilder {
-
-  /** Set the name of the event. */
-  EventBuilder setEventName(String eventName);
-
-  /** Set the attributes to attach to the event. */
-  EventBuilder setAttributes(Attributes attributes);
 
   /** Sets the timestamp for the event. */
   EventBuilder setTimestamp(long epochNanos);

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventBuilder.java
@@ -5,11 +5,27 @@
 
 package io.opentelemetry.api.events;
 
-/** The EventBuilder is used to emit() events. */
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/** The EventBuilder is used to {@link #emit()} events. */
 public interface EventBuilder {
 
-  /** Sets the timestamp for the event. */
-  EventBuilder setTimestamp(long epochNanos);
+  /**
+   * Set the epoch {@code timestamp} for the event, using the timestamp and unit.
+   *
+   * <p>The {@code timestamp} is the time at which the event occurred. If unset, it will be set to
+   * the current time when {@link #emit()} is called.
+   */
+  EventBuilder setTimestamp(long timestamp, TimeUnit unit);
+
+  /**
+   * Set the epoch {@code timestamp} for the event, using the instant.
+   *
+   * <p>The {@code timestamp} is the time at which the event occurred. If unset, it will be set to
+   * the current time when {@link #emit()} is called.
+   */
+  EventBuilder setTimestamp(Instant instant);
 
   /** Emit an event. */
   void emit();

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
@@ -35,6 +35,17 @@ public interface EventEmitter {
   /**
    * Emit an event.
    *
+   * @param epochNanos The time at which the event happened, in epoch nanoseconds.
+   * @param eventName the event name, which acts as a classifier for events. Within a particular
+   *     event domain, event name defines a particular class or type of event.
+   * @param attributes attributes associated with the event
+   */
+  @SuppressWarnings("InconsistentOverloads")
+  void emit(long epochNanos, String eventName, Attributes attributes);
+
+  /**
+   * Emit an event.
+   *
    * @param eventName the event name, which acts as a classifier for events. Within a particular
    *     event domain, event name defines a particular class or type of event.
    * @param attributes attributes associated with the event

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
@@ -52,9 +52,5 @@ public interface EventEmitter {
    */
   void emit(String eventName, Attributes attributes);
 
-  EventBuilder builder();
-
-  EventBuilder builder(String eventName);
-
   EventBuilder builder(String eventName, Attributes attributes);
 }

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
@@ -51,4 +51,10 @@ public interface EventEmitter {
    * @param attributes attributes associated with the event
    */
   void emit(String eventName, Attributes attributes);
+
+  EventBuilder builder();
+
+  EventBuilder builder(String eventName);
+
+  EventBuilder builder(String eventName, Attributes attributes);
 }

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
@@ -35,22 +35,18 @@ public interface EventEmitter {
   /**
    * Emit an event.
    *
-   * @param epochNanos The time at which the event happened, in epoch nanoseconds.
-   * @param eventName the event name, which acts as a classifier for events. Within a particular
-   *     event domain, event name defines a particular class or type of event.
-   * @param attributes attributes associated with the event
-   */
-  @SuppressWarnings("InconsistentOverloads")
-  void emit(long epochNanos, String eventName, Attributes attributes);
-
-  /**
-   * Emit an event.
-   *
    * @param eventName the event name, which acts as a classifier for events. Within a particular
    *     event domain, event name defines a particular class or type of event.
    * @param attributes attributes associated with the event
    */
   void emit(String eventName, Attributes attributes);
 
+  /**
+   * Return a {@link EventBuilder} to emit an event.
+   *
+   * @param eventName the event name, which acts as a classifier for events. Within a particular
+   *     event domain, event name defines a particular class or type of event.
+   * @param attributes attributes associated with the event
+   */
   EventBuilder builder(String eventName, Attributes attributes);
 }

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -22,4 +22,11 @@ class DefaultEventEmitterTest {
                     .emit("event-name", Attributes.builder().put("key1", "value1").build()))
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void emitWithTimestamp() {
+    EventEmitter emitter = DefaultEventEmitter.getInstance();
+    Attributes attributes = Attributes.builder().put("key1", "value1").build();
+    assertThatCode(() -> emitter.emit(System.nanoTime(), "event-name", attributes));
+  }
 }

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -30,4 +30,36 @@ class DefaultEventEmitterTest {
     assertThatCode(() -> emitter.emit(System.nanoTime(), "event-name", attributes))
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void builder() {
+    Attributes attributes = Attributes.builder().put("key1", "value1").build();
+    EventEmitter emitter = DefaultEventEmitter.getInstance();
+    assertThatCode(
+            () ->
+                emitter
+                    .builder()
+                    .setEventName("myEvent")
+                    .setAttributes(attributes)
+                    .setTimestamp(123456L)
+                    .emit())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void builderWithName() {
+    Attributes attributes = Attributes.builder().put("key1", "value1").build();
+    EventEmitter emitter = DefaultEventEmitter.getInstance();
+    assertThatCode(
+            () -> emitter.builder("myEvent").setAttributes(attributes).setTimestamp(123456L).emit())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void builderWithNameAndAttrs() {
+    Attributes attributes = Attributes.builder().put("key1", "value1").build();
+    EventEmitter emitter = DefaultEventEmitter.getInstance();
+    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
+        .doesNotThrowAnyException();
+  }
 }

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -35,14 +35,7 @@ class DefaultEventEmitterTest {
   void builder() {
     Attributes attributes = Attributes.builder().put("key1", "value1").build();
     EventEmitter emitter = DefaultEventEmitter.getInstance();
-    assertThatCode(
-            () ->
-                emitter
-                    .builder()
-                    .setEventName("myEvent")
-                    .setAttributes(attributes)
-                    .setTimestamp(123456L)
-                    .emit())
+    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
         .doesNotThrowAnyException();
   }
 
@@ -50,8 +43,7 @@ class DefaultEventEmitterTest {
   void builderWithName() {
     Attributes attributes = Attributes.builder().put("key1", "value1").build();
     EventEmitter emitter = DefaultEventEmitter.getInstance();
-    assertThatCode(
-            () -> emitter.builder("myEvent").setAttributes(attributes).setTimestamp(123456L).emit())
+    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
         .doesNotThrowAnyException();
   }
 

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.api.events;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.Attributes;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class DefaultEventEmitterTest {
@@ -24,34 +26,16 @@ class DefaultEventEmitterTest {
   }
 
   @Test
-  void emitWithTimestamp() {
-    EventEmitter emitter = DefaultEventEmitter.getInstance();
-    Attributes attributes = Attributes.builder().put("key1", "value1").build();
-    assertThatCode(() -> emitter.emit(System.nanoTime(), "event-name", attributes))
-        .doesNotThrowAnyException();
-  }
-
-  @Test
   void builder() {
     Attributes attributes = Attributes.builder().put("key1", "value1").build();
     EventEmitter emitter = DefaultEventEmitter.getInstance();
-    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
-        .doesNotThrowAnyException();
-  }
-
-  @Test
-  void builderWithName() {
-    Attributes attributes = Attributes.builder().put("key1", "value1").build();
-    EventEmitter emitter = DefaultEventEmitter.getInstance();
-    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
-        .doesNotThrowAnyException();
-  }
-
-  @Test
-  void builderWithNameAndAttrs() {
-    Attributes attributes = Attributes.builder().put("key1", "value1").build();
-    EventEmitter emitter = DefaultEventEmitter.getInstance();
-    assertThatCode(() -> emitter.builder("myEvent", attributes).setTimestamp(123456L).emit())
+    assertThatCode(
+            () ->
+                emitter
+                    .builder("myEvent", attributes)
+                    .setTimestamp(123456L, TimeUnit.NANOSECONDS)
+                    .setTimestamp(Instant.now())
+                    .emit())
         .doesNotThrowAnyException();
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -15,31 +15,24 @@ import io.opentelemetry.sdk.common.Clock;
 import java.util.concurrent.TimeUnit;
 
 class SdkEventBuilder implements EventBuilder {
-  private static final String DEFAULT_EVENT_NAME = "unknown-event";
   private final Clock clock;
   private final Logger delegateLogger;
   private final String eventDomain;
-
-  private String eventName = DEFAULT_EVENT_NAME;
-  private Attributes attributes = Attributes.empty();
+  private final String eventName;
+  private final Attributes attributes;
   private long epochNanos = Long.MIN_VALUE;
 
-  SdkEventBuilder(Clock clock, Logger delegateLogger, String eventDomain) {
+  SdkEventBuilder(
+      Clock clock,
+      Logger delegateLogger,
+      String eventDomain,
+      String eventName,
+      Attributes attributes) {
     this.clock = clock;
     this.delegateLogger = delegateLogger;
     this.eventDomain = eventDomain;
-  }
-
-  @Override
-  public EventBuilder setEventName(String eventName) {
     this.eventName = eventName;
-    return this;
-  }
-
-  @Override
-  public EventBuilder setAttributes(Attributes attributes) {
     this.attributes = attributes;
-    return this;
   }
 
   @Override

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs.internal;
+
+import static io.opentelemetry.sdk.logs.internal.SdkEventEmitterProvider.EVENT_DOMAIN;
+import static io.opentelemetry.sdk.logs.internal.SdkEventEmitterProvider.EVENT_NAME;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.events.EventBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.sdk.common.Clock;
+import java.util.concurrent.TimeUnit;
+
+class SdkEventBuilder implements EventBuilder {
+  private static final String DEFAULT_EVENT_NAME = "unknown-event";
+  private final Clock clock;
+  private final Logger delegateLogger;
+  private final String eventDomain;
+
+  private String eventName = DEFAULT_EVENT_NAME;
+  private Attributes attributes = Attributes.empty();
+  private long epochNanos = Long.MIN_VALUE;
+
+  SdkEventBuilder(Clock clock, Logger delegateLogger, String eventDomain) {
+    this.clock = clock;
+    this.delegateLogger = delegateLogger;
+    this.eventDomain = eventDomain;
+  }
+
+  @Override
+  public EventBuilder setEventName(String eventName) {
+    this.eventName = eventName;
+    return this;
+  }
+
+  @Override
+  public EventBuilder setAttributes(Attributes attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  @Override
+  public EventBuilder setTimestamp(long epochNanos) {
+    this.epochNanos = epochNanos;
+    return this;
+  }
+
+  @Override
+  public void emit() {
+    long timestamp = epochNanos == Long.MIN_VALUE ? clock.now() : epochNanos;
+    delegateLogger
+        .logRecordBuilder()
+        .setTimestamp(timestamp, TimeUnit.NANOSECONDS)
+        .setAllAttributes(attributes)
+        .setAttribute(EVENT_DOMAIN, eventDomain)
+        .setAttribute(EVENT_NAME, eventName)
+        .emit();
+  }
+}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -5,51 +5,37 @@
 
 package io.opentelemetry.sdk.logs.internal;
 
-import static io.opentelemetry.sdk.logs.internal.SdkEventEmitterProvider.EVENT_DOMAIN;
-import static io.opentelemetry.sdk.logs.internal.SdkEventEmitterProvider.EVENT_NAME;
-
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.events.EventBuilder;
-import io.opentelemetry.api.logs.Logger;
-import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 class SdkEventBuilder implements EventBuilder {
-  private final Clock clock;
-  private final Logger delegateLogger;
+  private final LogRecordBuilder logRecordBuilder;
   private final String eventDomain;
   private final String eventName;
-  private final Attributes attributes;
-  private long epochNanos = Long.MIN_VALUE;
 
-  SdkEventBuilder(
-      Clock clock,
-      Logger delegateLogger,
-      String eventDomain,
-      String eventName,
-      Attributes attributes) {
-    this.clock = clock;
-    this.delegateLogger = delegateLogger;
+  SdkEventBuilder(LogRecordBuilder logRecordBuilder, String eventDomain, String eventName) {
+    this.logRecordBuilder = logRecordBuilder;
     this.eventDomain = eventDomain;
     this.eventName = eventName;
-    this.attributes = attributes;
   }
 
   @Override
-  public EventBuilder setTimestamp(long epochNanos) {
-    this.epochNanos = epochNanos;
+  public EventBuilder setTimestamp(long timestamp, TimeUnit unit) {
+    this.logRecordBuilder.setTimestamp(timestamp, unit);
+    return this;
+  }
+
+  @Override
+  public EventBuilder setTimestamp(Instant instant) {
+    this.logRecordBuilder.setTimestamp(instant);
     return this;
   }
 
   @Override
   public void emit() {
-    long timestamp = epochNanos == Long.MIN_VALUE ? clock.now() : epochNanos;
-    delegateLogger
-        .logRecordBuilder()
-        .setTimestamp(timestamp, TimeUnit.NANOSECONDS)
-        .setAllAttributes(attributes)
-        .setAttribute(EVENT_DOMAIN, eventDomain)
-        .setAttribute(EVENT_NAME, eventName)
-        .emit();
+    SdkEventEmitterProvider.addEventNameAndDomain(logRecordBuilder, eventDomain, eventName);
+    logRecordBuilder.emit();
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
@@ -113,9 +113,14 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
     @Override
     public void emit(String eventName, Attributes attributes) {
+      emit(clock.now(), eventName, attributes);
+    }
+
+    @Override
+    public void emit(long epochNanos, String eventName, Attributes attributes) {
       delegateLogger
           .logRecordBuilder()
-          .setTimestamp(clock.now(), TimeUnit.NANOSECONDS)
+          .setTimestamp(epochNanos, TimeUnit.NANOSECONDS)
           .setAllAttributes(attributes)
           .setAttribute(EVENT_DOMAIN, eventDomain)
           .setAttribute(EVENT_NAME, eventName)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
@@ -112,18 +112,8 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
     }
 
     @Override
-    public EventBuilder builder() {
-      return new SdkEventBuilder(clock, delegateLogger, eventDomain);
-    }
-
-    @Override
-    public EventBuilder builder(String eventName) {
-      return builder().setEventName(eventName);
-    }
-
-    @Override
     public EventBuilder builder(String eventName, Attributes attributes) {
-      return builder().setEventName(eventName).setAttributes(attributes);
+      return new SdkEventBuilder(clock, delegateLogger, eventDomain, eventName, attributes);
     }
 
     @Override
@@ -133,10 +123,8 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
     @Override
     public void emit(long epochNanos, String eventName, Attributes attributes) {
-      new SdkEventBuilder(clock, delegateLogger, eventDomain)
+      new SdkEventBuilder(clock, delegateLogger, eventDomain, eventName, attributes)
           .setTimestamp(epochNanos)
-          .setAttributes(attributes)
-          .setEventName(eventName)
           .emit();
     }
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
@@ -33,10 +33,8 @@ class SdkEventBuilderTest {
     when(logRecordBuilder.setAttribute(any(), any())).thenReturn(logRecordBuilder);
     when(logRecordBuilder.setAllAttributes(any())).thenReturn(logRecordBuilder);
 
-    new SdkEventBuilder(Clock.getDefault(), logger, eventDomain)
-        .setEventName(eventName)
+    new SdkEventBuilder(Clock.getDefault(), logger, eventDomain, eventName, attributes)
         .setTimestamp(123456L)
-        .setAttributes(attributes)
         .emit();
     verify(logRecordBuilder).setAllAttributes(attributes);
     verify(logRecordBuilder).setAttribute(stringKey("event.domain"), eventDomain);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.sdk.common.Clock;
+import org.junit.jupiter.api.Test;
+
+class SdkEventBuilderTest {
+
+  @Test
+  void emit() {
+    String eventDomain = "mydomain";
+    String eventName = "banana";
+    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
+
+    Logger logger = mock(Logger.class);
+    LogRecordBuilder logRecordBuilder = mock(LogRecordBuilder.class);
+    when(logger.logRecordBuilder()).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setTimestamp(anyLong(), any())).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setAttribute(any(), any())).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setAllAttributes(any())).thenReturn(logRecordBuilder);
+
+    new SdkEventBuilder(Clock.getDefault(), logger, eventDomain)
+        .setEventName(eventName)
+        .setTimestamp(123456L)
+        .setAttributes(attributes)
+        .emit();
+    verify(logRecordBuilder).setAllAttributes(attributes);
+    verify(logRecordBuilder).setAttribute(stringKey("event.domain"), eventDomain);
+    verify(logRecordBuilder).setAttribute(stringKey("event.name"), eventName);
+    verify(logRecordBuilder).emit();
+  }
+}

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
@@ -114,4 +114,23 @@ class SdkEventEmitterProviderTest {
                 .put("event.name", "testing")
                 .build());
   }
+
+  @Test
+  void builder() {
+    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
+    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
+
+    EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
+
+    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
+    assertThat(seenLog.get().toLogRecordData())
+        .hasResource(RESOURCE)
+        .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
+        .hasTimestamp(yesterday)
+        .hasAttributes(
+            attributes.toBuilder()
+                .put("event.domain", "unknown")
+                .put("event.name", "testing")
+                .build());
+  }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
@@ -125,7 +125,7 @@ class SdkEventEmitterProviderTest {
 
     EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
 
-    emitter.builder("testing").setAttributes(attributes).setTimestamp(yesterday).emit();
+    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
     verifySeen(yesterday, attributes);
   }
 
@@ -136,12 +136,7 @@ class SdkEventEmitterProviderTest {
 
     EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
 
-    emitter
-        .builder()
-        .setEventName("testing")
-        .setAttributes(attributes)
-        .setTimestamp(yesterday)
-        .emit();
+    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
     verifySeen(yesterday, attributes);
   }
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
@@ -96,47 +96,13 @@ class SdkEventEmitterProviderTest {
   }
 
   @Test
-  void emit_withTimestamp() {
-    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
-    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
-
-    EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
-
-    emitter.emit(yesterday, "testing", attributes);
-
-    verifySeen(yesterday, attributes);
-  }
-
-  @Test
-  void builderWithNameAndAttributes() {
-    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
-    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
-
-    EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
-
-    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
-    verifySeen(yesterday, attributes);
-  }
-
-  @Test
-  void builderWithName() {
-    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
-    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
-
-    EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
-
-    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
-    verifySeen(yesterday, attributes);
-  }
-
-  @Test
   void builder() {
     long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
     Attributes attributes = Attributes.of(stringKey("foo"), "bar");
 
     EventEmitter emitter = eventEmitterProvider.eventEmitterBuilder("test-scope").build();
 
-    emitter.builder("testing", attributes).setTimestamp(yesterday).emit();
+    emitter.builder("testing", attributes).setTimestamp(yesterday, TimeUnit.NANOSECONDS).emit();
     verifySeen(yesterday, attributes);
   }
 


### PR DESCRIPTION
There are several cases where events may need to be emitted with a timestamp that is different from "now" (the current time), the main ones being:

* Handling events that occur prior to SDK initialization
* Event log recording/playback

These are not contrived use cases. In Android, we have a specific need to track certain startup behaviors, and the sdk creation is not necessarily early enough in the application lifecycle to handle this.