### PR TITLE
Add get{Signal}Exporter methods to Simple{Signal}Processor, Batch{Signal}Processor

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.export.LogRecordExporter getLogRecordExporter()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.export.LogRecordExporter getLogRecordExporter()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SpanExporter getSpanExporter()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.SimpleSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.export.SpanExporter getSpanExporter()

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -105,6 +105,11 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     return worker.forceFlush();
   }
 
+  /** Return the processor's configured {@link LogRecordExporter}. */
+  public LogRecordExporter getLogRecordExporter() {
+    return worker.logRecordExporter;
+  }
+
   // Visible for testing
   List<LogRecordData> getBatch() {
     return worker.batch;

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
@@ -107,6 +107,11 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
     return CompletableResultCode.ofAll(pendingExports);
   }
 
+  /** Return the processor's configured {@link LogRecordExporter}. */
+  public LogRecordExporter getLogRecordExporter() {
+    return logRecordExporter;
+  }
+
   @Override
   public String toString() {
     return "SimpleLogRecordProcessor{" + "logRecordExporter=" + logRecordExporter + '}';

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.logs.export;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.awaitility.Awaitility.await;
@@ -415,6 +416,13 @@ class BatchLogRecordProcessorTest {
     CompletableResultCode result = processor.shutdown();
     result.join(1, TimeUnit.SECONDS);
     assertThat(result.isSuccess()).isFalse();
+  }
+
+  @Test
+  void getLogRecordExporter() {
+    assertThat(
+            BatchLogRecordProcessor.builder(mockLogRecordExporter).build().getLogRecordExporter())
+        .isSameAs(mockLogRecordExporter);
   }
 
   @Test

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessorTest.java
@@ -121,6 +121,14 @@ class SimpleLogRecordProcessorTest {
   }
 
   @Test
+  void getLogRecordExporter() {
+    assertThat(
+            ((SimpleLogRecordProcessor) SimpleLogRecordProcessor.create(logRecordExporter))
+                .getLogRecordExporter())
+        .isSameAs(logRecordExporter);
+  }
+
+  @Test
   void toString_Valid() {
     when(logRecordExporter.toString()).thenReturn("MockLogRecordExporter");
     assertThat(logRecordProcessor.toString())

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -120,6 +120,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
     return worker.forceFlush();
   }
 
+  /** Return the processor's configured {@link SpanExporter}. */
+  public SpanExporter getSpanExporter() {
+    return worker.spanExporter;
+  }
+
   // Visible for testing
   List<SpanData> getBatch() {
     return worker.batch;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessor.java
@@ -126,6 +126,11 @@ public final class SimpleSpanProcessor implements SpanProcessor {
     return CompletableResultCode.ofAll(pendingExports);
   }
 
+  /** Return the processor's configured {@link SpanExporter}. */
+  public SpanExporter getSpanExporter() {
+    return spanExporter;
+  }
+
   @Override
   public String toString() {
     return "SimpleSpanProcessor{" + "spanExporter=" + spanExporter + '}';

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -561,6 +561,12 @@ class BatchSpanProcessorTest {
   }
 
   @Test
+  void getSpanExporter() {
+    assertThat(BatchSpanProcessor.builder(mockSpanExporter).build().getSpanExporter())
+        .isSameAs(mockSpanExporter);
+  }
+
+  @Test
   void stringRepresentation() {
     BatchSpanProcessor processor = BatchSpanProcessor.builder(mockSpanExporter).build();
     String processorStr = processor.toString();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -252,4 +252,10 @@ class SimpleSpanProcessorTest {
     simpleSampledSpansProcessor.close();
     verify(spanExporter).shutdown();
   }
+
+  @Test
+  void getSpanExporter() {
+    assertThat(((SimpleSpanProcessor) SimpleSpanProcessor.create(spanExporter)).getSpanExporter())
+        .isSameAs(spanExporter);
+  }
 }


### PR DESCRIPTION
Originally discussed in this [comment](https://github.com/open-telemetry/opentelemetry-java/pull/5986#discussion_r1412295799), the idea is to make `AutoConfigurationCustomizer#addSpanProcessorCustomizer` more useful by allowing you to extract the configured SpanExporter/LogRecordExporter from the processor, and plug it into your own processor.
```
autoConfiguration.addSpanProcessorCustomizer(
        (spanProcessor, configProperties) -> {
          if (spanProcessor instanceof BatchSpanProcessor) {
            SpanExporter exporter = ((BatchSpanProcessor) spanProcessor).getExporter();
            return new MyCustomProcessor(exporter);
          }
          return spanProcessor;
        });
```