### PR TITLE
Ability to access version.properties API file with GraalVM native

### DIFF
--- a/api/all/src/main/resources/META-INF/native-image/io.opentelemetry/opentelemetry-api/reflect-config.json
+++ b/api/all/src/main/resources/META-INF/native-image/io.opentelemetry/opentelemetry-api/reflect-config.json
@@ -1,0 +1,10 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern":"\\Qio/opentelemetry/api/version.properties\\E"
+      }
+    ]
+  },
+  "bundles": []
+}


### PR DESCRIPTION
The `opentelemetry-api` jar has a `version.properties` files. The PR allows access to this file with a GraalVM native execution.