### PR TITLE
Fix delta metric storage concurrency bug

### DIFF
--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/TestSdk.java
@@ -38,7 +38,7 @@ public enum TestSdk {
               .get("io.opentelemetry.sdk.metrics");
         }
       }),
-  SDK(
+  SDK_CUMULATIVE(
       new SdkBuilder() {
         @Override
         Meter build() {
@@ -47,6 +47,19 @@ public enum TestSdk {
               .setResource(Resource.empty())
               // Must register reader for real SDK.
               .registerMetricReader(InMemoryMetricReader.create())
+              .build()
+              .get("io.opentelemetry.sdk.metrics");
+        }
+      }),
+  SDK_DELTA(
+      new SdkBuilder() {
+        @Override
+        Meter build() {
+          return SdkMeterProvider.builder()
+              .setClock(Clock.getDefault())
+              .setResource(Resource.empty())
+              // Must register reader for real SDK.
+              .registerMetricReader(InMemoryMetricReader.createDelta())
               .build()
               .get("io.opentelemetry.sdk.metrics");
         }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -50,9 +49,7 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
   private final MetricDescriptor metricDescriptor;
   private final AggregationTemporality aggregationTemporality;
   private final Aggregator<T, U> aggregator;
-  private final AtomicInteger collectCount = new AtomicInteger();
-  private final AggregatorHolder<T, U> holder1 = new AggregatorHolder<>();
-  private final AggregatorHolder<T, U> holder2 = new AggregatorHolder<>();
+  private volatile AggregatorHolder<T, U> aggregatorHolder = new AggregatorHolder<>();
   private final AttributesProcessor attributesProcessor;
 
   /**
@@ -88,7 +85,6 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
 
   @Override
   public void recordLong(long value, Attributes attributes, Context context) {
-    AggregatorHolder<T, U> aggregatorHolder = collectCount.get() % 2 == 0 ? holder1 : holder2;
     Lock readLock = aggregatorHolder.lock.readLock();
     readLock.lock();
     try {
@@ -112,7 +108,6 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
               + ". Dropping measurement.");
       return;
     }
-    AggregatorHolder<T, U> aggregatorHolder = collectCount.get() % 2 == 0 ? holder1 : holder2;
     Lock readLock = aggregatorHolder.lock.readLock();
     readLock.lock();
     try {
@@ -172,7 +167,8 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
 
     ConcurrentHashMap<Attributes, AggregatorHandle<T, U>> aggregatorHandles;
     if (reset) {
-      AggregatorHolder<T, U> holder = collectCount.getAndIncrement() % 2 == 0 ? holder1 : holder2;
+      AggregatorHolder<T, U> holder = this.aggregatorHolder;
+      this.aggregatorHolder = new AggregatorHolder<>();
       Lock writeLock = holder.lock.writeLock();
       writeLock.lock();
       try {
@@ -181,7 +177,7 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
         writeLock.unlock();
       }
     } else {
-      aggregatorHandles = holder1.aggregatorHandles;
+      aggregatorHandles = this.aggregatorHolder.aggregatorHandles;
     }
 
     // Grab aggregated points.
@@ -203,10 +199,6 @@ public final class DefaultSynchronousMetricStorage<T extends PointData, U extend
     int toDelete = aggregatorHandlePool.size() - (maxCardinality + 1);
     for (int i = 0; i < toDelete; i++) {
       aggregatorHandlePool.poll();
-    }
-
-    if (reset) {
-      aggregatorHandles.clear();
     }
 
     if (points.isEmpty()) {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/SynchronousMetricStorageTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.util.concurrent.AtomicDouble;
+import com.google.common.util.concurrent.Uninterruptibles;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -21,9 +23,11 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.InstrumentValueType;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.aggregator.EmptyMetricData;
@@ -37,8 +41,17 @@ import io.opentelemetry.sdk.metrics.internal.view.ViewRegistry;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.time.TestClock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
 @SuppressLogger(DefaultSynchronousMetricStorage.class)
@@ -369,5 +382,80 @@ public class SynchronousMetricStorageTest {
 
     assertThat(storage.getAggregatorHandlePool()).hasSize(CARDINALITY_LIMIT);
     logs.assertContains("Instrument name has exceeded the maximum allowed cardinality");
+  }
+
+  @ParameterizedTest
+  @MethodSource("concurrentStressTestArguments")
+  void recordAndCollect_concurrentStressTest(
+      DefaultSynchronousMetricStorage<?, ?> storage, BiConsumer<Double, AtomicDouble> collect) {
+    // Define record threads. Each records a value of 1.0, 2000 times
+    List<Thread> threads = new ArrayList<>();
+    CountDownLatch latch = new CountDownLatch(4);
+    for (int i = 0; i < 4; i++) {
+      Thread thread =
+          new Thread(
+              () -> {
+                for (int j = 0; j < 2000; j++) {
+                  storage.recordDouble(1.0, Attributes.empty(), Context.current());
+                  Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(1));
+                }
+                latch.countDown();
+              });
+      threads.add(thread);
+    }
+
+    // Define collect thread. Collect thread collects and aggregates the
+    AtomicDouble cumulativeSum = new AtomicDouble();
+    Thread collectThread =
+        new Thread(
+            () -> {
+              do {
+                Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(1));
+                MetricData metricData =
+                    storage.collect(Resource.empty(), InstrumentationScopeInfo.empty(), 0, 1);
+                if (metricData.isEmpty()) {
+                  continue;
+                }
+                metricData.getDoubleSumData().getPoints().stream()
+                    .findFirst()
+                    .ifPresent(pointData -> collect.accept(pointData.getValue(), cumulativeSum));
+              } while (latch.getCount() != 0);
+            });
+
+    // Start all the threads
+    collectThread.start();
+    threads.forEach(Thread::start);
+
+    // Wait for the collect thread to end, which collects until the record threads are done
+    Uninterruptibles.joinUninterruptibly(collectThread);
+
+    assertThat(cumulativeSum.get()).isEqualTo(8000.0);
+  }
+
+  private static Stream<Arguments> concurrentStressTestArguments() {
+    Aggregator<PointData, ExemplarData> aggregator =
+        ((AggregatorFactory) Aggregation.sum())
+            .createAggregator(DESCRIPTOR, ExemplarFilter.alwaysOff());
+    return Stream.of(
+        Arguments.of(
+            // Delta
+            new DefaultSynchronousMetricStorage<>(
+                RegisteredReader.create(InMemoryMetricReader.createDelta(), ViewRegistry.create()),
+                METRIC_DESCRIPTOR,
+                aggregator,
+                AttributesProcessor.noop(),
+                CARDINALITY_LIMIT),
+            (BiConsumer<Double, AtomicDouble>)
+                (value, cumulativeCount) -> cumulativeCount.addAndGet(value)),
+        Arguments.of(
+            // Cumulative
+            new DefaultSynchronousMetricStorage<>(
+                RegisteredReader.create(InMemoryMetricReader.create(), ViewRegistry.create()),
+                METRIC_DESCRIPTOR,
+                aggregator,
+                AttributesProcessor.noop(),
+                CARDINALITY_LIMIT),
+            (BiConsumer<Double, AtomicDouble>)
+                (value, cumulativeCount) -> cumulativeCount.set(value)));
   }
 }


### PR DESCRIPTION
@asafm has identified a rather nefarious concurrency bug in the DefaultSynchronousMetricStorage for delta aggregation temporality.

This PR introduces a test which recreates almost always, and a fix utilizing a read-write lock. The idea is that while recording we take a relatively cheap read lock, and while collecting we take the more expensive write lock. 

This results in a modest reduction in performance, but it seems to be the best way to solve the problem and correctness should trump performance. Here's the [before](https://gist.github.com/jack-berg/8d96e5459805582bc14ff5877fb5740d) and [after](https://gist.github.com/jack-berg/9636f25b0c9e474e0ca496e2c7f519d3) of [MetricsBenchmark](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/MetricsBenchmarks.java), which focuses on heavily exercising the record path.