### PR TITLE
Building animal sniffer signatures directly from android corelib

### DIFF
--- a/animal-sniffer/build.gradle.kts
+++ b/animal-sniffer/build.gradle.kts
@@ -1,0 +1,54 @@
+import ru.vyarus.gradle.plugin.animalsniffer.info.SignatureInfoTask
+import ru.vyarus.gradle.plugin.animalsniffer.signature.BuildSignatureTask
+
+plugins {
+  id("otel.java-conventions")
+  id("ru.vyarus.animalsniffer")
+}
+
+val signatureJar = configurations.create("signatureJar") {
+  isCanBeConsumed = false
+  isCanBeResolved = false
+}
+val signatureJarClasspath = configurations.create("signatureJarClasspath") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+  extendsFrom(signatureJar)
+}
+val generatedSignature = configurations.create("generatedSignature") {
+  isCanBeConsumed = true
+  isCanBeResolved = false
+}
+configurations.add(signatureJar)
+configurations.add(signatureJarClasspath)
+configurations.add(generatedSignature)
+
+repositories {
+  mavenCentral()
+  google()
+}
+
+dependencies {
+  signature("com.toasttab.android:gummy-bears-api-21:0.6.1@signature")
+  signatureJar("com.android.tools:desugar_jdk_libs:2.0.4")
+}
+
+val signatureSimpleName = "android.signature"
+val signatureBuilderTask = tasks.register("buildSignature", BuildSignatureTask::class.java) {
+  files(signatureJarClasspath) // All the jar files here will be added to the signature file.
+  signatures(configurations.signature) // We'll extend from the existing signatures added to this config.
+  outputName = signatureSimpleName // Name for the generated signature file.
+}
+
+// Exposing the "generatedSignature" consumable config to be used in other subprojects
+artifacts {
+  add("generatedSignature", project.provider { File(signatureBuilderTask.get().outputs.files.singleFile, signatureSimpleName) }) {
+    builtBy(signatureBuilderTask)
+  }
+}
+
+// Utility task to show what's in the signature file
+tasks.register( "printSignature", SignatureInfoTask::class.java) {
+  signature = signatureBuilderTask.get().outputFiles
+  depth = 1
+}

--- a/buildSrc/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-  add("signature", "com.toasttab.android:gummy-bears-api-21:0.3.0:coreLib@signature")
+  signature(project(path = ":animal-sniffer", configuration = "generatedSignature"))
 }
 
 animalsniffer {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,7 @@ include(":sdk-extensions:autoconfigure-spi")
 include(":sdk-extensions:incubator")
 include(":sdk-extensions:jaeger-remote-sampler")
 include(":testing-internal")
+include(":animal-sniffer")
 
 val gradleEnterpriseServer = "https://ge.opentelemetry.io"
 val isCI = System.getenv("CI") != null


### PR DESCRIPTION
Android [corelib or desugar_jdk](https://github.com/google/desugar_jdk_libs/tree/master) lib is a jar containing missing JDK8 classes from Android OS versions below API 26. The idea is that apps targeting old Android devices, where said classes are missing, can add those into the app itself to avoid `NoClassDefFoundException` runtime errors in old devices. More info [here](https://developer.android.com/studio/write/java8-support#library-desugaring).

However, the corelib doesn't have ALL the JDK8 missing classes, so we need to make sure we don't use those in order to avoid Android runtime exceptions. That's where Animal Sniffer helps, by checking our codebase against a signature that contains all the info about the classes available at runtime in old Android devices, both from the OS itself and from the corelib as well.

Since the corelib version of gummy-bears [is not currently up-to-date](https://github.com/open-toast/gummy-bears/issues/25) with the latest [corelib/desugar lib](https://github.com/google/desugar_jdk_libs/blob/HEAD/CHANGELOG.md) changes from Google, these changes aim to locally generate our android animal sniffer signature directly from the android lib, while also extending gummy-bears' existing plain (without the corelib parts, just the OS runtime classes) signature by following [this guide on how to create/extend signatures](https://github.com/xvik/gradle-animalsniffer-plugin/wiki/Buid-project-signature) for animal sniffer.