### PR TITLE
Base64 encode AnyValue bytes in string representation

### DIFF
--- a/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/logs/AnyValueBytes.java
+++ b/extensions/incubator/src/main/java/io/opentelemetry/extension/incubator/logs/AnyValueBytes.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.extension.incubator.logs;
 
-import io.opentelemetry.api.internal.OtelEncodingUtils;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Objects;
 
 final class AnyValueBytes implements AnyValue<ByteBuffer> {
@@ -35,11 +35,7 @@ final class AnyValueBytes implements AnyValue<ByteBuffer> {
 
   @Override
   public String asString() {
-    // TODO: base64 would be better, but isn't available in android and java. Can we vendor in a
-    // base64 implementation?
-    char[] arr = new char[raw.length * 2];
-    OtelEncodingUtils.bytesToBase16(raw, arr, raw.length);
-    return new String(arr);
+    return Base64.getEncoder().encodeToString(raw);
   }
 
   @Override

--- a/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/logs/AnyValueTest.java
+++ b/extensions/incubator/src/test/java/io/opentelemetry/extension/incubator/logs/AnyValueTest.java
@@ -9,11 +9,11 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import io.opentelemetry.api.internal.OtelEncodingUtils;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -208,16 +208,15 @@ class AnyValueTest {
                     AnyValue.of(Collections.singletonMap("grandchild", AnyValue.of("str"))))),
             "[child=[grandchild=str]]"),
         // bytes
-        arguments(
-            AnyValue.of("hello world".getBytes(StandardCharsets.UTF_8)), "68656c6c6f20776f726c64"));
+        arguments(AnyValue.of("hello world".getBytes(StandardCharsets.UTF_8)), "aGVsbG8gd29ybGQ="));
   }
 
   @Test
   void anyValueByteAsString() {
     // TODO: add more test cases
     String str = "hello world";
-    String base16Encoded = AnyValue.of(str.getBytes(StandardCharsets.UTF_8)).asString();
-    byte[] decodedBytes = OtelEncodingUtils.bytesFromBase16(base16Encoded, base16Encoded.length());
+    String base64Encoded = AnyValue.of(str.getBytes(StandardCharsets.UTF_8)).asString();
+    byte[] decodedBytes = Base64.getDecoder().decode(base64Encoded);
     assertThat(new String(decodedBytes, StandardCharsets.UTF_8)).isEqualTo(str);
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/AnyValueBodyTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/AnyValueBodyTest.java
@@ -54,7 +54,7 @@ class AnyValueBodyTest {
             logRecordData -> {
               // TODO (jack-berg): add assertion when ANY_VALUE is added to Body.Type
               // assertThat(logRecordData.getBody().getType()).isEqualTo(Body.Type.ANY_VALUE);
-              assertThat(logRecordData.getBody().asString()).isEqualTo("68656c6c6f20776f726c64");
+              assertThat(logRecordData.getBody().asString()).isEqualTo("aGVsbG8gd29ybGQ=");
               assertThat(((AnyValueBody) logRecordData.getBody()).asAnyValue())
                   .isEqualTo(AnyValue.of("hello world".getBytes(StandardCharsets.UTF_8)));
             });
@@ -104,7 +104,7 @@ class AnyValueBodyTest {
                           + "bool_key=true, "
                           + "long_key=1, "
                           + "double_key=1.1, "
-                          + "bytes_key=6279746573, "
+                          + "bytes_key=Ynl0ZXM=, "
                           + "arr_key=[entry1, 2, 3.3], "
                           + "key_value_list_key=[child_str_key1=child_value1, child_str_key2=child_value2]"
                           + "]");


### PR DESCRIPTION
#5973 upgrades the desguaring version so that we have access to `Base64`. This produces a more compact / familiar encoding for AnyValue bytes than the hex encoding currently being used. 