### PR TITLE
Autoconfigure listener

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,13 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setMeterProvider(java.util.function.Supplier<io.opentelemetry.api.metrics.MeterProvider>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setMeterProvider(java.util.function.Supplier<io.opentelemetry.api.metrics.MeterProvider>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder setMeterProvider(java.util.function.Supplier<io.opentelemetry.api.metrics.MeterProvider>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setMeterProvider(java.util.function.Supplier<io.opentelemetry.api.metrics.MeterProvider>)

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -123,8 +123,8 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public GrpcExporterBuilder<T> setMeterProvider(MeterProvider meterProvider) {
-    this.meterProviderSupplier = () -> meterProvider;
+  public GrpcExporterBuilder<T> setMeterProvider(Supplier<MeterProvider> meterProviderSupplier) {
+    this.meterProviderSupplier = meterProviderSupplier;
     return this;
   }
 

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -112,8 +112,8 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public HttpExporterBuilder<T> setMeterProvider(MeterProvider meterProvider) {
-    this.meterProviderSupplier = () -> meterProvider;
+  public HttpExporterBuilder<T> setMeterProvider(Supplier<MeterProvider> meterProviderSupplier) {
+    this.meterProviderSupplier = meterProviderSupplier;
     return this;
   }
 

--- a/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
+++ b/exporters/jaeger/src/main/java/io/opentelemetry/exporter/jaeger/JaegerGrpcSpanExporterBuilder.java
@@ -145,7 +145,7 @@ public final class JaegerGrpcSpanExporterBuilder {
    */
   public JaegerGrpcSpanExporterBuilder setMeterProvider(MeterProvider meterProvider) {
     requireNonNull(meterProvider, "meterProvider");
-    delegate.setMeterProvider(meterProvider);
+    delegate.setMeterProvider(() -> meterProvider);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -16,6 +16,7 @@ import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -135,7 +136,18 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setMeterProvider(MeterProvider meterProvider) {
     requireNonNull(meterProvider, "meterProvider");
-    delegate.setMeterProvider(meterProvider);
+    setMeterProvider(() -> meterProvider);
+    return this;
+  }
+
+  /**
+   * Sets the {@link MeterProvider} supplier used to collect metrics related to export. If not set,
+   * uses {@link GlobalOpenTelemetry#getMeterProvider()}.
+   */
+  public OtlpHttpLogRecordExporterBuilder setMeterProvider(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    requireNonNull(meterProviderSupplier, "meterProviderSupplier");
+    delegate.setMeterProvider(meterProviderSupplier);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -43,7 +43,7 @@ public final class OtlpHttpMetricExporterBuilder {
 
   OtlpHttpMetricExporterBuilder(HttpExporterBuilder<MetricsRequestMarshaler> delegate) {
     this.delegate = delegate;
-    delegate.setMeterProvider(MeterProvider.noop());
+    delegate.setMeterProvider(MeterProvider::noop);
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -16,6 +16,7 @@ import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -136,7 +137,18 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setMeterProvider(MeterProvider meterProvider) {
     requireNonNull(meterProvider, "meterProvider");
-    delegate.setMeterProvider(meterProvider);
+    setMeterProvider(() -> meterProvider);
+    return this;
+  }
+
+  /**
+   * Sets the {@link MeterProvider} supplier to use to collect metrics related to export. If not
+   * set, uses {@link GlobalOpenTelemetry#getMeterProvider()}.
+   */
+  public OtlpHttpSpanExporterBuilder setMeterProvider(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    requireNonNull(meterProviderSupplier, "meterProviderSupplier");
+    delegate.setMeterProvider(meterProviderSupplier);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
@@ -9,14 +9,18 @@ import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_L
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * {@link LogRecordExporter} SPI implementation for {@link OtlpGrpcLogRecordExporter} and {@link
@@ -25,7 +29,12 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public class OtlpLogRecordExporterProvider implements ConfigurableLogRecordExporterProvider {
+public class OtlpLogRecordExporterProvider
+    implements ConfigurableLogRecordExporterProvider, AutoConfigureListener {
+
+  private final AtomicReference<MeterProvider> meterProviderRef =
+      new AtomicReference<>(MeterProvider.noop());
+
   @Override
   public LogRecordExporter createExporter(ConfigProperties config) {
     String protocol = OtlpConfigUtil.getOtlpProtocol(DATA_TYPE_LOGS, config);
@@ -43,6 +52,7 @@ public class OtlpLogRecordExporterProvider implements ConfigurableLogRecordExpor
           builder::setTrustedCertificates,
           builder::setClientTls,
           builder::setRetryPolicy);
+      builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
@@ -58,6 +68,7 @@ public class OtlpLogRecordExporterProvider implements ConfigurableLogRecordExpor
           builder::setTrustedCertificates,
           builder::setClientTls,
           builder::setRetryPolicy);
+      builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
     }
@@ -77,5 +88,10 @@ public class OtlpLogRecordExporterProvider implements ConfigurableLogRecordExpor
   // Visible for testing
   OtlpGrpcLogRecordExporterBuilder grpcBuilder() {
     return OtlpGrpcLogRecordExporter.builder();
+  }
+
+  @Override
+  public void afterAutoConfigure(OpenTelemetrySdk sdk) {
+    meterProviderRef.set(sdk.getMeterProvider());
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
  * at any time.
  */
 public class OtlpMetricExporterProvider implements ConfigurableMetricExporterProvider {
+
   @Override
   public MetricExporter createExporter(ConfigProperties config) {
     String protocol = OtlpConfigUtil.getOtlpProtocol(DATA_TYPE_METRICS, config);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
@@ -9,14 +9,18 @@ import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_T
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_GRPC;
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * {@link SpanExporter} SPI implementation for {@link OtlpGrpcSpanExporter} and {@link
@@ -25,7 +29,12 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public class OtlpSpanExporterProvider implements ConfigurableSpanExporterProvider {
+public class OtlpSpanExporterProvider
+    implements ConfigurableSpanExporterProvider, AutoConfigureListener {
+
+  private final AtomicReference<MeterProvider> meterProviderRef =
+      new AtomicReference<>(MeterProvider.noop());
+
   @Override
   public SpanExporter createExporter(ConfigProperties config) {
     String protocol = OtlpConfigUtil.getOtlpProtocol(DATA_TYPE_TRACES, config);
@@ -42,6 +51,7 @@ public class OtlpSpanExporterProvider implements ConfigurableSpanExporterProvide
           builder::setTrustedCertificates,
           builder::setClientTls,
           builder::setRetryPolicy);
+      builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
@@ -57,6 +67,7 @@ public class OtlpSpanExporterProvider implements ConfigurableSpanExporterProvide
           builder::setTrustedCertificates,
           builder::setClientTls,
           builder::setRetryPolicy);
+      builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
     }
@@ -76,5 +87,10 @@ public class OtlpSpanExporterProvider implements ConfigurableSpanExporterProvide
   // Visible for testing
   OtlpGrpcSpanExporterBuilder grpcBuilder() {
     return OtlpGrpcSpanExporter.builder();
+  }
+
+  @Override
+  public void afterAutoConfigure(OpenTelemetrySdk sdk) {
+    meterProviderRef.set(sdk.getMeterProvider());
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -179,7 +180,18 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    */
   public OtlpGrpcLogRecordExporterBuilder setMeterProvider(MeterProvider meterProvider) {
     requireNonNull(meterProvider, "meterProvider");
-    delegate.setMeterProvider(meterProvider);
+    setMeterProvider(() -> meterProvider);
+    return this;
+  }
+
+  /**
+   * Sets the {@link MeterProvider} supplier used to collect metrics related to export. If not set,
+   * uses {@link GlobalOpenTelemetry#getMeterProvider()}.
+   */
+  public OtlpGrpcLogRecordExporterBuilder setMeterProvider(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    requireNonNull(meterProviderSupplier, "meterProviderSupplier");
+    delegate.setMeterProvider(meterProviderSupplier);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -53,7 +53,7 @@ public final class OtlpGrpcMetricExporterBuilder {
 
   OtlpGrpcMetricExporterBuilder(GrpcExporterBuilder<MetricsRequestMarshaler> delegate) {
     this.delegate = delegate;
-    delegate.setMeterProvider(MeterProvider.noop());
+    delegate.setMeterProvider(MeterProvider::noop);
     OtlpUserAgent.addUserAgentHeader(delegate::addHeader);
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -176,7 +177,18 @@ public final class OtlpGrpcSpanExporterBuilder {
    */
   public OtlpGrpcSpanExporterBuilder setMeterProvider(MeterProvider meterProvider) {
     requireNonNull(meterProvider, "meterProvider");
-    delegate.setMeterProvider(meterProvider);
+    setMeterProvider(() -> meterProvider);
+    return this;
+  }
+
+  /**
+   * Sets the {@link MeterProvider} supplier used to collect metrics related to export. If not set,
+   * uses {@link GlobalOpenTelemetry#getMeterProvider()}.
+   */
+  public OtlpGrpcSpanExporterBuilder setMeterProvider(
+      Supplier<MeterProvider> meterProviderSupplier) {
+    requireNonNull(meterProviderSupplier, "meterProviderSupplier");
+    delegate.setMeterProvider(meterProviderSupplier);
     return this;
   }
 

--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -259,7 +259,7 @@ public class OtlpPipelineStressTest {
     // set up the span exporter and wire it into the SDK
     OtlpGrpcSpanExporter spanExporter =
         OtlpGrpcSpanExporter.builder()
-            .setMeterProvider(meterProvider)
+            .setMeterProvider(() -> meterProvider)
             .setEndpoint(
                 "http://"
                     + toxiproxyContainer.getHost()

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/AutoConfigureListener.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/AutoConfigureListener.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi.internal;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+/**
+ * Interface to be extended by SPIs that require access to the autoconfigured {@link
+ * OpenTelemetrySdk} instance.
+ *
+ * <p>This is not a standalone SPI. Instead, implementations of other SPIs can also implement this
+ * interface to receive a callback with the configured SDK.
+ */
+public interface AutoConfigureListener {
+
+  void afterAutoConfigure(OpenTelemetrySdk sdk);
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableMetricExporterTest.java
@@ -49,6 +49,10 @@ class ConfigurableMetricExporterTest {
           .isInstanceOf(TestConfigurableMetricExporterProvider.TestMetricExporter.class)
           .extracting("config")
           .isSameAs(config);
+      assertThat(spiHelper.getListeners())
+          .satisfiesExactlyInAnyOrder(
+              listener ->
+                  assertThat(listener).isInstanceOf(TestConfigurableMetricExporterProvider.class));
     }
   }
 
@@ -88,6 +92,7 @@ class ConfigurableMetricExporterTest {
         .hasMessageContaining("otel.metrics.exporter contains none along with other exporters");
     cleanup.addCloseables(closeables);
     assertThat(closeables).isEmpty();
+    assertThat(spiHelper.getListeners()).isEmpty();
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.internal.OtlpSpanExporterProvider;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
@@ -63,6 +64,11 @@ class ConfigurableSpanExporterTest {
         .isSameAs(config);
     assertThat(closeables)
         .hasExactlyElementsOfTypes(TestConfigurableSpanExporterProvider.TestSpanExporter.class);
+    assertThat(spiHelper.getListeners())
+        .satisfiesExactlyInAnyOrder(
+            listener ->
+                assertThat(listener).isInstanceOf(TestConfigurableSpanExporterProvider.class),
+            listener -> assertThat(listener).isInstanceOf(OtlpSpanExporterProvider.class));
   }
 
   @Test
@@ -83,6 +89,7 @@ class ConfigurableSpanExporterTest {
         .hasMessageContaining("testExporter");
     cleanup.addCloseables(closeables);
     assertThat(closeables).isEmpty();
+    assertThat(spiHelper.getListeners()).isEmpty();
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/MetricCustomizer.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/MetricCustomizer.java
@@ -48,7 +48,13 @@ public class MetricCustomizer implements AutoConfigurationCustomizerProvider {
         // please configure the SdkMeterProvider with the appropriate view.
         Collection<MetricData> filtered =
             metrics.stream()
-                .filter(metricData -> metricData.getName().equals("my-metric"))
+                .filter(
+                    metricData ->
+                        metricData.getName().equals("my-metric")
+                            || metricData
+                                .getInstrumentationScopeInfo()
+                                .getName()
+                                .startsWith("io.opentelemetry.exporters"))
                 .collect(Collectors.toList());
         return delegate.export(filtered);
       }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableLogRecordExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableLogRecordExporterProvider.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.sdk.autoconfigure.provider;
 
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -13,7 +15,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.util.Collection;
 
 public class TestConfigurableLogRecordExporterProvider
-    implements ConfigurableLogRecordExporterProvider {
+    implements ConfigurableLogRecordExporterProvider, AutoConfigureListener {
 
   @Override
   public LogRecordExporter createExporter(ConfigProperties config) {
@@ -24,6 +26,9 @@ public class TestConfigurableLogRecordExporterProvider
   public String getName() {
     return "testExporter";
   }
+
+  @Override
+  public void afterAutoConfigure(OpenTelemetrySdk sdk) {}
 
   public static class TestLogRecordExporter implements LogRecordExporter {
     private final ConfigProperties config;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableMetricExporterProvider.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.sdk.autoconfigure.provider;
 
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -14,7 +16,8 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
 
-public class TestConfigurableMetricExporterProvider implements ConfigurableMetricExporterProvider {
+public class TestConfigurableMetricExporterProvider
+    implements ConfigurableMetricExporterProvider, AutoConfigureListener {
 
   @Override
   public MetricExporter createExporter(ConfigProperties config) {
@@ -25,6 +28,9 @@ public class TestConfigurableMetricExporterProvider implements ConfigurableMetri
   public String getName() {
     return "testExporter";
   }
+
+  @Override
+  public void afterAutoConfigure(OpenTelemetrySdk sdk) {}
 
   public static class TestMetricExporter implements MetricExporter {
     private final ConfigProperties config;

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSpanExporterProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestConfigurableSpanExporterProvider.java
@@ -5,14 +5,17 @@
 
 package io.opentelemetry.sdk.autoconfigure.provider;
 
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 
-public class TestConfigurableSpanExporterProvider implements ConfigurableSpanExporterProvider {
+public class TestConfigurableSpanExporterProvider
+    implements ConfigurableSpanExporterProvider, AutoConfigureListener {
   @Override
   public SpanExporter createExporter(ConfigProperties config) {
     return new TestSpanExporter(config);
@@ -22,6 +25,9 @@ public class TestConfigurableSpanExporterProvider implements ConfigurableSpanExp
   public String getName() {
     return "testExporter";
   }
+
+  @Override
+  public void afterAutoConfigure(OpenTelemetrySdk sdk) {}
 
   public static class TestSpanExporter implements SpanExporter {
 


### PR DESCRIPTION
Resolves #5862, #5021.

Add a new (experimental) interface called `AutoConfigureListener`. This is not a standalone SPI. Instead, implementations of existing SPIs can additionally implement `AutoConfigureListener`. By doing so, they get a callback to the autoconfigured `OpenTelemetrySdk` instance.

Why have SPI implementations implement an additional interface instead of adding a new SPI? If we were to introduce a new standalone SPI, each SPI implementation that needs a callback would have to hold a reference to their configured SDK components in a static variable, and update those references with `OpenTelemetrySdk` in the callback.

With the strategy in this PR, the same SPI implementation instance that configured the SDK component is invoked with the `OpenTelemetrySdk`, so it only has to hold class instance references to the configured SDK components. 

See `OtlpLogRecordExporterProvider`, `OtlpSpanExporterProvider` for how this would work in practice.

I figure we incubate this for a bit before committing to the API.

If we agree with this strategy, I can followup with another PR to update `ZipkinSpanExporterProvider`.