### PR TITLE
Revert com.gradle.enterprise 3.16 upgrade

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
   plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.gradle.enterprise") version "3.16"
+    id("com.gradle.enterprise") version "3.15.1"
     id("de.undercouch.download") version "5.5.0"
     id("org.jsonschema2pojo") version "1.2.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"


### PR DESCRIPTION
I can't build locally after merging #6050. Reverting so we can get through the release and I have time to investigate.