### PR TITLE
Improve autoconfiguration capabilities for adding, delaying or dropping spans

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,4 +1,5 @@
 Comparing source compatibility of  against 
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addLogRecordProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.logs.LogRecordProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.logs.LogRecordProcessor>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
@@ -1,4 +1,5 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder addBatchSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addLogRecordProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.logs.LogRecordProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.logs.LogRecordProcessor>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder addSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder addBatchSpanProcessorCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.trace.SpanProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.trace.SpanProcessor>)

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Map;
@@ -61,6 +62,21 @@ public interface AutoConfigurationCustomizer {
   AutoConfigurationCustomizer addSpanExporterCustomizer(
       BiFunction<? super SpanExporter, ConfigProperties, ? extends SpanExporter>
           exporterCustomizer);
+
+  /**
+   * Adds a {@link BiFunction} to invoke with the default autoconfigured {@link
+   * io.opentelemetry.sdk.trace.SpanProcessor}s responsible for invoking registered {@link
+   * SpanExporter}s. The return value of the {@link BiFunction} will replace the passed-in argument.
+   * In contrast to {@link #addSpanExporterCustomizer(BiFunction)} this allows modifications to
+   * happen before batching occurs. As a result, it is possible to efficiently filter spans, add
+   * artificial spans or delay spans for enhancing them with external, delayed data. The provided
+   * function will be invoked at most once per customized SDK instance.
+   *
+   * <p>Multiple calls will execute the customizers in order.
+   */
+  AutoConfigurationCustomizer addSpanExportProcessorCustomizer(
+      BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
+          exporterProcessorCustomizer);
 
   /**
    * Adds a {@link Supplier} of a map of property names and values to use as defaults for the {@link

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.autoconfigure.spi;
 
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
@@ -179,6 +180,22 @@ public interface AutoConfigurationCustomizer {
   default AutoConfigurationCustomizer addLogRecordExporterCustomizer(
       BiFunction<? super LogRecordExporter, ConfigProperties, ? extends LogRecordExporter>
           exporterCustomizer) {
+    return this;
+  }
+
+  /**
+   * Adds a {@link BiFunction} to invoke for all autoconfigured {@link
+   * io.opentelemetry.sdk.logs.LogRecordProcessor}s. The return value of the {@link BiFunction} will
+   * replace the passed-in argument. In contrast to {@link
+   * #addLogRecordExporterCustomizer(BiFunction)} (BiFunction)} this allows modifications to happen
+   * before batching occurs. As a result, it is possible to efficiently filter logs, add artificial
+   * logs or delay logs for enhancing them with external, delayed data.
+   *
+   * <p>Multiple calls will execute the customizers in order.
+   */
+  default AutoConfigurationCustomizer addLogRecordProcessorCustomizer(
+      BiFunction<? super LogRecordProcessor, ConfigProperties, ? extends LogRecordProcessor>
+          logRecordProcessorCustomizer) {
     return this;
   }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -76,7 +76,7 @@ public interface AutoConfigurationCustomizer {
    */
   default AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-          exporterProcessorCustomizer){
+          exporterProcessorCustomizer) {
     return this;
   }
 

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -74,9 +74,11 @@ public interface AutoConfigurationCustomizer {
    *
    * <p>Multiple calls will execute the customizers in order.
    */
-  AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(
+  default AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-          exporterProcessorCustomizer);
+          exporterProcessorCustomizer){
+    return this;
+  }
 
   /**
    * Adds a {@link Supplier} of a map of property names and values to use as defaults for the {@link

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -64,19 +64,18 @@ public interface AutoConfigurationCustomizer {
           exporterCustomizer);
 
   /**
-   * Adds a {@link BiFunction} to invoke with the default autoconfigured {@link
-   * io.opentelemetry.sdk.trace.SpanProcessor}s responsible for invoking registered {@link
-   * SpanExporter}s. The return value of the {@link BiFunction} will replace the passed-in argument.
-   * In contrast to {@link #addSpanExporterCustomizer(BiFunction)} this allows modifications to
-   * happen before batching occurs. As a result, it is possible to efficiently filter spans, add
-   * artificial spans or delay spans for enhancing them with external, delayed data. The provided
-   * function will be invoked at most once per customized SDK instance.
+   * Adds a {@link BiFunction} to invoke for all autoconfigured {@link
+   * io.opentelemetry.sdk.trace.SpanProcessor}. The return value of the {@link BiFunction} will
+   * replace the passed-in argument. In contrast to {@link #addSpanExporterCustomizer(BiFunction)}
+   * this allows modifications to happen before batching occurs. As a result, it is possible to
+   * efficiently filter spans, add artificial spans or delay spans for enhancing them with external,
+   * delayed data.
    *
    * <p>Multiple calls will execute the customizers in order.
    */
-  default AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(
+  default AutoConfigurationCustomizer addSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-          exporterProcessorCustomizer) {
+          spanProcessorCustomizer) {
     return this;
   }
 

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/AutoConfigurationCustomizer.java
@@ -74,7 +74,7 @@ public interface AutoConfigurationCustomizer {
    *
    * <p>Multiple calls will execute the customizers in order.
    */
-  AutoConfigurationCustomizer addSpanExportProcessorCustomizer(
+  AutoConfigurationCustomizer addBatchSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
           exporterProcessorCustomizer);
 

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -74,7 +74,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
       spanExporterCustomizer = (a, unused) -> a;
 
   private BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-      spanExporterProcessorCustomizer = (a, unused) -> a;
+      batchSpanProcessorCustomizer = (a, unused) -> a;
   private BiFunction<? super Sampler, ConfigProperties, ? extends Sampler> samplerCustomizer =
       (a, unused) -> a;
 
@@ -207,12 +207,12 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
    * <p>Multiple calls will execute the customizers in order.
    */
   @Override
-  public AutoConfigurationCustomizer addSpanExportProcessorCustomizer(
+  public AutoConfiguredOpenTelemetrySdkBuilder addBatchSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-          spanExporterProcessorCustomizer) {
-    requireNonNull(spanExporterProcessorCustomizer, "spanExporterCustomizer");
-    this.spanExporterProcessorCustomizer =
-        mergeCustomizer(this.spanExporterProcessorCustomizer, spanExporterProcessorCustomizer);
+          batchSpanProcessorCustomizer) {
+    requireNonNull(batchSpanProcessorCustomizer, "batchSpanProcessorCustomizer");
+    this.batchSpanProcessorCustomizer =
+        mergeCustomizer(this.batchSpanProcessorCustomizer, batchSpanProcessorCustomizer);
     return this;
   }
 
@@ -397,7 +397,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
             spiHelper,
             meterProvider,
             spanExporterCustomizer,
-            spanExporterProcessorCustomizer,
+            batchSpanProcessorCustomizer,
             samplerCustomizer,
             closeables);
         tracerProviderBuilder = tracerProviderCustomizer.apply(tracerProviderBuilder, config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -74,7 +74,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
       spanExporterCustomizer = (a, unused) -> a;
 
   private BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-      batchSpanProcessorCustomizer = (a, unused) -> a;
+      spanProcessorCustomizer = (a, unused) -> a;
   private BiFunction<? super Sampler, ConfigProperties, ? extends Sampler> samplerCustomizer =
       (a, unused) -> a;
 
@@ -196,23 +196,22 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   }
 
   /**
-   * Adds a {@link BiFunction} to invoke with the default autoconfigured {@link
-   * io.opentelemetry.sdk.trace.SpanProcessor}s responsible for invoking registered {@link
-   * SpanExporter}s. The return value of the {@link BiFunction} will replace the passed-in argument.
-   * In contrast to {@link #addSpanExporterCustomizer(BiFunction)} this allows modifications to
-   * happen before batching occurs. As a result, it is possible to efficiently filter spans, add
-   * artificial spans or delay spans for enhancing them with external, delayed data. The provided
-   * function will be invoked at most once per customized SDK instance.
+   * Adds a {@link BiFunction} to invoke for all autoconfigured {@link
+   * io.opentelemetry.sdk.trace.SpanProcessor}. The return value of the {@link BiFunction} will
+   * replace the passed-in argument. In contrast to {@link #addSpanExporterCustomizer(BiFunction)}
+   * this allows modifications to happen before batching occurs. As a result, it is possible to
+   * efficiently filter spans, add artificial spans or delay spans for enhancing them with external,
+   * delayed data.
    *
    * <p>Multiple calls will execute the customizers in order.
    */
   @Override
-  public AutoConfiguredOpenTelemetrySdkBuilder addBatchSpanProcessorCustomizer(
+  public AutoConfiguredOpenTelemetrySdkBuilder addSpanProcessorCustomizer(
       BiFunction<? super SpanProcessor, ConfigProperties, ? extends SpanProcessor>
-          batchSpanProcessorCustomizer) {
-    requireNonNull(batchSpanProcessorCustomizer, "batchSpanProcessorCustomizer");
-    this.batchSpanProcessorCustomizer =
-        mergeCustomizer(this.batchSpanProcessorCustomizer, batchSpanProcessorCustomizer);
+          spanProcessorCustomizer) {
+    requireNonNull(spanProcessorCustomizer, "spanProcessorCustomizer");
+    this.spanProcessorCustomizer =
+        mergeCustomizer(this.spanProcessorCustomizer, spanProcessorCustomizer);
     return this;
   }
 
@@ -397,7 +396,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
             spiHelper,
             meterProvider,
             spanExporterCustomizer,
-            batchSpanProcessorCustomizer,
+            spanProcessorCustomizer,
             samplerCustomizer,
             closeables);
         tracerProviderBuilder = tracerProviderCustomizer.apply(tracerProviderBuilder, config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.AutoConfigureListener;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
@@ -87,6 +88,8 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
       loggerProviderCustomizer = (a, unused) -> a;
   private BiFunction<? super LogRecordExporter, ConfigProperties, ? extends LogRecordExporter>
       logRecordExporterCustomizer = (a, unused) -> a;
+  private BiFunction<? super LogRecordProcessor, ConfigProperties, ? extends LogRecordProcessor>
+      logRecordProcessorCustomizer = (a, unused) -> a;
 
   private BiFunction<? super Resource, ConfigProperties, ? extends Resource> resourceCustomizer =
       (a, unused) -> a;
@@ -314,6 +317,26 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   }
 
   /**
+   * Adds a {@link BiFunction} to invoke for all autoconfigured {@link
+   * io.opentelemetry.sdk.logs.LogRecordProcessor}s. The return value of the {@link BiFunction} will
+   * replace the passed-in argument. In contrast to {@link
+   * #addLogRecordExporterCustomizer(BiFunction)} (BiFunction)} this allows modifications to happen
+   * before batching occurs. As a result, it is possible to efficiently filter logs, add artificial
+   * logs or delay logs for enhancing them with external, delayed data.
+   *
+   * <p>Multiple calls will execute the customizers in order.
+   */
+  @Override
+  public AutoConfigurationCustomizer addLogRecordProcessorCustomizer(
+      BiFunction<? super LogRecordProcessor, ConfigProperties, ? extends LogRecordProcessor>
+          logRecordProcessorCustomizer) {
+    requireNonNull(logRecordProcessorCustomizer, "logRecordProcessorCustomizer");
+    this.logRecordProcessorCustomizer =
+        mergeCustomizer(this.logRecordProcessorCustomizer, logRecordProcessorCustomizer);
+    return this;
+  }
+
+  /**
    * Disable the registration of a shutdown hook to shut down the SDK when appropriate. By default,
    * the shutdown hook is registered.
    *
@@ -411,6 +434,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
             spiHelper,
             meterProvider,
             logRecordExporterCustomizer,
+            logRecordProcessorCustomizer,
             closeables);
         loggerProviderBuilder = loggerProviderCustomizer.apply(loggerProviderBuilder, config);
         SdkLoggerProvider loggerProvider = loggerProviderBuilder.build();

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfiguration.java
@@ -35,6 +35,8 @@ final class LoggerProviderConfiguration {
       MeterProvider meterProvider,
       BiFunction<? super LogRecordExporter, ConfigProperties, ? extends LogRecordExporter>
           logRecordExporterCustomizer,
+      BiFunction<? super LogRecordProcessor, ConfigProperties, ? extends LogRecordProcessor>
+          logRecordProcessorCustomizer,
       List<Closeable> closeables) {
 
     loggerProviderBuilder.setLogLimits(() -> configureLogLimits(config));
@@ -42,8 +44,15 @@ final class LoggerProviderConfiguration {
     Map<String, LogRecordExporter> exportersByName =
         configureLogRecordExporters(config, spiHelper, logRecordExporterCustomizer, closeables);
 
-    configureLogRecordProcessors(config, exportersByName, meterProvider, closeables)
-        .forEach(loggerProviderBuilder::addLogRecordProcessor);
+    List<LogRecordProcessor> processors =
+        configureLogRecordProcessors(config, exportersByName, meterProvider, closeables);
+    for (LogRecordProcessor processor : processors) {
+      LogRecordProcessor wrapped = logRecordProcessorCustomizer.apply(processor, config);
+      if (wrapped != processor) {
+        closeables.add(wrapped);
+      }
+      loggerProviderBuilder.addLogRecordProcessor(wrapped);
+    }
   }
 
   // Visible for testing

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -55,8 +55,9 @@ final class TracerProviderConfiguration {
         SpanExporterConfiguration.configureSpanExporters(
             config, spiHelper, spanExporterCustomizer, closeables);
 
-    List<SpanProcessor> processors = configureExportingSpanProcessors(config, exportersByName, meterProvider, closeables);
-    if(!processors.isEmpty()) {
+    List<SpanProcessor> processors =
+        configureExportingSpanProcessors(config, exportersByName, meterProvider, closeables);
+    if (!processors.isEmpty()) {
       SpanProcessor composite = SpanProcessor.composite(processors);
       closeables.add(composite);
       composite = batchSpanProcessorCustomizer.apply(composite, config);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfiguration.java
@@ -58,9 +58,9 @@ final class TracerProviderConfiguration {
     List<SpanProcessor> processors = configureExportingSpanProcessors(config, exportersByName, meterProvider, closeables);
     if(!processors.isEmpty()) {
       SpanProcessor composite = SpanProcessor.composite(processors);
+      closeables.add(composite);
       composite = batchSpanProcessorCustomizer.apply(composite, config);
       tracerProviderBuilder.addSpanProcessor(composite);
-      closeables.add(composite);
     }
   }
 
@@ -75,16 +75,16 @@ final class TracerProviderConfiguration {
     SpanExporter exporter = exportersByNameCopy.remove("logging");
     if (exporter != null) {
       SpanProcessor spanProcessor = SimpleSpanProcessor.create(exporter);
-      spanProcessors.add(spanProcessor);
       closeables.add(spanProcessor);
+      spanProcessors.add(spanProcessor);
     }
 
     if (!exportersByNameCopy.isEmpty()) {
       SpanExporter compositeSpanExporter = SpanExporter.composite(exportersByNameCopy.values());
       SpanProcessor spanProcessor =
           configureBatchSpanProcessor(config, compositeSpanExporter, meterProvider);
-      spanProcessors.add(spanProcessor);
       closeables.add(spanProcessor);
+      spanProcessors.add(spanProcessor);
     }
 
     return spanProcessors;

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.github.netmikey.logunit.api.LogCapturer;
@@ -49,8 +51,11 @@ import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -266,6 +271,50 @@ class AutoConfiguredOpenTelemetrySdkTest {
         .extracting("worker")
         .extracting("spanExporter")
         .isEqualTo(spanExporter2);
+  }
+
+  @Test
+  void builder_addBatchSpanProcessorCustomizer() {
+    SpanProcessor mockProcessor1 = Mockito.mock(SpanProcessor.class);
+    SpanProcessor mockProcessor2 = Mockito.mock(SpanProcessor.class);
+    doReturn(true).when(mockProcessor2).isStartRequired();
+    doReturn(true).when(mockProcessor2).isEndRequired();
+    Mockito.lenient().doReturn(CompletableResultCode.ofSuccess()).when(mockProcessor2).shutdown();
+    Mockito.lenient().when(spanExporter1.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+    SdkTracerProvider sdkTracerProvider =
+        builder
+            .addSpanExporterCustomizer((prev, config) -> spanExporter1)
+            .addBatchSpanProcessorCustomizer(
+                (previous, config) -> {
+                  assertThat(previous).isNotSameAs(mockProcessor2);
+                  return mockProcessor1;
+                })
+            .addBatchSpanProcessorCustomizer(
+                (previous, config) -> {
+                  assertThat(previous).isSameAs(mockProcessor1);
+                  return mockProcessor2;
+                })
+            .build()
+            .getOpenTelemetrySdk()
+            .getSdkTracerProvider();
+
+    assertThat(sdkTracerProvider)
+        .extracting("sharedState")
+        .extracting("activeSpanProcessor")
+        .isSameAs(mockProcessor2);
+
+    Span span = sdkTracerProvider.get("dummy-scope")
+        .spanBuilder("dummy-span")
+        .startSpan();
+
+    verify(mockProcessor2).onStart(any(), same((ReadWriteSpan) span));
+
+    span.end();
+    verify(mockProcessor2).onEnd(same((ReadableSpan) span));
+
+    verifyNoInteractions(mockProcessor1);
+    verifyNoInteractions(spanExporter1);
   }
 
   @Test

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -399,6 +399,8 @@ class AutoConfiguredOpenTelemetrySdkTest {
 
   // TODO: add test for addLogRecordExporterCustomizer once OTLP export is enabled by default
 
+  // TODO: add test for addLogRecordProcessorCustomizer once OTLP export is enabled by default
+
   @Test
   void builder_setResultAsGlobalFalse() {
     GlobalOpenTelemetry.set(OpenTelemetry.noop());

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -274,7 +274,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
   }
 
   @Test
-  void builder_addBatchSpanProcessorCustomizer() {
+  void builder_addSpanProcessorCustomizer() {
     SpanProcessor mockProcessor1 = Mockito.mock(SpanProcessor.class);
     SpanProcessor mockProcessor2 = Mockito.mock(SpanProcessor.class);
     doReturn(true).when(mockProcessor2).isStartRequired();
@@ -285,12 +285,12 @@ class AutoConfiguredOpenTelemetrySdkTest {
     SdkTracerProvider sdkTracerProvider =
         builder
             .addSpanExporterCustomizer((prev, config) -> spanExporter1)
-            .addBatchSpanProcessorCustomizer(
+            .addSpanProcessorCustomizer(
                 (previous, config) -> {
                   assertThat(previous).isNotSameAs(mockProcessor2);
                   return mockProcessor1;
                 })
-            .addBatchSpanProcessorCustomizer(
+            .addSpanProcessorCustomizer(
                 (previous, config) -> {
                   assertThat(previous).isSameAs(mockProcessor1);
                   return mockProcessor2;

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -304,9 +304,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
         .extracting("activeSpanProcessor")
         .isSameAs(mockProcessor2);
 
-    Span span = sdkTracerProvider.get("dummy-scope")
-        .spanBuilder("dummy-span")
-        .startSpan();
+    Span span = sdkTracerProvider.get("dummy-scope").spanBuilder("dummy-span").startSpan();
 
     verify(mockProcessor2).onStart(any(), same((ReadWriteSpan) span));
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -48,6 +48,7 @@ class LoggerProviderConfigurationTest {
         SpiHelper.create(LoggerProviderConfiguration.class.getClassLoader()),
         MeterProvider.noop(),
         (a, unused) -> a,
+        (a, unused) -> a,
         closeables);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/TracerProviderConfigurationTest.java
@@ -79,6 +79,7 @@ class TracerProviderConfigurationTest {
         MeterProvider.noop(),
         (a, unused) -> a,
         (a, unused) -> a,
+        (a, unused) -> a,
         closeables);
 
     try (SdkTracerProvider tracerProvider = tracerProviderBuilder.build()) {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -141,7 +141,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureExportingSpanProcessors(
+        TracerProviderConfiguration.configureSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, LoggingSpanExporter.create()),
@@ -159,7 +159,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureExportingSpanProcessors(
+        TracerProviderConfiguration.configureSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, ZipkinSpanExporter.builder().build()),
@@ -176,7 +176,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureExportingSpanProcessors(
+        TracerProviderConfiguration.configureSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "otlp,zipkin")),
             ImmutableMap.of(
@@ -218,7 +218,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureExportingSpanProcessors(
+        TracerProviderConfiguration.configureSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "logging,zipkin")),
             ImmutableMap.of(

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -146,6 +146,7 @@ class ConfigurableSpanExporterTest {
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, LoggingSpanExporter.create()),
             MeterProvider.noop(),
+            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -164,6 +165,7 @@ class ConfigurableSpanExporterTest {
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
+            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -185,6 +187,7 @@ class ConfigurableSpanExporterTest {
                 "zipkin",
                 ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
+            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -227,6 +230,7 @@ class ConfigurableSpanExporterTest {
                 "zipkin",
                 ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
+            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ConfigurableSpanExporterTest.java
@@ -141,12 +141,11 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureSpanProcessors(
+        TracerProviderConfiguration.configureExportingSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, LoggingSpanExporter.create()),
             MeterProvider.noop(),
-            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -160,12 +159,11 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureSpanProcessors(
+        TracerProviderConfiguration.configureExportingSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", exporterName)),
             ImmutableMap.of(exporterName, ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
-            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -178,7 +176,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureSpanProcessors(
+        TracerProviderConfiguration.configureExportingSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "otlp,zipkin")),
             ImmutableMap.of(
@@ -187,7 +185,6 @@ class ConfigurableSpanExporterTest {
                 "zipkin",
                 ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
-            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 
@@ -221,7 +218,7 @@ class ConfigurableSpanExporterTest {
     List<Closeable> closeables = new ArrayList<>();
 
     List<SpanProcessor> spanProcessors =
-        TracerProviderConfiguration.configureSpanProcessors(
+        TracerProviderConfiguration.configureExportingSpanProcessors(
             DefaultConfigProperties.createFromMap(
                 Collections.singletonMap("otel.traces.exporter", "logging,zipkin")),
             ImmutableMap.of(
@@ -230,7 +227,6 @@ class ConfigurableSpanExporterTest {
                 "zipkin",
                 ZipkinSpanExporter.builder().build()),
             MeterProvider.noop(),
-            (p, conf) -> p,
             closeables);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -47,6 +47,7 @@ class LoggerProviderConfigurationTest {
         SpiHelper.create(LoggerProviderConfiguration.class.getClassLoader()),
         MeterProvider.noop(),
         (a, unused) -> a,
+        (a, unused) -> a,
         closeables);
     cleanup.addCloseables(closeables);
 


### PR DESCRIPTION
The goal of this PR is to start a discussion around enhancing the ability to modify spans before export.

The existing mechanism to do this are the following: 
 * SpanProcessor for modifying spans on start
 * wrapping `SpanExporters` for modifying spans before they are exported (= after they have ended)

These options only allow to modify the contents of spans, but they do not allow to efficiently perform the following changes:
 * Filtering spans, so that they are not exported
    * See for example [this slack discussion](https://cloud-native.slack.com/archives/C014L2KCTE3/p1671486545789789)
 * Delaying spans
   * E.g. in order to add profiling statistics to spans as attributes. Those statistics are likely not immediately available on span end.
 * Adding artificial spans
   * Example use-case: Generating spans from profiling data. Could be done via a normal `Tracer`, but this would technically break the `SpanProcessor` contracts because `onStart` / `onEnd` will not be invoked synchronously on the thread to which the span "belongs".

In theory these actions can already be performed by wrapping `SpanExporters`. This is however not a good idea, because the addition, delay or dropping would happen *after* the batching performed by `BatchSpanProcessor`.
As a result, it essentially breaks batching, making it not really suitable for production.

A batching-friendly alternative would be to wrap the `BatchSpanProcessor` instead of the `SpanExporters`:

```
BatchSpanProcessor exportProcessor = BatchSpanProcessor.builder(myExporter).build();

SdkTracerProvider.builder()
  ...
  .addSpanProcessor(new MyWrapper(exportProcessor))
```

This approach already works nicely for manually configured SDK instances.
Unfortunately there is no corresponding hook available in the SDK autoconfiguration mechanism.
The code changes in this PR adds a corresponding hook, which could be made experimental for a start.

~Note that this PR is intended as just a starting point for a discussion rather than a ready-to-merge suggestion. I'm more than happy to discuss totally different alternatives.~

~If we decide to go the route suggested in this PR, I'll add test cases which I have omitted for a start.~

PR has been updated and enhanced with a test case.