### PR TITLE
Use a custom output stream in marshaling jmh benchmarks

### DIFF
--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/GrpcGzipBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/GrpcGzipBenchmark.java
@@ -141,8 +141,8 @@ public class GrpcGzipBenchmark {
   }
 
   @Benchmark
-  public ByteArrayOutputStream gzipCompressor() throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+  public TestOutputStream gzipCompressor() throws IOException {
+    TestOutputStream baos = new TestOutputStream();
     OutputStream gzos = GZIP_CODEC.compress(baos);
     METRICS_REQUEST.writeTo(gzos);
     gzos.close();
@@ -150,8 +150,8 @@ public class GrpcGzipBenchmark {
   }
 
   @Benchmark
-  public ByteArrayOutputStream identityCompressor() throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+  public TestOutputStream identityCompressor() throws IOException {
+    TestOutputStream baos = new TestOutputStream();
     OutputStream gzos = IDENTITY_CODEC.compress(baos);
     METRICS_REQUEST.writeTo(gzos);
     gzos.close();

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/MetricsRequestMarshalerBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/MetricsRequestMarshalerBenchmark.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -117,9 +116,9 @@ public class MetricsRequestMarshalerBenchmark {
   }
 
   @Benchmark
-  public ByteArrayOutputStream marshaler() throws IOException {
+  public TestOutputStream marshaler() throws IOException {
     MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(METRICS);
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    TestOutputStream bos = new TestOutputStream();
     marshaler.writeBinaryTo(bos);
     return bos;
   }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/RequestMarshalBenchmarks.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/RequestMarshalBenchmarks.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.exporter.internal.otlp;
 
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -27,26 +26,26 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public ByteArrayOutputStream createCustomMarshal(RequestMarshalState state) {
+  public TestOutputStream createCustomMarshal(RequestMarshalState state) {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
-    return new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+    return new TestOutputStream(requestMarshaler.getBinarySerializedSize());
   }
 
   @Benchmark
   @Threads(1)
-  public ByteArrayOutputStream marshalCustom(RequestMarshalState state) throws IOException {
+  public TestOutputStream marshalCustom(RequestMarshalState state) throws IOException {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
-    ByteArrayOutputStream customOutput =
-        new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+    TestOutputStream customOutput =
+        new TestOutputStream(requestMarshaler.getBinarySerializedSize());
     requestMarshaler.writeBinaryTo(customOutput);
     return customOutput;
   }
 
   @Benchmark
   @Threads(1)
-  public ByteArrayOutputStream marshalJson(RequestMarshalState state) throws IOException {
+  public TestOutputStream marshalJson(RequestMarshalState state) throws IOException {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
-    ByteArrayOutputStream customOutput = new ByteArrayOutputStream();
+    TestOutputStream customOutput = new TestOutputStream();
     requestMarshaler.writeJsonTo(customOutput);
     return customOutput;
   }

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/TestOutputStream.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/TestOutputStream.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import java.io.OutputStream;
+
+class TestOutputStream extends OutputStream {
+  private final int size;
+  private int count;
+
+  TestOutputStream() {
+    this(-1);
+  }
+
+  TestOutputStream(int size) {
+    this.size = size;
+  }
+
+  @Override
+  public void write(int b) {
+    count++;
+    if (size > 0 && count > size) {
+      throw new IllegalStateException("max size exceeded");
+    }
+  }
+}


### PR DESCRIPTION
`ByteArrayOutputStream`, that is currently used, also allocates memory which is included in the jmh output. Removing the allocations for the output buffer gives a more accurate representation of the allocations performed by the marshaling.