### PR TITLE
Prototype exposing the exemplar reservoir for upcoming spec changes

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoirFactory.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoirFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.exemplar;
+
+import io.opentelemetry.sdk.common.Clock;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+/**
+ * An interface for constructing an appropriate ExemplarReservoir for a given metric "memory cell".
+ */
+public interface ExemplarReservoirFactory {
+  ExemplarReservoir<LongExemplarData> createLongExemplarReservoir();
+
+  ExemplarReservoir<DoubleExemplarData> createDoubleExemplarReservoir();
+
+  /** An exemplar reservoir that stores no exemplars. */
+  static ExemplarReservoirFactory noSamples() {
+    return new ExemplarReservoirFactory() {
+      @Override
+      public ExemplarReservoir<LongExemplarData> createLongExemplarReservoir() {
+        return NoopExemplarReservoir.LONG_INSTANCE;
+      }
+
+      @Override
+      public ExemplarReservoir<DoubleExemplarData> createDoubleExemplarReservoir() {
+        return NoopExemplarReservoir.DOUBLE_INSTANCE;
+      }
+
+      @Override
+      public String toString() {
+        return "noSamples";
+      }
+    };
+  }
+
+  /**
+   * A reservoir with fixed size that stores the given number of exemplars.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param size The maximum number of exemplars to preserve.
+   * @param randomSupplier The random number generator to use for sampling.
+   */
+  static ExemplarReservoirFactory fixedSize(
+      Clock clock, int size, Supplier<Random> randomSupplier) {
+    return new ExemplarReservoirFactory() {
+      @Override
+      public ExemplarReservoir<LongExemplarData> createLongExemplarReservoir() {
+        return RandomFixedSizeExemplarReservoir.createLong(clock, size, randomSupplier);
+      }
+
+      @Override
+      public ExemplarReservoir<DoubleExemplarData> createDoubleExemplarReservoir() {
+        return RandomFixedSizeExemplarReservoir.createDouble(clock, size, randomSupplier);
+      }
+
+      @Override
+      public String toString() {
+        return "fixedSize(" + size + ")";
+      }
+    };
+  }
+
+  /**
+   * A Reservoir sampler that preserves the latest seen measurement per-histogram bucket.
+   *
+   * @param clock The clock to use when annotating measurements with time.
+   * @param boundaries A list of (inclusive) upper bounds for the histogram. Should be in order from
+   *     lowest to highest.
+   */
+  static ExemplarReservoirFactory histogramBucket(Clock clock, List<Double> boundaries) {
+    return new ExemplarReservoirFactory() {
+      @Override
+      public ExemplarReservoir<LongExemplarData> createLongExemplarReservoir() {
+        throw new UnsupportedOperationException(
+            "Cannot create long exemplars for histogram buckets");
+      }
+
+      @Override
+      public ExemplarReservoir<DoubleExemplarData> createDoubleExemplarReservoir() {
+        return new HistogramExemplarReservoir(clock, boundaries);
+      }
+
+      @Override
+      public String toString() {
+        return "histogramBucket(" + boundaries + ")";
+      }
+    };
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AggregationExtension.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AggregationExtension.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.view;
+
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoirFactory;
+
+/**
+ * An interface which allows customized configuration of aggregators.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public interface AggregationExtension extends Aggregation, AggregatorFactory {
+  /** Override the exemplar reservoir used for this aggregation. */
+  AggregationExtension setExemplarReservoirFactory(ExemplarReservoirFactory reservoirFactory);
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DropAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/DropAggregation.java
@@ -9,9 +9,9 @@ import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.internal.aggregator.Aggregator;
-import io.opentelemetry.sdk.metrics.internal.aggregator.AggregatorFactory;
 import io.opentelemetry.sdk.metrics.internal.descriptor.InstrumentDescriptor;
 import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoirFactory;
 
 /**
  * Configuration representing no aggregation.
@@ -19,7 +19,7 @@ import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class DropAggregation implements Aggregation, AggregatorFactory {
+public final class DropAggregation implements AggregationExtension {
 
   private static final Aggregation INSTANCE = new DropAggregation();
 
@@ -44,5 +44,11 @@ public final class DropAggregation implements Aggregation, AggregatorFactory {
   @Override
   public String toString() {
     return "DropAggregation";
+  }
+
+  @Override
+  public AggregationExtension setExemplarReservoirFactory(
+      ExemplarReservoirFactory reservoirFactory) {
+    throw new UnsupportedOperationException("DropAggregation does not allow exemplars");
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkCustomExemplarReservoirTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkCustomExemplarReservoirTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter;
+import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoirFactory;
+import io.opentelemetry.sdk.metrics.internal.view.AggregationExtension;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.time.TestClock;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for using the AggregationExtension and ExemplarReservoirFactory internal APIs. */
+public class SdkCustomExemplarReservoirTest {
+  private static final Resource RESOURCE =
+      Resource.create(Attributes.of(stringKey("resource_key"), "resource_value"));
+  private final TestClock testClock = TestClock.create();
+
+  private Meter initialize(InMemoryMetricReader memory, ExemplarReservoirFactory reservoirFactory) {
+    SdkMeterProvider sdkMeterProvider =
+        SdkMeterProvider.builder()
+            .setClock(testClock)
+            .setResource(RESOURCE)
+            .setExemplarFilter(ExemplarFilter.alwaysOn())
+            .registerView(
+                InstrumentSelector.builder().setName("test").build(),
+                View.builder()
+                    .setAggregation(
+                        ((AggregationExtension) Aggregation.sum())
+                            .setExemplarReservoirFactory(reservoirFactory))
+                    .build())
+            .registerMetricReader(memory)
+            .build();
+    return sdkMeterProvider.get(getClass().getName());
+  }
+
+  @Test
+  void collectMetrics_withCustomExemplarReservoir() {
+    // Create reservoir that always samples, and makes sure we get the first two samples.
+    ExemplarReservoirFactory testReservor =
+        ExemplarReservoirFactory.fixedSize(
+            testClock,
+            2,
+            () ->
+                new Random() {
+                  @Override
+                  public int nextInt(int bound) {
+                    return bound - 1;
+                  }
+                });
+    InMemoryMetricReader sdkMeterReader = InMemoryMetricReader.create();
+    Meter sdkMeter = initialize(sdkMeterReader, testReservor);
+    DoubleCounter instrument = sdkMeter.counterBuilder("test").ofDoubles().build();
+    instrument.add(10);
+    instrument.add(1);
+    assertThat(sdkMeterReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasResource(RESOURCE)
+                    .hasDoubleSumSatisfying(
+                        sum ->
+                            sum.isMonotonic()
+                                .isCumulative()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(11)
+                                            // TODO - has exemplars matching reservoir behavior
+                                            .hasExemplarsSatisfying(
+                                                exemplar -> exemplar.hasValue(10),
+                                                exemplar -> exemplar.hasValue(1)))));
+  }
+}


### PR DESCRIPTION
- Create ExemplarReservoirFactory to help abstract over Double/Long hell
- Create AggregationExtension that allows specifying an exemplar reservoir factory
- Add a test which hacks RNG to make sure this all works correctly.

This is for open discussion on how we want to expose customization of ExemplarReservoir to users.  One of the two remaining blockers for stabilizing Exemplar specification.

cc @jack-berg 