### PR TITLE
Add null check to StrictContextStorage

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
@@ -268,14 +268,11 @@ final class StrictContextStorage implements ContextStorage, AutoCloseable {
       try {
         while (!Thread.interrupted()) {
           Reference<? extends Scope> reference = remove();
-          if (reference != null) {
-            CallerStackTrace caller = map.remove(reference);
-            if (caller != null && !caller.closed) {
-              logger.log(
-                  Level.SEVERE,
-                  "Scope garbage collected before being closed.",
-                  callerError(caller));
-            }
+          // on openj9 ReferenceQueue.remove can return null
+          CallerStackTrace caller = reference != null ? map.remove(reference) : null;
+          if (caller != null && !caller.closed) {
+            logger.log(
+                Level.SEVERE, "Scope garbage collected before being closed.", callerError(caller));
           }
         }
       } catch (InterruptedException ignored) {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/y3ppcyqy2q5v2/tests/task/:instrumentation:reactor:reactor-netty:reactor-netty-1.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.ReactorNettyHttpClientUsingFromTest/shouldNotLeakConnections()?expanded-stacktrace=WyIwIl0&top-execution=1
Also see https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7304
Apparently `ReferenceQueue#remove()` can return null on openj9.