### PR TITLE
Add support for commas in values for exporter.otlp.headers

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -181,7 +181,21 @@ public final class DefaultConfigProperties implements ConfigProperties {
     if (value == null) {
       return Collections.emptyList();
     }
-    return filterBlanksAndNulls(value.split(","));
+
+    // Support list members containing commas per RFC9110 5.5 suggestion
+    String[] listMembers;
+    // check if list members are double-quoted
+    if (value.startsWith("\"") && value.endsWith("\"")) {
+      // remove first and last quote and split on '","'
+      value = value.substring(1, value.length() - 1);
+      listMembers = value.split("\"\\s?,\\s?\"");
+    } else if (value.contains(",") && value.contains("\"")) {
+      throw new ConfigurationException("Invalid list property: " + name + "=" + config.get(name));
+    } else {
+      listMembers = value.split(",");
+    }
+
+    return filterBlanksAndNulls(listMembers);
   }
 
   /**

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -36,7 +36,7 @@ class ConfigPropertiesTest {
         .containsExactly(entry("cat", "meow"), entry("dog", "bark"), entry("bear", "growl"));
     assertThat(config.getMap("test.map.commas"))
         .containsExactly(
-            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "growl,roar"));
+            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "roar"));
     assertThat(config.getDuration("test.duration")).isEqualTo(Duration.ofSeconds(1));
   }
 
@@ -54,7 +54,7 @@ class ConfigPropertiesTest {
         .containsExactly(entry("cat", "meow"), entry("dog", "bark"), entry("bear", "growl"));
     assertThat(config.getMap("test-map-commas"))
         .containsExactly(
-            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "growl,roar"));
+            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "roar"));
     assertThat(config.getDuration("test-duration")).isEqualTo(Duration.ofSeconds(1));
   }
 
@@ -179,17 +179,6 @@ class ConfigPropertiesTest {
   }
 
   @Test
-  void invalidList() {
-    DefaultConfigProperties config =
-        DefaultConfigProperties.createFromMap(
-            Collections.singletonMap(
-                "invalid", "\"cat=meow,hiss\",\"dog=bark,growl\", bear=growl"));
-    assertThatThrownBy(() -> config.getList("invalid"))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessageContaining("Invalid list property");
-  }
-
-  @Test
   void invalidDuration() {
     assertThatThrownBy(
             () ->
@@ -297,7 +286,7 @@ class ConfigPropertiesTest {
     properties.put("test.list", "cat,dog,bear");
     properties.put("test.map", "cat=meow,dog=bark,bear=growl,bird=");
     properties.put("test.duration", "1s");
-    properties.put("test.map.commas", "\"cat=meow,hiss\",\"dog=bark,growl\", \"bear=growl,roar\"");
+    properties.put("test.map.commas", "cat=\"meow,hiss\",dog=\"bark,growl\", bear=roar");
     return properties;
   }
 }

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -34,6 +34,9 @@ class ConfigPropertiesTest {
     assertThat(config.getList("test.list")).containsExactly("cat", "dog", "bear");
     assertThat(config.getMap("test.map"))
         .containsExactly(entry("cat", "meow"), entry("dog", "bark"), entry("bear", "growl"));
+    assertThat(config.getMap("test.map.commas"))
+        .containsExactly(
+            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "growl,roar"));
     assertThat(config.getDuration("test.duration")).isEqualTo(Duration.ofSeconds(1));
   }
 
@@ -49,6 +52,9 @@ class ConfigPropertiesTest {
     assertThat(config.getList("test-list")).containsExactly("cat", "dog", "bear");
     assertThat(config.getMap("test-map"))
         .containsExactly(entry("cat", "meow"), entry("dog", "bark"), entry("bear", "growl"));
+    assertThat(config.getMap("test-map-commas"))
+        .containsExactly(
+            entry("cat", "meow,hiss"), entry("dog", "bark,growl"), entry("bear", "growl,roar"));
     assertThat(config.getDuration("test-duration")).isEqualTo(Duration.ofSeconds(1));
   }
 
@@ -61,6 +67,7 @@ class ConfigPropertiesTest {
     assertThat(config.getDouble("test.double")).isNull();
     assertThat(config.getList("test.list")).isEmpty();
     assertThat(config.getMap("test.map")).isEmpty();
+    assertThat(config.getMap("test.map.commas")).isEmpty();
     assertThat(config.getDuration("test.duration")).isNull();
   }
 
@@ -73,6 +80,7 @@ class ConfigPropertiesTest {
     properties.put("test.double", "");
     properties.put("test.list", "");
     properties.put("test.map", "");
+    properties.put("test.map.commas", "");
     properties.put("test.duration", "");
 
     ConfigProperties config = DefaultConfigProperties.createFromMap(properties);
@@ -82,6 +90,7 @@ class ConfigPropertiesTest {
     assertThat(config.getDouble("test.double")).isNull();
     assertThat(config.getList("test.list")).isEmpty();
     assertThat(config.getMap("test.map")).isEmpty();
+    assertThat(config.getMap("test.map.commas")).isEmpty();
     assertThat(config.getDuration("test.duration")).isNull();
   }
 
@@ -167,6 +176,17 @@ class ConfigPropertiesTest {
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
         .hasMessage("Invalid map property: map=a=1,=b");
+  }
+
+  @Test
+  void invalidList() {
+    DefaultConfigProperties config =
+        DefaultConfigProperties.createFromMap(
+            Collections.singletonMap(
+                "invalid", "\"cat=meow,hiss\",\"dog=bark,growl\", bear=growl"));
+    assertThatThrownBy(() -> config.getList("invalid"))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("Invalid list property");
   }
 
   @Test
@@ -277,6 +297,7 @@ class ConfigPropertiesTest {
     properties.put("test.list", "cat,dog,bear");
     properties.put("test.map", "cat=meow,dog=bark,bear=growl,bird=");
     properties.put("test.duration", "1s");
+    properties.put("test.map.commas", "\"cat=meow,hiss\",\"dog=bark,growl\", \"bear=growl,roar\"");
     return properties;
   }
 }


### PR DESCRIPTION
My use for the OpenTelemetry Java Agent requires that I pass headers with values containing commas to my otel collector. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) section 5.5 has some verbiage on how to support this.

headerOneKey=headerOneValueA,HeaderOneValueB
headerTwoKey=headerTwoValue

could now be passed as

```
-Dotel.exporter.otlp.headers="\"headerOneKey=headerOneValueA,HeaderOneValueB\", \"headerTwoKey=headerTwoValue\""
```