### PR TITLE
Generate SBOM during build/release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
           name: coverage-report
           path: all/build/reports/jacoco/test/html
 
+      - uses: anchore/sbom-action@v0
+
   markdown-link-check:
     # release branches are excluded to avoid unnecessary maintenance
     if: ${{ !startsWith(github.ref_name, 'release/') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,14 +93,14 @@ jobs:
         name: Collect SBOM's
         run: |
           mkdir sboms
-          find . -path ./sboms -prune -o -name "*.spdx.json" -print
+          find . -path ./sboms -prune -o -name "*.cyclonedx.json" -exec mv {} ./sboms/ \;
           find . -path ./sboms -prune -o -name "*.spdx.json" -exec mv {} ./sboms/ \;
 
       - uses: actions/upload-artifact@v4
         name: Save SBOM's to build
         with:
           name: SBOM-${{ matrix.os }}-${{ matrix.test-java-version }}.zip
-          path: "sboms/*.spdx.json"
+          path: "sboms/*.json"
 
   markdown-link-check:
     # release branches are excluded to avoid unnecessary maintenance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,17 +89,18 @@ jobs:
           name: coverage-report
           path: all/build/reports/jacoco/test/html
 
-      - uses: anchore/sbom-action@v0
-
-      - uses: anchore/sbom-action@v0
-        with:
-          format: cyclonedx-json
+      - shell: bash
+        name: Collect SBOM's
+        run: |
+          mkdir sboms
+          find . -path ./sboms -prune -o -name "*.spdx.json" -print
+          find . -path ./sboms -prune -o -name "*.spdx.json" -exec mv {} ./sboms/ \;
 
       - uses: actions/upload-artifact@v4
-        name: Save gradle generated SBOM's to build
+        name: Save SBOM's to build
         with:
-          name: Gradle SPDX SBOMs ${{ matrix.os }}-${{ matrix.test-java-version }}
-          path: "**/build/spdx/*.spdx.json"
+          name: SBOM-${{ matrix.os }}-${{ matrix.test-java-version }}.zip
+          path: "sboms/*.spdx.json"
 
   markdown-link-check:
     # release branches are excluded to avoid unnecessary maintenance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,12 @@ jobs:
         with:
           format: cyclonedx-json
 
+      - uses: actions/upload-artifact@v4
+        name: Save gradle generated SBOM's to build
+        with:
+          name: Gradle SPDX SBOMs ${{ matrix.os }}-${{ matrix.test-java-version }}
+          path: "**/build/spdx/*.spdx.json"
+
   markdown-link-check:
     # release branches are excluded to avoid unnecessary maintenance
     if: ${{ !startsWith(github.ref_name, 'release/') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,10 @@ jobs:
 
       - uses: anchore/sbom-action@v0
 
+      - uses: anchore/sbom-action@v0
+        with:
+          format: cyclonedx-json
+
   markdown-link-check:
     # release branches are excluded to avoid unnecessary maintenance
     if: ${{ !startsWith(github.ref_name, 'release/') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
           find . -path ./sboms -prune -o -name "*.spdx.json" -print
           find . -path ./sboms -prune -o -name "*.spdx.json" -exec mv {} ./sboms/ \;
           zip SBOM.zip sboms/*
+          cp SBOM.zip /tmp/
+        # copy SBOM.zip out of the repo to avoid being deleted with repo checkout below.
 
       - uses: actions/upload-artifact@v4
         name: Save SBOM's to build
@@ -135,7 +137,7 @@ jobs:
                             --title "Version $VERSION" \
                             --notes-file /tmp/release-notes.txt \
                             v$VERSION \
-                            SBOM.zip
+                            /tmp/SBOM.zip
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,19 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
+      - shell: bash
+        name: Collect SBOM's
+        run: |
+          mkdir sboms
+          find . -path ./sboms -prune -o -name "*.spdx.json" -print
+          find . -path ./sboms -prune -o -name "*.spdx.json" -exec mv {} ./sboms/ \;
+          zip SBOM.zip sboms/*
+
       - uses: actions/upload-artifact@v4
-        name: Save gradle generated SBOM's to build
+        name: Save SBOM's to build
         with:
-          name: Gradle SPDX SBOMs
-          path: "**/build/spdx/*.spdx.json"
-
-      - uses: anchore/sbom-action@v0
-
-      - uses: anchore/sbom-action@v0
-        with:
-          format: cyclonedx-json
+          name: SBOM.zip
+          path: "sboms/*.spdx.json"
 
       - name: Set environment variables
         run: |
@@ -132,7 +134,8 @@ jobs:
           gh release create --target $GITHUB_REF_NAME \
                             --title "Version $VERSION" \
                             --notes-file /tmp/release-notes.txt \
-                            v$VERSION
+                            v$VERSION \
+                            SBOM.zip
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         name: Collect SBOM's
         run: |
           mkdir sboms
-          find . -path ./sboms -prune -o -name "*.spdx.json" -print
+          find . -path ./sboms -prune -o -name "*.cyclonedx.json" -exec mv {} ./sboms/ \;
           find . -path ./sboms -prune -o -name "*.spdx.json" -exec mv {} ./sboms/ \;
           zip SBOM.zip sboms/*
           cp SBOM.zip /tmp/
@@ -45,7 +45,7 @@ jobs:
         name: Save SBOM's to build
         with:
           name: SBOM.zip
-          path: "sboms/*.spdx.json"
+          path: "sboms/*.json"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
+      - uses: actions/upload-artifact@v4
+        name: Save gradle generated SBOM's to build
+        with:
+          name: Gradle SPDX SBOMs
+          path: "**/build/spdx/*.spdx.json"
+
       - uses: anchore/sbom-action@v0
 
       - uses: anchore/sbom-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
 
       - uses: anchore/sbom-action@v0
 
+      - uses: anchore/sbom-action@v0
+        with:
+          format: cyclonedx-json
+
       - name: Set environment variables
         run: |
           version=$(.github/scripts/get-version.sh)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
+      - uses: anchore/sbom-action@v0
+
       - name: Set environment variables
         run: |
           version=$(.github/scripts/get-version.sh)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
   implementation("org.owasp:dependency-check-gradle:9.0.9")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.1")
   implementation("org.spdx:spdx-gradle-plugin:0.5.0")
+  implementation("org.cyclonedx:cyclonedx-gradle-plugin:1.8.2")
 }
 
 // We can't apply conventions to this build so include important ones such as the Java compilation

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
   implementation("org.owasp:dependency-check-gradle:9.0.9")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.1")
+  implementation("org.spdx:spdx-gradle-plugin:0.5.0")
 }
 
 // We can't apply conventions to this build so include important ones such as the Java compilation

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -111,5 +111,8 @@ if (!project.name.startsWith("bom")) {
     tasks.named("assemble") {
       dependsOn("spdxSbom", "cyclonedxBom")
     }
+    tasks.withType<AbstractPublishToMaven>() {
+      dependsOn("spdxSbom", "cyclonedxBom")
+    }
   }
 }

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.UUID
+
 plugins {
   `maven-publish`
   signing
@@ -71,7 +73,15 @@ if (!project.name.startsWith("bom")) {
       // create a target with name based on the project path,
       // this is used for the task name (spdxSbomFor<PATH>)
       // and output file (<PATH>.spdx.json)
-      create(project.path.substring(1).replace(":", "-"))
+      create(project.path.substring(1).replace(":", "-")) {
+        scm {
+          uri.set("https://github.com/" + System.getenv("GITHUB_REPOSITORY"))
+          revision.set(System.getenv("GITHUB_SHA"))
+        }
+        document {
+          namespace.set("https://opentelemetry.io/spdx/" + UUID.randomUUID())
+        }
+      }
     }
   }
   tasks.named("assemble") {

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   signing
 
   id("otel.japicmp-conventions")
+  id("org.spdx.sbom")
 }
 
 publishing {
@@ -61,5 +62,19 @@ if (System.getenv("CI") != null) {
   signing {
     useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
     sign(publishing.publications["mavenPublication"])
+  }
+}
+
+if (!project.name.startsWith("bom")) {
+  spdxSbom {
+    targets {
+      // create a target with name based on the project path,
+      // this is used for the task name (spdxSbomFor<PATH>)
+      // and output file (<PATH>.spdx.json)
+      create(project.path.substring(1).replace(":", "-"))
+    }
+  }
+  tasks.named("assemble") {
+    dependsOn("spdxSbom")
   }
 }

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -67,24 +67,28 @@ if (System.getenv("CI") != null) {
   }
 }
 
-if (!project.name.startsWith("bom")) {
-  spdxSbom {
-    targets {
-      // create a target with name based on the project path,
-      // this is used for the task name (spdxSbomFor<PATH>)
-      // and output file (<PATH>.spdx.json)
-      create(project.path.substring(1).replace(":", "-")) {
-        scm {
-          uri.set("https://github.com/" + System.getenv("GITHUB_REPOSITORY"))
-          revision.set(System.getenv("GITHUB_SHA"))
-        }
-        document {
-          namespace.set("https://opentelemetry.io/spdx/" + UUID.randomUUID())
+project.afterEvaluate {
+  if (!project.name.startsWith("bom")) {
+    spdxSbom {
+      targets {
+        val sbomName = "opentelemetry-java_" + base.archivesName.get()
+        // Create a target to match the published jar name.
+        // This is used for the task name (spdxSbomFor<SbomName>)
+        // and output file (<sbomName>.spdx.json).
+        create(sbomName) {
+          scm {
+            uri.set("https://github.com/" + System.getenv("GITHUB_REPOSITORY"))
+            revision.set(System.getenv("GITHUB_SHA"))
+          }
+          document {
+            name.set(sbomName)
+            namespace.set("https://opentelemetry.io/spdx/" + UUID.randomUUID())
+          }
         }
       }
     }
-  }
-  tasks.named("assemble") {
-    dependsOn("spdxSbom")
+    tasks.named("assemble") {
+      dependsOn("spdxSbom")
+    }
   }
 }

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -1,4 +1,4 @@
-import java.util.UUID
+import java.util.*
 
 plugins {
   `maven-publish`
@@ -28,6 +28,15 @@ publishing {
       versionMapping {
         allVariants {
           fromResolutionResult()
+        }
+      }
+
+      if (!project.name.startsWith("bom")) {
+        afterEvaluate {
+          artifact("${layout.buildDirectory.get()}/spdx/${"opentelemetry-java_" + base.archivesName.get()}.spdx.json") {
+            classifier = "spdx"
+            extension = "spdx.json"
+          }
         }
       }
 
@@ -67,8 +76,8 @@ if (System.getenv("CI") != null) {
   }
 }
 
-project.afterEvaluate {
-  if (!project.name.startsWith("bom")) {
+if (!project.name.startsWith("bom")) {
+  project.afterEvaluate {
     spdxSbom {
       targets {
         val sbomName = "opentelemetry-java_" + base.archivesName.get()


### PR DESCRIPTION
This has been requested by customers to enable better security practices.

Adds the [spdx-gradle-plugin](https://github.com/spdx/spdx-gradle-plugin) and the [cyclonedx-gradle-plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) to published projects to generate SBOM files for the build.

When run in a build job, the various generated SBOMs are collected into `SBOM.zip` and uploaded as a build artifact . When run as a release, it will also upload the SBOM to the github release.

The release part has been verified: https://github.com/tylerbenson/opentelemetry-java/releases/tag/v1.37.0
(Notice the `SBOM.zip` file attached.  This was done automatically by the workflow.)

The SBOM's are also attached to the publication so they are individually uploaded to Maven Central as part of the release process. This process was verified with the `publishToMavenLocal` task.

Related links:
- https://github.com/open-telemetry/community/discussions/1741
- https://github.com/security-slam/metrics/blob/main/cncf/2023/mechanizer.md