### PR TITLE
Fix owasp dependency check

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -23,6 +23,11 @@ tasks {
   }
 }
 
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}
+
 val testTasks = mutableListOf<Task>()
 
 dependencies {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -41,14 +41,19 @@ checkstyle {
 }
 
 dependencyCheck {
-  skipConfigurations = listOf(
+  skipConfigurations = mutableListOf(
     "errorprone",
     "checkstyle",
     "annotationProcessor",
+    "java9AnnotationProcessor",
+    "moduleAnnotationProcessor",
+    "testAnnotationProcessor",
+    "testJpmsAnnotationProcessor",
     "animalsniffer",
-    "spotless865457264", // spotless865457264 is a weird configuration that's only added in jaeger-proto, jaeger-remote-sampler
+    "spotless996155815", // spotless996155815 is a weird configuration that's only added in jaeger-proto, jaeger-remote-sampler
     "js2p",
     "jmhAnnotationProcessor",
+    "jmhBasedTestAnnotationProcessor",
     "jmhCompileClasspath",
     "jmhRuntimeClasspath",
     "jmhRuntimeOnly")

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -16,6 +16,16 @@ dependencies {
   testImplementation("com.google.guava:guava")
 }
 
+dependencyCheck {
+  skipConfigurations.add("braveInOtelTestAnnotationProcessor")
+  skipConfigurations.add("grpcInOtelTestAnnotationProcessor")
+  skipConfigurations.add("otelAsBraveTestAnnotationProcessor")
+  skipConfigurations.add("otelInBraveTestAnnotationProcessor")
+  skipConfigurations.add("otelInGrpcTestAnnotationProcessor")
+  skipConfigurations.add("storageWrappersTestAnnotationProcessor")
+  skipConfigurations.add("strictContextEnabledTestAnnotationProcessor")
+}
+
 testing {
   suites {
     register<JvmTestSuite>("grpcInOtelTest") {

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
   jmh(project(":sdk:testing"))
 }
 
+dependencyCheck {
+  skipConfigurations.add("debugEnabledTestAnnotationProcessor")
+}
+
 testing {
   suites {
     register<JvmTestSuite>("debugEnabledTest") {


### PR DESCRIPTION
Fix the [owasp dependency check task](https://github.com/open-telemetry/opentelemetry-java/actions/workflows/owasp-dependency-check-daily.yml), which has been failing due to changes from gradle upgrades and dependency upgrades shifting around gradle configurations we need to exclude.