### PR TITLE
Add option to export unsampled spans from span processors

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,25 +1,2 @@
 Comparing source compatibility of  against 
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setConnectTimeout(java.time.Duration)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setConnectTimeout(java.time.Duration)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setConnectTimeout(java.time.Duration)
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
-***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,25 @@
 Comparing source compatibility of  against 
-No changes.
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setConnectTimeout(java.time.Duration)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setConnectTimeout(java.time.Duration)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setConnectTimeout(long, java.util.concurrent.TimeUnit)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setConnectTimeout(java.time.Duration)
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)
+***! MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED METHOD: PUBLIC(-) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setHeaders(java.util.function.Supplier<java.util.Map<java.lang.String,java.lang.String>>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,7 +1,7 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setExportPredicate(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setExportFilter(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder builder(io.opentelemetry.sdk.trace.export.SpanExporter)
@@ -9,4 +9,4 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessor build()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder setExportPredicate(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder setExportFilter(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,12 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder exportUnsampledSpans(boolean)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder builder(io.opentelemetry.sdk.trace.export.SpanExporter)
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessor build()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder exportUnsampledSpans(boolean)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,7 +1,7 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setExportFilter(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setExportUnsampledSpans(boolean)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder builder(io.opentelemetry.sdk.trace.export.SpanExporter)
@@ -9,4 +9,4 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessor build()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder setExportFilter(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder setExportUnsampledSpans(boolean)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,7 +1,7 @@
 Comparing source compatibility of  against 
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder exportUnsampledSpans(boolean)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder setExportPredicate(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder builder(io.opentelemetry.sdk.trace.export.SpanExporter)
@@ -9,4 +9,4 @@ Comparing source compatibility of  against
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessor build()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder exportUnsampledSpans(boolean)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SimpleSpanProcessorBuilder setExportPredicate(java.util.function.Predicate<io.opentelemetry.sdk.trace.ReadableSpan>)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -415,7 +415,7 @@ class OpenTelemetrySdkTest {
                 + "resource=Resource{schemaUrl=null, attributes={service.name=\"otel-test\"}}, "
                 + "spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, "
                 + "sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, "
-                + "spanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}}"
+                + "spanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}, exportUnsampledSpans=false}"
                 + "}, "
                 + "meterProvider=SdkMeterProvider{"
                 + "clock=SystemClock{}, "

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -53,6 +53,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       AttributeKey.booleanKey("dropped");
   private static final String SPAN_PROCESSOR_TYPE_VALUE = BatchSpanProcessor.class.getSimpleName();
 
+  private final boolean exportUnsampledSpans;
   private final Worker worker;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -69,11 +70,13 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   BatchSpanProcessor(
       SpanExporter spanExporter,
+      boolean exportUnsampledSpans,
       MeterProvider meterProvider,
       long scheduleDelayNanos,
       int maxQueueSize,
       int maxExportBatchSize,
       long exporterTimeoutNanos) {
+    this.exportUnsampledSpans = exportUnsampledSpans;
     this.worker =
         new Worker(
             spanExporter,
@@ -96,10 +99,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (span == null || !span.getSpanContext().isSampled()) {
-      return;
+    if (span != null && (exportUnsampledSpans || span.getSpanContext().isSampled())) {
+      worker.addSpan(span);
     }
-    worker.addSpan(span);
   }
 
   @Override

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,7 +53,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       AttributeKey.booleanKey("dropped");
   private static final String SPAN_PROCESSOR_TYPE_VALUE = BatchSpanProcessor.class.getSimpleName();
 
-  private final Predicate<ReadableSpan> exportPredicate;
+  private final boolean exportUnsampledSpans;
   private final Worker worker;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -71,13 +70,13 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   BatchSpanProcessor(
       SpanExporter spanExporter,
-      Predicate<ReadableSpan> exportPredicate,
+      boolean exportUnsampledSpans,
       MeterProvider meterProvider,
       long scheduleDelayNanos,
       int maxQueueSize,
       int maxExportBatchSize,
       long exporterTimeoutNanos) {
-    this.exportPredicate = exportPredicate;
+    this.exportUnsampledSpans = exportUnsampledSpans;
     this.worker =
         new Worker(
             spanExporter,
@@ -100,7 +99,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (span != null && exportPredicate.test(span)) {
+    if (span != null && (exportUnsampledSpans || span.getSpanContext().isSampled())) {
       worker.addSpan(span);
     }
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -54,7 +54,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
       AttributeKey.booleanKey("dropped");
   private static final String SPAN_PROCESSOR_TYPE_VALUE = BatchSpanProcessor.class.getSimpleName();
 
-  private final Predicate<ReadableSpan> exporterPredicate;
+  private final Predicate<ReadableSpan> exportPredicate;
   private final Worker worker;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -71,13 +71,13 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   BatchSpanProcessor(
       SpanExporter spanExporter,
-      Predicate<ReadableSpan> exporterPredicate,
+      Predicate<ReadableSpan> exportPredicate,
       MeterProvider meterProvider,
       long scheduleDelayNanos,
       int maxQueueSize,
       int maxExportBatchSize,
       long exporterTimeoutNanos) {
-    this.exporterPredicate = exporterPredicate;
+    this.exportPredicate = exportPredicate;
     this.worker =
         new Worker(
             spanExporter,
@@ -100,7 +100,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (span != null && exporterPredicate.test(span)) {
+    if (span != null && exportPredicate.test(span)) {
       worker.addSpan(span);
     }
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -137,6 +137,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
     return "BatchSpanProcessor{"
         + "spanExporter="
         + worker.spanExporter
+        + ", exportUnsampledSpans="
+        + exportUnsampledSpans
         + ", scheduleDelayNanos="
         + worker.scheduleDelayNanos
         + ", maxExportBatchSize="

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -9,10 +9,8 @@ import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.sdk.trace.ReadableSpan;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 /** Builder class for {@link BatchSpanProcessor}. */
 public final class BatchSpanProcessorBuilder {
@@ -27,7 +25,7 @@ public final class BatchSpanProcessorBuilder {
   static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
 
   private final SpanExporter spanExporter;
-  private Predicate<ReadableSpan> exportPredicate = span -> span.getSpanContext().isSampled();
+  private boolean exportUnsampledSpans;
   private long scheduleDelayNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_SCHEDULE_DELAY_MILLIS);
   private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
   private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
@@ -39,11 +37,11 @@ public final class BatchSpanProcessorBuilder {
   }
 
   /**
-   * Sets a {@link Predicate Predicate&lt;ReadableSpan&gt;} that filters the {@link ReadableSpan}s
-   * that are to be exported. If unset, defaults to exporting sampled spans.
+   * Sets whether unsampled spans should be exported. If unset, defaults to exporting only sampled
+   * spans.
    */
-  public BatchSpanProcessorBuilder setExportFilter(Predicate<ReadableSpan> exportPredicate) {
-    this.exportPredicate = requireNonNull(exportPredicate, "exportPredicate");
+  public BatchSpanProcessorBuilder setExportUnsampledSpans(boolean exportUnsampledSpans) {
+    this.exportUnsampledSpans = exportUnsampledSpans;
     return this;
   }
 
@@ -158,7 +156,7 @@ public final class BatchSpanProcessorBuilder {
   public BatchSpanProcessor build() {
     return new BatchSpanProcessor(
         spanExporter,
-        exportPredicate,
+        exportUnsampledSpans,
         meterProvider,
         scheduleDelayNanos,
         maxQueueSize,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -42,7 +42,7 @@ public final class BatchSpanProcessorBuilder {
    * Sets a {@link Predicate Predicate&lt;ReadableSpan&gt;} that filters the {@link ReadableSpan}s
    * that are to be exported. If unset, defaults to exporting sampled spans.
    */
-  public BatchSpanProcessorBuilder setExportPredicate(Predicate<ReadableSpan> exportPredicate) {
+  public BatchSpanProcessorBuilder setExportFilter(Predicate<ReadableSpan> exportPredicate) {
     this.exportPredicate = requireNonNull(exportPredicate, "exportPredicate");
     return this;
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -25,6 +25,7 @@ public final class BatchSpanProcessorBuilder {
   static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
 
   private final SpanExporter spanExporter;
+  private boolean exportUnsampledSpans = false;
   private long scheduleDelayNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_SCHEDULE_DELAY_MILLIS);
   private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
   private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
@@ -33,6 +34,15 @@ public final class BatchSpanProcessorBuilder {
 
   BatchSpanProcessorBuilder(SpanExporter spanExporter) {
     this.spanExporter = requireNonNull(spanExporter, "spanExporter");
+  }
+
+  /**
+   * Sets whether unsampled spans should be exported. If unset, unsampled spans will not be
+   * exported.
+   */
+  public BatchSpanProcessorBuilder exportUnsampledSpans(boolean exportUnsampledSpans) {
+    this.exportUnsampledSpans = exportUnsampledSpans;
+    return this;
   }
 
   /**
@@ -146,6 +156,7 @@ public final class BatchSpanProcessorBuilder {
   public BatchSpanProcessor build() {
     return new BatchSpanProcessor(
         spanExporter,
+        exportUnsampledSpans,
         meterProvider,
         scheduleDelayNanos,
         maxQueueSize,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -132,6 +132,11 @@ public final class SimpleSpanProcessor implements SpanProcessor {
 
   @Override
   public String toString() {
-    return "SimpleSpanProcessor{" + "spanExporter=" + spanExporter + '}';
+    return "SimpleSpanProcessor{"
+        + "spanExporter="
+        + spanExporter
+        + ", exportUnsampledSpans="
+        + exportUnsampledSpans
+        + '}';
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,7 +37,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
   private static final Logger logger = Logger.getLogger(SimpleSpanProcessor.class.getName());
 
   private final SpanExporter spanExporter;
-  private final boolean exportUnsampledSpans;
+  private final Predicate<ReadableSpan> exportPredicate;
   private final Set<CompletableResultCode> pendingExports =
       Collections.newSetFromMap(new ConcurrentHashMap<>());
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
@@ -53,7 +54,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
    */
   public static SpanProcessor create(SpanExporter exporter) {
     requireNonNull(exporter, "exporter");
-    return new SimpleSpanProcessor(exporter, /* exportUnsampledSpans= */ false);
+    return builder(exporter).build();
   }
 
   public static SimpleSpanProcessorBuilder builder(SpanExporter exporter) {
@@ -61,9 +62,9 @@ public final class SimpleSpanProcessor implements SpanProcessor {
     return new SimpleSpanProcessorBuilder(exporter);
   }
 
-  SimpleSpanProcessor(SpanExporter spanExporter, boolean exportUnsampledSpans) {
+  SimpleSpanProcessor(SpanExporter spanExporter, Predicate<ReadableSpan> exportPredicate) {
     this.spanExporter = requireNonNull(spanExporter, "spanExporter");
-    this.exportUnsampledSpans = exportUnsampledSpans;
+    this.exportPredicate = exportPredicate;
   }
 
   @Override
@@ -78,7 +79,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (span != null && (exportUnsampledSpans || span.getSpanContext().isSampled())) {
+    if (span != null && exportPredicate.test(span)) {
       try {
         List<SpanData> spans = Collections.singletonList(span.toSpanData());
         CompletableResultCode result = spanExporter.export(spans);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -36,7 +36,7 @@ public final class SimpleSpanProcessor implements SpanProcessor {
   private static final Logger logger = Logger.getLogger(SimpleSpanProcessor.class.getName());
 
   private final SpanExporter spanExporter;
-  private final boolean sampled;
+  private final boolean exportUnsampledSpans;
   private final Set<CompletableResultCode> pendingExports =
       Collections.newSetFromMap(new ConcurrentHashMap<>());
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
@@ -53,12 +53,17 @@ public final class SimpleSpanProcessor implements SpanProcessor {
    */
   public static SpanProcessor create(SpanExporter exporter) {
     requireNonNull(exporter, "exporter");
-    return new SimpleSpanProcessor(exporter, /* sampled= */ true);
+    return new SimpleSpanProcessor(exporter, /* exportUnsampledSpans= */ false);
   }
 
-  SimpleSpanProcessor(SpanExporter spanExporter, boolean sampled) {
+  public static SimpleSpanProcessorBuilder builder(SpanExporter exporter) {
+    requireNonNull(exporter, "exporter");
+    return new SimpleSpanProcessorBuilder(exporter);
+  }
+
+  SimpleSpanProcessor(SpanExporter spanExporter, boolean exportUnsampledSpans) {
     this.spanExporter = requireNonNull(spanExporter, "spanExporter");
-    this.sampled = sampled;
+    this.exportUnsampledSpans = exportUnsampledSpans;
   }
 
   @Override
@@ -73,22 +78,21 @@ public final class SimpleSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (sampled && !span.getSpanContext().isSampled()) {
-      return;
-    }
-    try {
-      List<SpanData> spans = Collections.singletonList(span.toSpanData());
-      CompletableResultCode result = spanExporter.export(spans);
-      pendingExports.add(result);
-      result.whenComplete(
-          () -> {
-            pendingExports.remove(result);
-            if (!result.isSuccess()) {
-              logger.log(Level.FINE, "Exporter failed");
-            }
-          });
-    } catch (RuntimeException e) {
-      logger.log(Level.WARNING, "Exporter threw an Exception", e);
+    if (span != null && (exportUnsampledSpans || span.getSpanContext().isSampled())) {
+      try {
+        List<SpanData> spans = Collections.singletonList(span.toSpanData());
+        CompletableResultCode result = spanExporter.export(spans);
+        pendingExports.add(result);
+        result.whenComplete(
+            () -> {
+              pendingExports.remove(result);
+              if (!result.isSuccess()) {
+                logger.log(Level.FINE, "Exporter failed");
+              }
+            });
+      } catch (RuntimeException e) {
+        logger.log(Level.WARNING, "Exporter threw an Exception", e);
+      }
     }
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
@@ -23,7 +23,7 @@ public final class SimpleSpanProcessorBuilder {
    * Sets a {@link Predicate Predicate&lt;ReadableSpan&gt;} that filters the {@link ReadableSpan}s
    * that are to be exported. If unset, defaults to exporting sampled spans.
    */
-  public SimpleSpanProcessorBuilder setExportPredicate(Predicate<ReadableSpan> exportPredicate) {
+  public SimpleSpanProcessorBuilder setExportFilter(Predicate<ReadableSpan> exportPredicate) {
     this.exportPredicate = requireNonNull(exportPredicate, "exportPredicate");
     return this;
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import static java.util.Objects.requireNonNull;
+
+/** Builder class for {@link SimpleSpanProcessor}. */
+public final class SimpleSpanProcessorBuilder {
+  private final SpanExporter spanExporter;
+  private boolean exportUnsampledSpans = false;
+
+  SimpleSpanProcessorBuilder(SpanExporter spanExporter) {
+    this.spanExporter = requireNonNull(spanExporter, "spanExporter");
+  }
+
+  /**
+   * Sets whether unsampled spans should be exported. If unset, unsampled spans will not be
+   * exported.
+   */
+  public SimpleSpanProcessorBuilder exportUnsampledSpans(boolean exportUnsampledSpans) {
+    this.exportUnsampledSpans = exportUnsampledSpans;
+    return this;
+  }
+
+  /**
+   * Returns a new {@link SimpleSpanProcessor} that converts spans to proto and forwards them to the
+   * given {@code spanExporter}.
+   *
+   * @return a new {@link SimpleSpanProcessor}.
+   */
+  public SimpleSpanProcessor build() {
+    return new SimpleSpanProcessor(spanExporter, exportUnsampledSpans);
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
@@ -29,8 +29,7 @@ public final class SimpleSpanProcessorBuilder {
   }
 
   /**
-   * Returns a new {@link SimpleSpanProcessor} that converts spans to proto and forwards them to the
-   * given {@code spanExporter}.
+   * Returns a new {@link SimpleSpanProcessor} with the configuration of this builder.
    *
    * @return a new {@link SimpleSpanProcessor}.
    */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
@@ -7,24 +7,21 @@ package io.opentelemetry.sdk.trace.export;
 
 import static java.util.Objects.requireNonNull;
 
-import io.opentelemetry.sdk.trace.ReadableSpan;
-import java.util.function.Predicate;
-
 /** Builder class for {@link SimpleSpanProcessor}. */
 public final class SimpleSpanProcessorBuilder {
   private final SpanExporter spanExporter;
-  private Predicate<ReadableSpan> exportPredicate = span -> span.getSpanContext().isSampled();
+  private boolean exportUnsampledSpans;
 
   SimpleSpanProcessorBuilder(SpanExporter spanExporter) {
     this.spanExporter = requireNonNull(spanExporter, "spanExporter");
   }
 
   /**
-   * Sets a {@link Predicate Predicate&lt;ReadableSpan&gt;} that filters the {@link ReadableSpan}s
-   * that are to be exported. If unset, defaults to exporting sampled spans.
+   * Sets whether unsampled spans should be exported. If unset, defaults to exporting only sampled
+   * spans.
    */
-  public SimpleSpanProcessorBuilder setExportFilter(Predicate<ReadableSpan> exportPredicate) {
-    this.exportPredicate = requireNonNull(exportPredicate, "exportPredicate");
+  public SimpleSpanProcessorBuilder setExportUnsampledSpans(boolean exportUnsampledSpans) {
+    this.exportUnsampledSpans = exportUnsampledSpans;
     return this;
   }
 
@@ -34,6 +31,6 @@ public final class SimpleSpanProcessorBuilder {
    * @return a new {@link SimpleSpanProcessor}.
    */
   public SimpleSpanProcessor build() {
-    return new SimpleSpanProcessor(spanExporter, exportPredicate);
+    return new SimpleSpanProcessor(spanExporter, exportUnsampledSpans);
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorBuilder.java
@@ -7,21 +7,24 @@ package io.opentelemetry.sdk.trace.export;
 
 import static java.util.Objects.requireNonNull;
 
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import java.util.function.Predicate;
+
 /** Builder class for {@link SimpleSpanProcessor}. */
 public final class SimpleSpanProcessorBuilder {
   private final SpanExporter spanExporter;
-  private boolean exportUnsampledSpans = false;
+  private Predicate<ReadableSpan> exportPredicate = span -> span.getSpanContext().isSampled();
 
   SimpleSpanProcessorBuilder(SpanExporter spanExporter) {
     this.spanExporter = requireNonNull(spanExporter, "spanExporter");
   }
 
   /**
-   * Sets whether unsampled spans should be exported. If unset, unsampled spans will not be
-   * exported.
+   * Sets a {@link Predicate Predicate&lt;ReadableSpan&gt;} that filters the {@link ReadableSpan}s
+   * that are to be exported. If unset, defaults to exporting sampled spans.
    */
-  public SimpleSpanProcessorBuilder exportUnsampledSpans(boolean exportUnsampledSpans) {
-    this.exportUnsampledSpans = exportUnsampledSpans;
+  public SimpleSpanProcessorBuilder setExportPredicate(Predicate<ReadableSpan> exportPredicate) {
+    this.exportPredicate = requireNonNull(exportPredicate, "exportPredicate");
     return this;
   }
 
@@ -32,6 +35,6 @@ public final class SimpleSpanProcessorBuilder {
    * @return a new {@link SimpleSpanProcessor}.
    */
   public SimpleSpanProcessor build() {
-    return new SimpleSpanProcessor(spanExporter, exportUnsampledSpans);
+    return new SimpleSpanProcessor(spanExporter, exportPredicate);
   }
 }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -518,6 +518,38 @@ class BatchSpanProcessorTest {
   }
 
   @Test
+  void exportUnsampledSpans_recordOnly() {
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
+
+    when(mockSampler.shouldSample(any(), any(), any(), any(), any(), anyList()))
+        .thenReturn(SamplingResult.recordOnly());
+    sdkTracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(
+                BatchSpanProcessor.builder(waitingSpanExporter)
+                    .exportUnsampledSpans(true)
+                    .setScheduleDelay(MAX_SCHEDULE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
+                    .build())
+            .setSampler(mockSampler)
+            .build();
+
+    ReadableSpan span1 = createEndedSpan(SPAN_NAME_1);
+    when(mockSampler.shouldSample(any(), any(), any(), any(), any(), anyList()))
+        .thenReturn(SamplingResult.recordAndSample());
+    ReadableSpan span2 = createEndedSpan(SPAN_NAME_2);
+
+    // Spans are recorded and exported in the same order as they are ended, we test that a non
+    // exported span is not exported by creating and ending a sampled span after a non sampled span
+    // and checking that the first exported span is the sampled span (the non sampled did not get
+    // exported).
+    List<SpanData> exported = waitingSpanExporter.waitForExport();
+    // Need to check this because otherwise the variable span1 is unused, other option is to not
+    // have a span1 variable.
+    assertThat(exported).containsExactly(span1.toSpanData(), span2.toSpanData());
+  }
+
+  @Test
   @Timeout(10)
   @SuppressLogger(SdkTracerProvider.class)
   void shutdownFlushes() {

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -528,7 +528,7 @@ class BatchSpanProcessorTest {
         SdkTracerProvider.builder()
             .addSpanProcessor(
                 BatchSpanProcessor.builder(waitingSpanExporter)
-                    .setExportPredicate(span -> true)
+                    .setExportFilter(span -> true)
                     .setScheduleDelay(MAX_SCHEDULE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
                     .build())
             .setSampler(mockSampler)

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -601,6 +601,7 @@ class BatchSpanProcessorTest {
         .hasToString(
             "BatchSpanProcessor{"
                 + "spanExporter=mockSpanExporter, "
+                + "exportUnsampledSpans=false, "
                 + "scheduleDelayNanos=5000000000, "
                 + "maxExportBatchSize=512, "
                 + "exporterTimeoutNanos=30000000000}");

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -528,7 +528,7 @@ class BatchSpanProcessorTest {
         SdkTracerProvider.builder()
             .addSpanProcessor(
                 BatchSpanProcessor.builder(waitingSpanExporter)
-                    .exportUnsampledSpans(true)
+                    .setExportPredicate(span -> true)
                     .setScheduleDelay(MAX_SCHEDULE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
                     .build())
             .setSampler(mockSampler)

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -528,7 +528,7 @@ class BatchSpanProcessorTest {
         SdkTracerProvider.builder()
             .addSpanProcessor(
                 BatchSpanProcessor.builder(waitingSpanExporter)
-                    .setExportFilter(span -> true)
+                    .setExportUnsampledSpans(true)
                     .setScheduleDelay(MAX_SCHEDULE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
                     .build())
             .setSampler(mockSampler)

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -104,9 +104,8 @@ class SimpleSpanProcessorTest {
     SpanData spanData = TestUtils.makeBasicSpan();
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
-    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter)
-            .exportUnsampledSpans(true)
-            .build();
+    SpanProcessor simpleSpanProcessor =
+        SimpleSpanProcessor.builder(spanExporter).exportUnsampledSpans(true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -116,9 +115,8 @@ class SimpleSpanProcessorTest {
     SpanData spanData = TestUtils.makeBasicSpan();
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
-    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter)
-        .exportUnsampledSpans(true)
-        .build();
+    SpanProcessor simpleSpanProcessor =
+        SimpleSpanProcessor.builder(spanExporter).exportUnsampledSpans(true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -100,25 +100,27 @@ class SimpleSpanProcessorTest {
   }
 
   @Test
-  void onEndSync_OnlySampled_NotSampledSpan() {
+  void onEndSync_ExportUnsampledSpans_NotSampledSpan() {
+    SpanData spanData = TestUtils.makeBasicSpan();
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
-    when(readableSpan.toSpanData())
-        .thenReturn(TestUtils.makeBasicSpan())
-        .thenThrow(new RuntimeException());
-    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.create(spanExporter);
+    when(readableSpan.toSpanData()).thenReturn(spanData);
+    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter)
+            .exportUnsampledSpans(true)
+            .build();
     simpleSpanProcessor.onEnd(readableSpan);
-    verifyNoInteractions(spanExporter);
+    verify(spanExporter).export(Collections.singletonList(spanData));
   }
 
   @Test
-  void onEndSync_OnlySampled_SampledSpan() {
+  void onEndSync_ExportUnsampledSpans_SampledSpan() {
+    SpanData spanData = TestUtils.makeBasicSpan();
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
-    when(readableSpan.toSpanData())
-        .thenReturn(TestUtils.makeBasicSpan())
-        .thenThrow(new RuntimeException());
-    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.create(spanExporter);
+    when(readableSpan.toSpanData()).thenReturn(spanData);
+    SpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter)
+        .exportUnsampledSpans(true)
+        .build();
     simpleSpanProcessor.onEnd(readableSpan);
-    verify(spanExporter).export(Collections.singletonList(TestUtils.makeBasicSpan()));
+    verify(spanExporter).export(Collections.singletonList(spanData));
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -110,7 +110,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).setExportFilter(span -> true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportUnsampledSpans(true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -121,7 +121,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).setExportFilter(span -> true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportUnsampledSpans(true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -172,7 +172,7 @@ class SimpleSpanProcessorTest {
         SdkTracerProvider.builder()
             .addSpanProcessor(
                 SimpleSpanProcessor.builder(waitingSpanExporter)
-                    .setExportFilter(span -> true)
+                    .setExportUnsampledSpans(true)
                     .build())
             .setSampler(mockSampler)
             .build();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -110,7 +110,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).setExportPredicate(span -> true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportFilter(span -> true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -121,7 +121,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).setExportPredicate(span -> true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportFilter(span -> true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -172,7 +172,7 @@ class SimpleSpanProcessorTest {
         SdkTracerProvider.builder()
             .addSpanProcessor(
                 SimpleSpanProcessor.builder(waitingSpanExporter)
-                    .setExportPredicate(span -> true)
+                    .setExportFilter(span -> true)
                     .build())
             .setSampler(mockSampler)
             .build();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -122,7 +122,7 @@ class SimpleSpanProcessorTest {
   }
 
   @Test
-  void tracerSdk_NotSampled_Span() {
+  void tracerSdk_SampledSpan() {
     WaitingSpanExporter waitingSpanExporter =
         new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
 
@@ -159,25 +159,41 @@ class SimpleSpanProcessorTest {
   }
 
   @Test
-  void tracerSdk_NotSampled_RecordingEventsSpan() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
-    /*
-    tracer.addSpanProcessor(
-        BatchSpanProcessor.builder(waitingSpanExporter)
-            .setScheduleDelayMillis(MAX_SCHEDULE_DELAY_MILLIS)
-            .reportOnlySampled(false)
-            .build());
+  void tracerSdk_ExportUnsampledSpans_NotSampledSpan() {
+    WaitingSpanExporter waitingSpanExporter =
+        new WaitingSpanExporter(1, CompletableResultCode.ofSuccess());
 
-    io.opentelemetry.trace.Span span =
-        tracer
-            .spanBuilder("FOO")
-            .setSampler(Samplers.neverSample())
-            .startSpanWithSampler();
-    span.end();
+    SdkTracerProvider sdkTracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(
+                SimpleSpanProcessor.builder(waitingSpanExporter).exportUnsampledSpans(true).build())
+            .setSampler(mockSampler)
+            .build();
 
-    List<SpanData> exported = waitingSpanExporter.waitForExport(1);
-    assertThat(exported).containsExactly(((ReadableSpan) span).toSpanData());
-    */
+    when(mockSampler.shouldSample(any(), any(), any(), any(), any(), anyList()))
+        .thenReturn(SamplingResult.drop());
+
+    try {
+      Tracer tracer = sdkTracerProvider.get(getClass().getName());
+      tracer.spanBuilder(SPAN_NAME).startSpan();
+      tracer.spanBuilder(SPAN_NAME).startSpan();
+
+      when(mockSampler.shouldSample(any(), any(), any(), any(), any(), anyList()))
+          .thenReturn(SamplingResult.recordOnly());
+      Span span = tracer.spanBuilder(SPAN_NAME).startSpan();
+      span.end();
+
+      // Spans are recorded and exported in the same order as they are ended, we test that a non
+      // sampled span is not exported by creating and ending a sampled span after a non sampled span
+      // and checking that the first exported span is the sampled span (the non sampled did not get
+      // exported).
+      List<SpanData> exported = waitingSpanExporter.waitForExport();
+      // Need to check this because otherwise the variable span1 is unused, other option is to not
+      // have a span1 variable.
+      assertThat(exported).containsExactly(((ReadableSpan) span).toSpanData());
+    } finally {
+      sdkTracerProvider.shutdown();
+    }
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -59,7 +59,12 @@ class SimpleSpanProcessorTest {
           SpanId.getInvalid(),
           TraceFlags.getSampled(),
           TraceState.getDefault());
-  private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT = SpanContext.getInvalid();
+  private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT =
+      SpanContext.create(
+          TraceId.getInvalid(),
+          SpanId.getInvalid(),
+          TraceFlags.getDefault(),
+          TraceState.getDefault());
 
   private SpanProcessor simpleSampledSpansProcessor;
 
@@ -105,7 +110,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).exportUnsampledSpans(true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportPredicate(span -> true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -116,7 +121,7 @@ class SimpleSpanProcessorTest {
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     when(readableSpan.toSpanData()).thenReturn(spanData);
     SpanProcessor simpleSpanProcessor =
-        SimpleSpanProcessor.builder(spanExporter).exportUnsampledSpans(true).build();
+        SimpleSpanProcessor.builder(spanExporter).setExportPredicate(span -> true).build();
     simpleSpanProcessor.onEnd(readableSpan);
     verify(spanExporter).export(Collections.singletonList(spanData));
   }
@@ -166,7 +171,9 @@ class SimpleSpanProcessorTest {
     SdkTracerProvider sdkTracerProvider =
         SdkTracerProvider.builder()
             .addSpanProcessor(
-                SimpleSpanProcessor.builder(waitingSpanExporter).exportUnsampledSpans(true).build())
+                SimpleSpanProcessor.builder(waitingSpanExporter)
+                    .setExportPredicate(span -> true)
+                    .build())
             .setSampler(mockSampler)
             .build();
 


### PR DESCRIPTION
Adds an option to the `SimpleSpanProcessor` and `BatchSpanProcessor` which allows unsampled spans to be exported.

```cs
SpanExporter spanExporter = ...;

SimpleSpanProcessor simpleSpanProcessor = SimpleSpanProcessor.builder(spanExporter)
        .setExportUnsampledSpans(true)
        .build();

BatchSpanProcessor batchSpanProcessor = BatchSpanProcessor.builder(spanExporter)
        .setExportUnsampledSpans(true)
        .build();
```