### PR TITLE
Issue 6037 - Wrapping "invalid" SpanContexts in Span does not preserve SpanContext

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -81,9 +81,6 @@ public interface Span extends ImplicitContextKeyed {
       ApiUsageLogger.log("context is null");
       return getInvalid();
     }
-    if (!spanContext.isValid()) {
-      return getInvalid();
-    }
     return PropagatedSpan.create(spanContext);
   }
 


### PR DESCRIPTION
See [Issue 6037](https://github.com/open-telemetry/opentelemetry-java/issues/6037) for context.
