### PR TITLE
Ability to execute the API all tests with GraalVM native

### DIFF
--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -1,9 +1,12 @@
+import java.util.*
+
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
 
   id("otel.jmh-conventions")
   id("otel.animalsniffer-conventions")
+  id("org.graalvm.buildtools.native")
 }
 
 description = "OpenTelemetry API"
@@ -22,4 +25,24 @@ dependencies {
 tasks.test {
   // Configure environment variable for ConfigUtilTest
   environment("CONFIG_KEY", "environment")
+}
+
+graalvmNative {
+  binaries.all {
+    resources.autodetect()
+
+    // Required as of junit 5.10.0: https://junit.org/junit5/docs/5.10.0/release-notes/#deprecations-and-breaking-changes
+    buildArgs.add("--initialize-at-build-time=org.junit.platform.launcher.core.LauncherConfig")
+    buildArgs.add("--initialize-at-build-time=org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter")
+
+    // Required by JUnit 4
+    buildArgs.add("--initialize-at-build-time=org.junit.validator.PublicClassValidator")
+  }
+
+  // org.graalvm.buildtools.native pluging requires java 11+ as of version 0.9.26
+  tasks {
+    withType<JavaCompile>().configureEach {
+      options.release.set(11)
+    }
+  }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 class OpenTelemetryTest {
 
@@ -38,6 +39,7 @@ class OpenTelemetryTest {
   }
 
   @Test
+  @DisabledInNativeImage // Because of Mockito
   void propagating() {
     ContextPropagators contextPropagators = mock(ContextPropagators.class);
     OpenTelemetry openTelemetry = OpenTelemetry.propagating(contextPropagators);
@@ -57,6 +59,7 @@ class OpenTelemetryTest {
   }
 
   @Test
+  @DisabledInNativeImage // Because of Mockito
   void independentNonGlobalPropagators() {
     ContextPropagators propagators1 = mock(ContextPropagators.class);
     OpenTelemetry otel1 = OpenTelemetry.propagating(propagators1);

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/PercentEscaperFuzzTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/PercentEscaperFuzzTest.java
@@ -14,9 +14,11 @@ import edu.berkeley.cs.jqf.fuzz.random.NoGuidance;
 import io.opentelemetry.api.internal.PercentEscaper;
 import java.net.URLDecoder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 
+@DisabledInNativeImage // To investigate, may be related to JQF
 class PercentEscaperFuzzTest {
   @RunWith(JQF.class)
   public static class TestCases {

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
@@ -25,10 +25,12 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 
 @SuppressWarnings("SystemOut")
+@DisabledInNativeImage // To investigate, may be related to JQF
 class W3CBaggagePropagatorFuzzTest {
 
   @RunWith(JQF.class)

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -10,10 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 class AttributeKeyTest {
 
   @Test
+  @DisabledInNativeImage // To investigate, may be related to EqualsVerifier
   void equalsVerifier() {
     EqualsVerifier.forClass(InternalAttributeKeyImpl.class)
         .withIgnoredFields("keyUtf8")

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ConfigUtilTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ConfigUtilTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.api.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 /** Relies on environment configuration in {@code ./api/all/build.gradle.kts}. */
@@ -30,6 +31,7 @@ class ConfigUtilTest {
   }
 
   @Test
+  @DisabledInNativeImage // Set "CONFIG_KEY" environment variable to "environment"
   void getString_EnvironmentVariable() {
     assertThat(ConfigUtil.getString("config.key", "default")).isEqualTo("environment");
     assertThat(ConfigUtil.getString("other.config.key", "default")).isEqualTo("default");


### PR DESCRIPTION
This PR adds the ability to execute the [tests of API all](https://github.com/open-telemetry/opentelemetry-java/tree/main/api/all/src/test/java/io/opentelemetry/api) with GraalVM native