### PR TITLE
Read normalized otel.config.file property

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -483,7 +483,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
     if (configurationFile == null || configurationFile.isEmpty()) {
       return null;
     }
-    logger.debug("Autoconfiguring from configuration file: " + configurationFile);
+    logger.fine("Autoconfiguring from configuration file: " + configurationFile);
     FileInputStream fis;
     try {
       fis = new FileInputStream(configurationFile);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -483,7 +483,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
     if (configurationFile == null || configurationFile.isEmpty()) {
       return null;
     }
-    logger.info("Autoconfiguring from configuration file: " + configurationFile);
+    logger.debug("Autoconfiguring from configuration file: " + configurationFile);
     FileInputStream fis;
     try {
       fis = new FileInputStream(configurationFile);

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -479,10 +479,11 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   @Nullable
   private static AutoConfiguredOpenTelemetrySdk maybeConfigureFromFile(ConfigProperties config) {
-    String configurationFile = config.getString("OTEL_CONFIG_FILE");
+    String configurationFile = config.getString("otel.config.file");
     if (configurationFile == null || configurationFile.isEmpty()) {
       return null;
     }
+    logger.info("Autoconfiguring from configuration file: " + configurationFile);
     FileInputStream fis;
     try {
       fis = new FileInputStream(configurationFile);

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -26,7 +26,7 @@ class FileConfigurationTest {
   @RegisterExtension
   static final LogCapturer logCapturer =
       LogCapturer.create()
-          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.INFO);
+          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.TRACE);
 
   @Test
   void configFile(@TempDir Path tempDir) throws IOException {

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
@@ -16,9 +17,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.event.Level;
 
 class FileConfigurationTest {
+
+  @RegisterExtension
+  static final LogCapturer logCapturer =
+      LogCapturer.create()
+          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.INFO);
 
   @Test
   void configFile(@TempDir Path tempDir) throws IOException {
@@ -36,11 +44,12 @@ class FileConfigurationTest {
     Files.write(path, yaml.getBytes(StandardCharsets.UTF_8));
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", path.toString()));
+            Collections.singletonMap("otel.config.file", path.toString()));
 
     assertThatThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build())
         .isInstanceOf(ConfigurationException.class)
         .hasMessage(
             "Error configuring from file. Is opentelemetry-sdk-extension-incubator on the classpath?");
+    logCapturer.assertContains("Autoconfiguring from configuration file: " + path);
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -41,10 +42,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.event.Level;
 
 class FileConfigurationTest {
 
   @RegisterExtension private static final CleanupExtension cleanup = new CleanupExtension();
+
+  @RegisterExtension
+  static final LogCapturer logCapturer =
+      LogCapturer.create()
+          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.INFO);
 
   @TempDir private Path tempDir;
   private Path configFilePath;
@@ -71,7 +78,7 @@ class FileConfigurationTest {
   void configFile_Valid() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", configFilePath.toString()));
+            Collections.singletonMap("otel.config.file", configFilePath.toString()));
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdk.builder()
             .setTracerProvider(
@@ -102,13 +109,14 @@ class FileConfigurationTest {
     assertThat(autoConfiguredOpenTelemetrySdk.getResource()).isEqualTo(Resource.getDefault());
     verify(builder, times(1)).shutdownHook(autoConfiguredOpenTelemetrySdk.getOpenTelemetrySdk());
     assertThat(Runtime.getRuntime().removeShutdownHook(thread)).isTrue();
+    logCapturer.assertContains("Autoconfiguring from configuration file: " + configFilePath);
   }
 
   @Test
   void configFile_NoShutdownHook() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", configFilePath.toString()));
+            Collections.singletonMap("otel.config.file", configFilePath.toString()));
     AutoConfiguredOpenTelemetrySdkBuilder builder = spy(AutoConfiguredOpenTelemetrySdk.builder());
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
@@ -123,7 +131,7 @@ class FileConfigurationTest {
     GlobalOpenTelemetry.set(OpenTelemetry.noop());
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", configFilePath.toString()));
+            Collections.singletonMap("otel.config.file", configFilePath.toString()));
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
         AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build();
@@ -139,7 +147,7 @@ class FileConfigurationTest {
   void configFile_setResultAsGlobalTrue() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", configFilePath.toString()));
+            Collections.singletonMap("otel.config.file", configFilePath.toString()));
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
         AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).setResultAsGlobal().build();
@@ -169,7 +177,7 @@ class FileConfigurationTest {
     Files.write(path, yaml.getBytes(StandardCharsets.UTF_8));
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("OTEL_CONFIG_FILE", path.toString()));
+            Collections.singletonMap("otel.config.file", path.toString()));
 
     assertThatThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build())
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -51,7 +51,7 @@ class FileConfigurationTest {
   @RegisterExtension
   static final LogCapturer logCapturer =
       LogCapturer.create()
-          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.INFO);
+          .captureForLogger(AutoConfiguredOpenTelemetrySdkBuilder.class.getName(), Level.TRACE);
 
   @TempDir private Path tempDir;
   private Path configFilePath;


### PR DESCRIPTION
Right now its impossible to trigger file configuration in autoconfigure. 

Whether you set an environment variable `OTEL_CONFIG_FILE` or system property `otel.config.file`, we're reading the `OTEL_CONFIG_FILE`, which never matches the normalized environment variable or system property 🤦. This fixes the bug.