### PR TITLE
Fix flaky jaeger remote sampler test

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
@@ -148,7 +148,7 @@ class JaegerRemoteSamplerGrpcNettyTest {
   void initialSampler() {
     try (JaegerRemoteSampler sampler =
         JaegerRemoteSampler.builder()
-            .setChannel(managedChannel())
+            .setChannel(ManagedChannelBuilder.forTarget("example.com").build())
             .setServiceName(SERVICE_NAME)
             .setInitialSampler(Sampler.alwaysOn())
             .build()) {


### PR DESCRIPTION
https://scans.gradle.com/s/wcf3eniwf5tb6/tests/task/:sdk-extensions:jaeger-remote-sampler:testGrpcNetty/details/io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerGrpcNettyTest/initialSampler()?expanded-stacktrace=WyIwIl0&top-execution=1
Test fails when remote configuration is received before asserting sampler description.
The same test with okhttp uses `example.com` as target
https://github.com/open-telemetry/opentelemetry-java/blob/efa46a5dccb962b50943a0b4905c1800282d6be6/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java#L251