### PR TITLE
Update dependency io.zipkin.reporter2:zipkin-reporter-bom to 3.1.1

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -16,8 +16,8 @@ val DEPENDENCY_BOMS = listOf(
   "com.squareup.okio:okio-bom:3.7.0", // applies to transitive dependencies of okhttp
   "io.grpc:grpc-bom:1.60.1",
   "io.netty:netty-bom:4.1.104.Final",
+  "io.zipkin.reporter2:zipkin-reporter-bom:3.1.1",
   "io.zipkin.brave:brave-bom:5.17.0",
-  "io.zipkin.reporter2:zipkin-reporter-bom:2.17.1",
   "org.assertj:assertj-bom:3.25.1",
   "org.junit:junit-bom:5.10.1",
   "org.testcontainers:testcontainers-bom:1.19.3",

--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-zipkin.txt
@@ -1,2 +1,6 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED METHOD: PUBLIC io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setEncoder(zipkin2.codec.BytesEncoder<zipkin2.Span><zipkin2.Span>)
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder setEncoder(zipkin2.reporter.BytesEncoder<zipkin2.Span>)

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/BytesEncoderAdapter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/BytesEncoderAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import zipkin2.Span;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
+
+/**
+ * This supports the deprecated method {@link
+ * ZipkinSpanExporterBuilder#setEncoder(zipkin2.codec.BytesEncoder)}.
+ */
+final class BytesEncoderAdapter implements BytesEncoder<Span> {
+  private final zipkin2.codec.BytesEncoder<Span> delegate;
+  private final Encoding encoding;
+
+  @SuppressWarnings("deprecation") // we have to use the deprecated thrift encoding to return it
+  BytesEncoderAdapter(zipkin2.codec.BytesEncoder<Span> delegate) {
+    this.delegate = delegate;
+    switch (delegate.encoding()) {
+      case JSON:
+        this.encoding = Encoding.JSON;
+        break;
+      case PROTO3:
+        this.encoding = Encoding.PROTO3;
+        break;
+      case THRIFT:
+        this.encoding = Encoding.THRIFT;
+        break;
+      default:
+        // Only possible if zipkin2 adds an encoding besides above, which is very unlikely.
+        throw new UnsupportedOperationException("unsupported encoding " + delegate.encoding());
+    }
+  }
+
+  @Override
+  public Encoding encoding() {
+    return encoding;
+  }
+
+  @Override
+  public int sizeInBytes(Span span) {
+    return delegate.sizeInBytes(span);
+  }
+
+  @Override
+  public byte[] encode(Span span) {
+    return delegate.encode(span);
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+}

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java
@@ -19,10 +19,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import zipkin2.Callback;
 import zipkin2.Span;
-import zipkin2.codec.BytesEncoder;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
 
 /**

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -17,9 +17,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import zipkin2.Span;
-import zipkin2.codec.BytesEncoder;
-import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /** Builder class for {@link ZipkinSpanExporter}. */
@@ -47,6 +47,21 @@ public final class ZipkinSpanExporterBuilder {
     requireNonNull(sender, "sender");
     this.sender = sender;
     return this;
+  }
+
+  /**
+   * Sets the {@link zipkin2.codec.BytesEncoder}, which controls the format used by the {@link
+   * Sender}. Defaults to the {@link zipkin2.codec.SpanBytesEncoder#JSON_V2}.
+   *
+   * @param encoder the {@code BytesEncoder} to use.
+   * @return this.
+   * @see zipkin2.codec.SpanBytesEncoder
+   * @deprecated Use {@link #setEncoder(BytesEncoder)} instead.
+   */
+  @Deprecated
+  public ZipkinSpanExporterBuilder setEncoder(zipkin2.codec.BytesEncoder<Span> encoder) {
+    requireNonNull(encoder, "encoder");
+    return setEncoder(new BytesEncoderAdapter(encoder));
   }
 
   /**

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/BytesEncoderAdapterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/BytesEncoderAdapterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.zipkin;
+
+import static io.opentelemetry.exporter.zipkin.ZipkinTestUtil.PARENT_SPAN_ID;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestUtil.SPAN_ID;
+import static io.opentelemetry.exporter.zipkin.ZipkinTestUtil.TRACE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
+
+class BytesEncoderAdapterTest {
+
+  /** Contains {@link Span#localEndpoint()} to ensure would be encoded differently. */
+  private final Span testSpan =
+      Span.newBuilder()
+          .traceId(TRACE_ID)
+          .parentId(PARENT_SPAN_ID)
+          .id(SPAN_ID)
+          .localEndpoint(Endpoint.newBuilder().serviceName("test").build())
+          .build();
+
+  @Test
+  void testJsonV2() {
+    BytesEncoderAdapter adapter = new BytesEncoderAdapter(zipkin2.codec.SpanBytesEncoder.JSON_V2);
+    assertThat(adapter.encoding()).isEqualTo(Encoding.JSON);
+    assertThat(adapter.encode(testSpan)).isEqualTo(SpanBytesEncoder.JSON_V2.encode(testSpan));
+    assertThat(adapter.sizeInBytes(testSpan))
+        .isEqualTo(SpanBytesEncoder.JSON_V2.sizeInBytes(testSpan));
+    assertThat(adapter).hasToString(SpanBytesEncoder.JSON_V2.toString());
+  }
+
+  @Test
+  void testProtobuf() {
+    BytesEncoderAdapter adapter = new BytesEncoderAdapter(zipkin2.codec.SpanBytesEncoder.PROTO3);
+    assertThat(adapter.encoding()).isEqualTo(Encoding.PROTO3);
+    assertThat(adapter.encode(testSpan)).isEqualTo(SpanBytesEncoder.PROTO3.encode(testSpan));
+    assertThat(adapter.sizeInBytes(testSpan))
+        .isEqualTo(SpanBytesEncoder.PROTO3.sizeInBytes(testSpan));
+    assertThat(adapter).hasToString(SpanBytesEncoder.PROTO3.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // we have to use the deprecated thrift encoding to test it
+  void testThrift() {
+    BytesEncoderAdapter adapter = new BytesEncoderAdapter(zipkin2.codec.SpanBytesEncoder.THRIFT);
+    assertThat(adapter.encoding()).isEqualTo(Encoding.THRIFT);
+    assertThat(adapter.encode(testSpan)).isEqualTo(SpanBytesEncoder.THRIFT.encode(testSpan));
+    assertThat(adapter.sizeInBytes(testSpan))
+        .isEqualTo(SpanBytesEncoder.THRIFT.sizeInBytes(testSpan));
+    assertThat(adapter).hasToString(SpanBytesEncoder.THRIFT.toString());
+  }
+
+  @Test
+  void testJsonV1() {
+    BytesEncoderAdapter adapter = new BytesEncoderAdapter(zipkin2.codec.SpanBytesEncoder.JSON_V1);
+    assertThat(adapter.encoding()).isEqualTo(Encoding.JSON);
+    assertThat(adapter.encode(testSpan)).isEqualTo(SpanBytesEncoder.JSON_V1.encode(testSpan));
+    assertThat(adapter.sizeInBytes(testSpan))
+        .isEqualTo(SpanBytesEncoder.JSON_V1.sizeInBytes(testSpan));
+    assertThat(adapter).hasToString(SpanBytesEncoder.JSON_V1.toString());
+  }
+}

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterEndToEndHttpTest.java
@@ -44,9 +44,9 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import zipkin2.Endpoint;
 import zipkin2.Span;
-import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesDecoder;
-import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 @Testcontainers(disabledWithoutDocker = true)
@@ -82,7 +82,7 @@ class ZipkinSpanExporterEndToEndHttpTest {
 
   @Container
   public static final GenericContainer<?> zipkinContainer =
-      new GenericContainer<>("ghcr.io/openzipkin/zipkin:2.23")
+      new GenericContainer<>("ghcr.io/openzipkin/zipkin:2.27")
           .withExposedPorts(ZIPKIN_API_PORT)
           .waitingFor(Wait.forHttp("/health").forPort(ZIPKIN_API_PORT));
 


### PR DESCRIPTION
Once merged, this will unlock spring-boot and micrometer tracing from zipkin reporter 2