### PR TITLE
Memory Mode: Adding support for OTLP HTTP Exporter - First draft

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Java8Compatability.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Java8Compatability.java
@@ -1,0 +1,46 @@
+package io.opentelemetry.exporter.internal.marshal;
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import java.nio.Buffer;
+
+/**
+ * Wrappers around {@link Buffer} methods that are covariantly overridden in Java 9+. See
+ * https://github.com/protocolbuffers/protobuf/issues/11393
+ *
+ * <p>TODO remove when Java 8 support is no longer needed.
+ */
+// Copied from
+// https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Java8Compatability.java
+final class Java8Compatibility {
+  static void clear(Buffer b) {
+    b.clear();
+  }
+
+  static void flip(Buffer b) {
+    b.flip();
+  }
+
+  static void limit(Buffer b, int limit) {
+    b.limit(limit);
+  }
+
+  static void mark(Buffer b) {
+    b.mark();
+  }
+
+  static void position(Buffer b, int position) {
+    b.position(position);
+  }
+
+  static void reset(Buffer b) {
+    b.reset();
+  }
+
+  private Java8Compatibility() {}
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
@@ -96,6 +96,12 @@ final class JsonSerializer extends Serializer {
     generator.writeNumber(value);
   }
 
+  /** Writes a protobuf {@code string} field, even if it matches the default value. */
+  public void writeString(ProtoFieldInfo field, String string) throws IOException {
+    generator.writeFieldName(field.getJsonName());
+    generator.writeString(string);
+  }
+
   @Override
   public void writeString(ProtoFieldInfo field, byte[] utf8Bytes) throws IOException {
     generator.writeFieldName(field.getJsonName());

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -265,6 +265,14 @@ public final class MarshalerUtil {
     return field.getTagSize() + CodedOutputStream.computeFixed32SizeNoTag(message);
   }
 
+  /** Returns the size of a string field, encoded using UTF-8 encoding */
+  public static int sizeStringUtf8(ProtoFieldInfo field, String message) {
+    if (message == null || message.isEmpty()) {
+      return 0;
+    }
+    return field.getTagSize() + CodedOutputStream.computeStringSizeNoTag(message);
+  }
+
   /** Returns the size of a bytes field. */
   public static int sizeBytes(ProtoFieldInfo field, byte[] message) {
     if (message.length == 0) {

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
@@ -160,12 +160,26 @@ public abstract class Serializer implements AutoCloseable {
    * Serializes a protobuf {@code string} field. {@code utf8Bytes} is the UTF8 encoded bytes of the
    * string to serialize.
    */
+  public void serializeString(ProtoFieldInfo field, String string) throws IOException {
+    if (string.length() == 0) {
+      return;
+    }
+    writeString(field, string);
+  }
+
+  /**
+   * Serializes a protobuf {@code string} field. {@code utf8Bytes} is the UTF8 encoded bytes of the
+   * string to serialize.
+   */
   public void serializeString(ProtoFieldInfo field, byte[] utf8Bytes) throws IOException {
     if (utf8Bytes.length == 0) {
       return;
     }
     writeString(field, utf8Bytes);
   }
+
+  /** Writes a protobuf {@code string} field, even if it matches the default value. */
+  public abstract void writeString(ProtoFieldInfo field, String string) throws IOException;
 
   /** Writes a protobuf {@code string} field, even if it matches the default value. */
   public abstract void writeString(ProtoFieldInfo field, byte[] utf8Bytes) throws IOException;

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Utf8.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Utf8.java
@@ -1,0 +1,901 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.isSurrogatePair;
+import static java.lang.Character.toCodePoint;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A set of low-level, high-performance static utility methods related to the UTF-8 character
+ * encoding. This class has no dependencies outside of the core JDK libraries.
+ *
+ * <p>There are several variants of UTF-8. The one implemented by this class is the restricted
+ * definition of UTF-8 introduced in Unicode 3.1, which mandates the rejection of "overlong" byte
+ * sequences as well as rejection of 3-byte surrogate codepoint byte sequences. Note that the UTF-8
+ * decoder included in Oracle's JDK has been modified to also reject "overlong" byte sequences, but
+ * (as of 2011) still accepts 3-byte surrogate codepoint byte sequences.
+ *
+ * <p>The byte sequences considered valid by this class are exactly those that can be roundtrip
+ * converted to Strings and back to bytes using the UTF-8 charset, without loss:
+ *
+ * <pre>{@code
+ * Arrays.equals(bytes, new String(bytes, Internal.UTF_8).getBytes(Internal.UTF_8))
+ * }</pre>
+ *
+ * <p>See the Unicode Standard,</br> Table 3-6. <em>UTF-8 Bit Distribution</em>,</br> Table 3-7.
+ * <em>Well Formed UTF-8 Byte Sequences</em>.
+ *
+ * <p>This class supports decoding of partial byte sequences, so that the bytes in a complete UTF-8
+ * byte sequence can be stored in multiple segments. Methods typically return {@link #MALFORMED} if
+ * the partial byte sequence is definitely not well-formed; {@link #COMPLETE} if it is well-formed
+ * in the absence of additional input; or, if the byte sequence apparently terminated in the middle
+ * of a character, an opaque integer "state" value containing enough information to decode the
+ * character when passed to a subsequent invocation of a partial decoding method.
+ *
+ * @author martinrb@google.com (Martin Buchholz)
+ */
+// Copied in and trimmed from
+// https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Utf8.java
+//
+// Removed:
+//    * All decoding methods - we only need encoding, and it has brought other classes in.
+final class Utf8 {
+
+  private static final Processor processor = new SafeProcessor();
+
+  /**
+   * A mask used when performing unsafe reads to determine if a long value contains any non-ASCII
+   * characters (i.e. any byte >= 0x80).
+   */
+  private static final long ASCII_MASK_LONG = 0x8080808080808080L;
+
+  /**
+   * Maximum number of bytes per Java UTF-16 char in UTF-8.
+   *
+   * @see java.nio.charset.CharsetEncoder#maxBytesPerChar()
+   */
+  static final int MAX_BYTES_PER_CHAR = 3;
+
+  /**
+   * State value indicating that the byte sequence is well-formed and complete (no further bytes are
+   * needed to complete a character).
+   */
+  static final int COMPLETE = 0;
+
+  /** State value indicating that the byte sequence is definitely not well-formed. */
+  static final int MALFORMED = -1;
+
+  /**
+   * Used by {@code Unsafe} UTF-8 string validation logic to determine the minimum string length
+   * above which to employ an optimized algorithm for counting ASCII characters. The reason for this
+   * threshold is that for small strings, the optimization may not be beneficial or may even
+   * negatively impact performance since it requires additional logic to avoid unaligned reads (when
+   * calling {@code Unsafe.getLong}). This threshold guarantees that even if the initial offset is
+   * unaligned, we're guaranteed to make at least one call to {@code Unsafe.getLong()} which
+   * provides a performance improvement that entirely subsumes the cost of the additional logic.
+   */
+  private static final int UNSAFE_COUNT_ASCII_THRESHOLD = 16;
+
+  // Other state values include the partial bytes of the incomplete
+  // character to be decoded in the simplest way: we pack the bytes
+  // into the state int in little-endian order.  For example:
+  //
+  // int state = byte1 ^ (byte2 << 8) ^ (byte3 << 16);
+  //
+  // Such a state is unpacked thus (note the ~ operation for byte2 to
+  // undo byte1's sign-extension bits):
+  //
+  // int byte1 = (byte) state;
+  // int byte2 = (byte) ~(state >> 8);
+  // int byte3 = (byte) (state >> 16);
+  //
+  // We cannot store a zero byte in the state because it would be
+  // indistinguishable from the absence of a byte.  But we don't need
+  // to, because partial bytes must always be negative.  When building
+  // a state, we ensure that byte1 is negative and subsequent bytes
+  // are valid trailing bytes.
+
+  /**
+   * Returns {@code true} if the given byte array is a well-formed UTF-8 byte sequence.
+   *
+   * <p>This is a convenience method, equivalent to a call to {@code isValidUtf8(bytes, 0,
+   * bytes.length)}.
+   */
+  static boolean isValidUtf8(byte[] bytes) {
+    return processor.isValidUtf8(bytes, 0, bytes.length);
+  }
+
+  /**
+   * Returns {@code true} if the given byte array slice is a well-formed UTF-8 byte sequence. The
+   * range of bytes to be checked extends from index {@code index}, inclusive, to {@code limit},
+   * exclusive.
+   *
+   * <p>This is a convenience method, equivalent to {@code partialIsValidUtf8(bytes, index, limit)
+   * == Utf8.COMPLETE}.
+   */
+  static boolean isValidUtf8(byte[] bytes, int index, int limit) {
+    return processor.isValidUtf8(bytes, index, limit);
+  }
+
+  /**
+   * Tells whether the given byte array slice is a well-formed, malformed, or incomplete UTF-8 byte
+   * sequence. The range of bytes to be checked extends from index {@code index}, inclusive, to
+   * {@code limit}, exclusive.
+   *
+   * @param state either {@link Utf8#COMPLETE} (if this is the initial decoding operation) or the
+   *     value returned from a call to a partial decoding method for the previous bytes
+   * @return {@link #MALFORMED} if the partial byte sequence is definitely not well-formed, {@link
+   *     #COMPLETE} if it is well-formed (no additional input needed), or if the byte sequence is
+   *     "incomplete", i.e. apparently terminated in the middle of a character, an opaque integer
+   *     "state" value containing enough information to decode the character when passed to a
+   *     subsequent invocation of a partial decoding method.
+   */
+  static int partialIsValidUtf8(int state, byte[] bytes, int index, int limit) {
+    return processor.partialIsValidUtf8(state, bytes, index, limit);
+  }
+
+  private static int incompleteStateFor(int byte1) {
+    return (byte1 > (byte) 0xF4) ? MALFORMED : byte1;
+  }
+
+  private static int incompleteStateFor(int byte1, int byte2) {
+    return (byte1 > (byte) 0xF4 || byte2 > (byte) 0xBF) ? MALFORMED : byte1 ^ (byte2 << 8);
+  }
+
+  private static int incompleteStateFor(int byte1, int byte2, int byte3) {
+    return (byte1 > (byte) 0xF4 || byte2 > (byte) 0xBF || byte3 > (byte) 0xBF)
+        ? MALFORMED
+        : byte1 ^ (byte2 << 8) ^ (byte3 << 16);
+  }
+
+  private static int incompleteStateFor(byte[] bytes, int index, int limit) {
+    int byte1 = bytes[index - 1];
+    switch (limit - index) {
+      case 0:
+        return incompleteStateFor(byte1);
+      case 1:
+        return incompleteStateFor(byte1, bytes[index]);
+      case 2:
+        return incompleteStateFor(byte1, bytes[index], bytes[index + 1]);
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  private static int incompleteStateFor(
+      final ByteBuffer buffer, final int byte1, final int index, final int remaining) {
+    switch (remaining) {
+      case 0:
+        return incompleteStateFor(byte1);
+      case 1:
+        return incompleteStateFor(byte1, buffer.get(index));
+      case 2:
+        return incompleteStateFor(byte1, buffer.get(index), buffer.get(index + 1));
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  // These UTF-8 handling methods are copied from Guava's Utf8 class with a modification to throw
+  // a protocol buffer local exception. This exception is then caught in CodedOutputStream so it can
+  // fallback to more lenient behavior.
+
+  static class UnpairedSurrogateException extends IllegalArgumentException {
+    UnpairedSurrogateException(int index, int length) {
+      super("Unpaired surrogate at index " + index + " of " + length);
+    }
+  }
+
+  /**
+   * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
+   * method is equivalent to {@code string.getBytes(UTF_8).length}, but is more efficient in both
+   * time and space.
+   *
+   * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
+   *     surrogates)
+   */
+  static int encodedLength(String string) {
+    // Warning to maintainers: this implementation is highly optimized.
+    int utf16Length = string.length();
+    int utf8Length = utf16Length;
+    int i = 0;
+
+    // This loop optimizes for pure ASCII.
+    while (i < utf16Length && string.charAt(i) < 0x80) {
+      i++;
+    }
+
+    // This loop optimizes for chars less than 0x800.
+    for (; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += ((0x7f - c) >>> 31); // branch free!
+      } else {
+        utf8Length += encodedLengthGeneral(string, i);
+        break;
+      }
+    }
+
+    if (utf8Length < utf16Length) {
+      // Necessary and sufficient condition for overflow because of maximum 3x expansion
+      throw new IllegalArgumentException(
+          "UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+    }
+    return utf8Length;
+  }
+
+  private static int encodedLengthGeneral(String string, int start) {
+    int utf16Length = string.length();
+    int utf8Length = 0;
+    for (int i = start; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += (0x7f - c) >>> 31; // branch free!
+      } else {
+        utf8Length += 2;
+        // jdk7+: if (Character.isSurrogate(c)) {
+        if (Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE) {
+          // Check that we have a well-formed surrogate pair.
+          int cp = Character.codePointAt(string, i);
+          if (cp < MIN_SUPPLEMENTARY_CODE_POINT) {
+            throw new UnpairedSurrogateException(i, utf16Length);
+          }
+          i++;
+        }
+      }
+    }
+    return utf8Length;
+  }
+
+  static int encode(String in, byte[] out, int offset, int length) {
+    return processor.encodeUtf8(in, out, offset, length);
+  }
+  // End Guava UTF-8 methods.
+
+  /**
+   * Encodes the given characters to the target {@link ByteBuffer} using UTF-8 encoding.
+   *
+   * <p>Selects an optimal algorithm based on the type of {@link ByteBuffer} (i.e. heap or direct)
+   * and the capabilities of the platform.
+   *
+   * @param in the source string to be encoded
+   * @param out the target buffer to receive the encoded string.
+   * @see Utf8#encode(String, byte[], int, int)
+   */
+  static void encodeUtf8(String in, ByteBuffer out) {
+    processor.encodeUtf8(in, out);
+  }
+
+  /**
+   * Counts (approximately) the number of consecutive ASCII characters in the given buffer. The byte
+   * order of the {@link ByteBuffer} does not matter, so performance can be improved if native byte
+   * order is used (i.e. no byte-swapping in {@link ByteBuffer#getLong(int)}).
+   *
+   * @param buffer the buffer to be scanned for ASCII chars
+   * @param index the starting index of the scan
+   * @param limit the limit within buffer for the scan
+   * @return the number of ASCII characters found. The stopping position will be at or before the
+   *     first non-ASCII byte.
+   */
+  private static int estimateConsecutiveAscii(ByteBuffer buffer, int index, int limit) {
+    int i = index;
+    final int lim = limit - 7;
+    // This simple loop stops when we encounter a byte >= 0x80 (i.e. non-ASCII).
+    // To speed things up further, we're reading longs instead of bytes so we use a mask to
+    // determine if any byte in the current long is non-ASCII.
+    for (; i < lim && (buffer.getLong(i) & ASCII_MASK_LONG) == 0; i += 8) {}
+    return i - index;
+  }
+
+  /** A processor of UTF-8 strings, providing methods for checking validity and encoding. */
+  // TODO: Add support for Memory/MemoryBlock on Android.
+  abstract static class Processor {
+    /**
+     * Returns {@code true} if the given byte array slice is a well-formed UTF-8 byte sequence. The
+     * range of bytes to be checked extends from index {@code index}, inclusive, to {@code limit},
+     * exclusive.
+     *
+     * <p>This is a convenience method, equivalent to {@code partialIsValidUtf8(bytes, index, limit)
+     * == Utf8.COMPLETE}.
+     */
+    final boolean isValidUtf8(byte[] bytes, int index, int limit) {
+      return partialIsValidUtf8(COMPLETE, bytes, index, limit) == COMPLETE;
+    }
+
+    /**
+     * Tells whether the given byte array slice is a well-formed, malformed, or incomplete UTF-8
+     * byte sequence. The range of bytes to be checked extends from index {@code index}, inclusive,
+     * to {@code limit}, exclusive.
+     *
+     * @param state either {@link Utf8#COMPLETE} (if this is the initial decoding operation) or the
+     *     value returned from a call to a partial decoding method for the previous bytes
+     * @return {@link #MALFORMED} if the partial byte sequence is definitely not well-formed, {@link
+     *     #COMPLETE} if it is well-formed (no additional input needed), or if the byte sequence is
+     *     "incomplete", i.e. apparently terminated in the middle of a character, an opaque integer
+     *     "state" value containing enough information to decode the character when passed to a
+     *     subsequent invocation of a partial decoding method.
+     */
+    abstract int partialIsValidUtf8(int state, byte[] bytes, int index, int limit);
+
+    /**
+     * Returns {@code true} if the given portion of the {@link ByteBuffer} is a well-formed UTF-8
+     * byte sequence. The range of bytes to be checked extends from index {@code index}, inclusive,
+     * to {@code limit}, exclusive.
+     *
+     * <p>This is a convenience method, equivalent to {@code partialIsValidUtf8(bytes, index, limit)
+     * == Utf8.COMPLETE}.
+     */
+    final boolean isValidUtf8(ByteBuffer buffer, int index, int limit) {
+      return partialIsValidUtf8(COMPLETE, buffer, index, limit) == COMPLETE;
+    }
+
+    /**
+     * Indicates whether or not the given buffer contains a valid UTF-8 string.
+     *
+     * @param buffer the buffer to check.
+     * @return {@code true} if the given buffer contains a valid UTF-8 string.
+     */
+    final int partialIsValidUtf8(
+        final int state, final ByteBuffer buffer, int index, final int limit) {
+      if (buffer.hasArray()) {
+        final int offset = buffer.arrayOffset();
+        return partialIsValidUtf8(state, buffer.array(), offset + index, offset + limit);
+      } else if (buffer.isDirect()) {
+        return partialIsValidUtf8Direct(state, buffer, index, limit);
+      }
+      return partialIsValidUtf8Default(state, buffer, index, limit);
+    }
+
+    /** Performs validation for direct {@link ByteBuffer} instances. */
+    abstract int partialIsValidUtf8Direct(
+        final int state, final ByteBuffer buffer, int index, final int limit);
+
+    /**
+     * Performs validation for {@link ByteBuffer} instances using the {@link ByteBuffer} API rather
+     * than potentially faster approaches. This first completes validation for the current character
+     * (provided by {@code state}) and then finishes validation for the sequence.
+     */
+    final int partialIsValidUtf8Default(
+        final int state, final ByteBuffer buffer, int index, final int limit) {
+      if (state != COMPLETE) {
+        // The previous decoding operation was incomplete (or malformed).
+        // We look for a well-formed sequence consisting of bytes from
+        // the previous decoding operation (stored in state) together
+        // with bytes from the array slice.
+        //
+        // We expect such "straddler characters" to be rare.
+
+        if (index >= limit) { // No bytes? No progress.
+          return state;
+        }
+
+        byte byte1 = (byte) state;
+        // byte1 is never ASCII.
+        if (byte1 < (byte) 0xE0) {
+          // two-byte form
+
+          // Simultaneously checks for illegal trailing-byte in
+          // leading position and overlong 2-byte form.
+          if (byte1 < (byte) 0xC2
+              // byte2 trailing-byte test
+              || buffer.get(index++) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else if (byte1 < (byte) 0xF0) {
+          // three-byte form
+
+          // Get byte2 from saved state or array
+          byte byte2 = (byte) ~(state >> 8);
+          if (byte2 == 0) {
+            byte2 = buffer.get(index++);
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2);
+            }
+          }
+          if (byte2 > (byte) 0xBF
+              // overlong? 5 most significant bits must not all be zero
+              || (byte1 == (byte) 0xE0 && byte2 < (byte) 0xA0)
+              // illegal surrogate codepoint?
+              || (byte1 == (byte) 0xED && byte2 >= (byte) 0xA0)
+              // byte3 trailing-byte test
+              || buffer.get(index++) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else {
+          // four-byte form
+
+          // Get byte2 and byte3 from saved state or array
+          byte byte2 = (byte) ~(state >> 8);
+          byte byte3 = 0;
+          if (byte2 == 0) {
+            byte2 = buffer.get(index++);
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2);
+            }
+          } else {
+            byte3 = (byte) (state >> 16);
+          }
+          if (byte3 == 0) {
+            byte3 = buffer.get(index++);
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2, byte3);
+            }
+          }
+
+          // If we were called with state == MALFORMED, then byte1 is 0xFF,
+          // which never occurs in well-formed UTF-8, and so we will return
+          // MALFORMED again below.
+
+          if (byte2 > (byte) 0xBF
+              // Check that 1 <= plane <= 16.  Tricky optimized form of:
+              // if (byte1 > (byte) 0xF4 ||
+              //     byte1 == (byte) 0xF0 && byte2 < (byte) 0x90 ||
+              //     byte1 == (byte) 0xF4 && byte2 > (byte) 0x8F)
+              || (((byte1 << 28) + (byte2 - (byte) 0x90)) >> 30) != 0
+              // byte3 trailing-byte test
+              || byte3 > (byte) 0xBF
+              // byte4 trailing-byte test
+              || buffer.get(index++) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        }
+      }
+
+      // Finish validation for the sequence.
+      return partialIsValidUtf8(buffer, index, limit);
+    }
+
+    /**
+     * Performs validation for {@link ByteBuffer} instances using the {@link ByteBuffer} API rather
+     * than potentially faster approaches.
+     */
+    private static int partialIsValidUtf8(final ByteBuffer buffer, int index, final int limit) {
+      index += estimateConsecutiveAscii(buffer, index, limit);
+
+      for (; ; ) {
+        // Optimize for interior runs of ASCII bytes.
+        // TODO: Consider checking 8 bytes at a time after some threshold?
+        // Maybe after seeing a few in a row that are ASCII, go back to fast mode?
+        int byte1;
+        do {
+          if (index >= limit) {
+            return COMPLETE;
+          }
+        } while ((byte1 = buffer.get(index++)) >= 0);
+
+        // If we're here byte1 is not ASCII. Only need to handle 2-4 byte forms.
+        if (byte1 < (byte) 0xE0) {
+          // Two-byte form (110xxxxx 10xxxxxx)
+          if (index >= limit) {
+            // Incomplete sequence
+            return byte1;
+          }
+
+          // Simultaneously checks for illegal trailing-byte in
+          // leading position and overlong 2-byte form.
+          if (byte1 < (byte) 0xC2 || buffer.get(index) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+          index++;
+        } else if (byte1 < (byte) 0xF0) {
+          // Three-byte form (1110xxxx 10xxxxxx 10xxxxxx)
+          if (index >= limit - 1) {
+            // Incomplete sequence
+            return incompleteStateFor(buffer, byte1, index, limit - index);
+          }
+
+          byte byte2 = buffer.get(index++);
+          if (byte2 > (byte) 0xBF
+              // overlong? 5 most significant bits must not all be zero
+              || (byte1 == (byte) 0xE0 && byte2 < (byte) 0xA0)
+              // check for illegal surrogate codepoints
+              || (byte1 == (byte) 0xED && byte2 >= (byte) 0xA0)
+              // byte3 trailing-byte test
+              || buffer.get(index) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+          index++;
+        } else {
+          // Four-byte form (1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx)
+          if (index >= limit - 2) {
+            // Incomplete sequence
+            return incompleteStateFor(buffer, byte1, index, limit - index);
+          }
+
+          // TODO: Consider using getInt() to improve performance.
+          int byte2 = buffer.get(index++);
+          if (byte2 > (byte) 0xBF
+              // Check that 1 <= plane <= 16.  Tricky optimized form of:
+              // if (byte1 > (byte) 0xF4 ||
+              //     byte1 == (byte) 0xF0 && byte2 < (byte) 0x90 ||
+              //     byte1 == (byte) 0xF4 && byte2 > (byte) 0x8F)
+              || (((byte1 << 28) + (byte2 - (byte) 0x90)) >> 30) != 0
+              // byte3 trailing-byte test
+              || buffer.get(index++) > (byte) 0xBF
+              // byte4 trailing-byte test
+              || buffer.get(index++) > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        }
+      }
+    }
+
+    /**
+     * Encodes an input character sequence ({@code in}) to UTF-8 in the target array ({@code out}).
+     * For a string, this method is similar to
+     *
+     * <pre>{@code
+     * byte[] a = string.getBytes(UTF_8);
+     * System.arraycopy(a, 0, bytes, offset, a.length);
+     * return offset + a.length;
+     * }</pre>
+     *
+     * but is more efficient in both time and space. One key difference is that this method requires
+     * paired surrogates, and therefore does not support chunking. While {@code
+     * String.getBytes(UTF_8)} replaces unpaired surrogates with the default replacement character,
+     * this method throws {@link UnpairedSurrogateException}.
+     *
+     * <p>To ensure sufficient space in the output buffer, either call {@link #encodedLength} to
+     * compute the exact amount needed, or leave room for {@code Utf8.MAX_BYTES_PER_CHAR *
+     * sequence.length()}, which is the largest possible number of bytes that any input can be
+     * encoded to.
+     *
+     * @param in the input character sequence to be encoded
+     * @param out the target array
+     * @param offset the starting offset in {@code bytes} to start writing at
+     * @param length the length of the {@code bytes}, starting from {@code offset}
+     * @throws UnpairedSurrogateException if {@code sequence} contains ill-formed UTF-16 (unpaired
+     *     surrogates)
+     * @throws ArrayIndexOutOfBoundsException if {@code sequence} encoded in UTF-8 is longer than
+     *     {@code bytes.length - offset}
+     * @return the new offset, equivalent to {@code offset + Utf8.encodedLength(sequence)}
+     */
+    abstract int encodeUtf8(String in, byte[] out, int offset, int length);
+
+    /**
+     * Encodes an input character sequence ({@code in}) to UTF-8 in the target buffer ({@code out}).
+     * Upon returning from this method, the {@code out} position will point to the position after
+     * the last encoded byte. This method requires paired surrogates, and therefore does not support
+     * chunking.
+     *
+     * <p>To ensure sufficient space in the output buffer, either call {@link #encodedLength} to
+     * compute the exact amount needed, or leave room for {@code Utf8.MAX_BYTES_PER_CHAR *
+     * in.length()}, which is the largest possible number of bytes that any input can be encoded to.
+     *
+     * @param in the source character sequence to be encoded
+     * @param out the target buffer
+     * @throws UnpairedSurrogateException if {@code in} contains ill-formed UTF-16 (unpaired
+     *     surrogates)
+     * @throws ArrayIndexOutOfBoundsException if {@code in} encoded in UTF-8 is longer than {@code
+     *     out.remaining()}
+     */
+    final void encodeUtf8(String in, ByteBuffer out) {
+      if (out.hasArray()) {
+        final int offset = out.arrayOffset();
+        int endIndex = Utf8.encode(in, out.array(), offset + out.position(), out.remaining());
+        Java8Compatibility.position(out, endIndex - offset);
+      } else if (out.isDirect()) {
+        encodeUtf8Direct(in, out);
+      } else {
+        encodeUtf8Default(in, out);
+      }
+    }
+
+    /** Encodes the input character sequence to a direct {@link ByteBuffer} instance. */
+    abstract void encodeUtf8Direct(String in, ByteBuffer out);
+
+    /**
+     * Encodes the input character sequence to a {@link ByteBuffer} instance using the {@link
+     * ByteBuffer} API, rather than potentially faster approaches.
+     */
+    final void encodeUtf8Default(String in, ByteBuffer out) {
+      final int inLength = in.length();
+      int outIx = out.position();
+      int inIx = 0;
+
+      // Since ByteBuffer.putXXX() already checks boundaries for us, no need to explicitly check
+      // access. Assume the buffer is big enough and let it handle the out of bounds exception
+      // if it occurs.
+      try {
+        // Designed to take advantage of
+        // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+        for (char c; inIx < inLength && (c = in.charAt(inIx)) < 0x80; ++inIx) {
+          out.put(outIx + inIx, (byte) c);
+        }
+        if (inIx == inLength) {
+          // Successfully encoded the entire string.
+          Java8Compatibility.position(out, outIx + inIx);
+          return;
+        }
+
+        outIx += inIx;
+        for (char c; inIx < inLength; ++inIx, ++outIx) {
+          c = in.charAt(inIx);
+          if (c < 0x80) {
+            // One byte (0xxx xxxx)
+            out.put(outIx, (byte) c);
+          } else if (c < 0x800) {
+            // Two bytes (110x xxxx 10xx xxxx)
+
+            // Benchmarks show put performs better than putShort here (for HotSpot).
+            out.put(outIx++, (byte) (0xC0 | (c >>> 6)));
+            out.put(outIx, (byte) (0x80 | (0x3F & c)));
+          } else if (c < MIN_SURROGATE || MAX_SURROGATE < c) {
+            // Three bytes (1110 xxxx 10xx xxxx 10xx xxxx)
+            // Maximum single-char code point is 0xFFFF, 16 bits.
+
+            // Benchmarks show put performs better than putShort here (for HotSpot).
+            out.put(outIx++, (byte) (0xE0 | (c >>> 12)));
+            out.put(outIx++, (byte) (0x80 | (0x3F & (c >>> 6))));
+            out.put(outIx, (byte) (0x80 | (0x3F & c)));
+          } else {
+            // Four bytes (1111 xxxx 10xx xxxx 10xx xxxx 10xx xxxx)
+
+            // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8
+            // bytes
+            final char low;
+            if (inIx + 1 == inLength || !isSurrogatePair(c, (low = in.charAt(++inIx)))) {
+              throw new UnpairedSurrogateException(inIx, inLength);
+            }
+            // TODO: Consider using putInt() to improve performance.
+            int codePoint = toCodePoint(c, low);
+            out.put(outIx++, (byte) ((0xF << 4) | (codePoint >>> 18)));
+            out.put(outIx++, (byte) (0x80 | (0x3F & (codePoint >>> 12))));
+            out.put(outIx++, (byte) (0x80 | (0x3F & (codePoint >>> 6))));
+            out.put(outIx, (byte) (0x80 | (0x3F & codePoint)));
+          }
+        }
+
+        // Successfully encoded the entire string.
+        Java8Compatibility.position(out, outIx);
+      } catch (IndexOutOfBoundsException e) {
+        // TODO: Consider making the API throw IndexOutOfBoundsException instead.
+
+        // If we failed in the outer ASCII loop, outIx will not have been updated. In this case,
+        // use inIx to determine the bad write index.
+        int badWriteIndex = out.position() + Math.max(inIx, outIx - out.position() + 1);
+        throw new ArrayIndexOutOfBoundsException(
+            "Failed writing " + in.charAt(inIx) + " at index " + badWriteIndex);
+      }
+    }
+  }
+
+  /** {@link Processor} implementation that does not use any {@code sun.misc.Unsafe} methods. */
+  static final class SafeProcessor extends Processor {
+    @Override
+    int partialIsValidUtf8(int state, byte[] bytes, int index, int limit) {
+      if (state != COMPLETE) {
+        // The previous decoding operation was incomplete (or malformed).
+        // We look for a well-formed sequence consisting of bytes from
+        // the previous decoding operation (stored in state) together
+        // with bytes from the array slice.
+        //
+        // We expect such "straddler characters" to be rare.
+
+        if (index >= limit) { // No bytes? No progress.
+          return state;
+        }
+        int byte1 = (byte) state;
+        // byte1 is never ASCII.
+        if (byte1 < (byte) 0xE0) {
+          // two-byte form
+
+          // Simultaneously checks for illegal trailing-byte in
+          // leading position and overlong 2-byte form.
+          if (byte1 < (byte) 0xC2
+              // byte2 trailing-byte test
+              || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else if (byte1 < (byte) 0xF0) {
+          // three-byte form
+
+          // Get byte2 from saved state or array
+          int byte2 = (byte) ~(state >> 8);
+          if (byte2 == 0) {
+            byte2 = bytes[index++];
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2);
+            }
+          }
+          if (byte2 > (byte) 0xBF
+              // overlong? 5 most significant bits must not all be zero
+              || (byte1 == (byte) 0xE0 && byte2 < (byte) 0xA0)
+              // illegal surrogate codepoint?
+              || (byte1 == (byte) 0xED && byte2 >= (byte) 0xA0)
+              // byte3 trailing-byte test
+              || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else {
+          // four-byte form
+
+          // Get byte2 and byte3 from saved state or array
+          int byte2 = (byte) ~(state >> 8);
+          int byte3 = 0;
+          if (byte2 == 0) {
+            byte2 = bytes[index++];
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2);
+            }
+          } else {
+            byte3 = (byte) (state >> 16);
+          }
+          if (byte3 == 0) {
+            byte3 = bytes[index++];
+            if (index >= limit) {
+              return incompleteStateFor(byte1, byte2, byte3);
+            }
+          }
+
+          // If we were called with state == MALFORMED, then byte1 is 0xFF,
+          // which never occurs in well-formed UTF-8, and so we will return
+          // MALFORMED again below.
+
+          if (byte2 > (byte) 0xBF
+              // Check that 1 <= plane <= 16.  Tricky optimized form of:
+              // if (byte1 > (byte) 0xF4 ||
+              //     byte1 == (byte) 0xF0 && byte2 < (byte) 0x90 ||
+              //     byte1 == (byte) 0xF4 && byte2 > (byte) 0x8F)
+              || (((byte1 << 28) + (byte2 - (byte) 0x90)) >> 30) != 0
+              // byte3 trailing-byte test
+              || byte3 > (byte) 0xBF
+              // byte4 trailing-byte test
+              || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        }
+      }
+
+      return partialIsValidUtf8(bytes, index, limit);
+    }
+
+    @Override
+    int partialIsValidUtf8Direct(int state, ByteBuffer buffer, int index, int limit) {
+      // For safe processing, we have to use the ByteBuffer API.
+      return partialIsValidUtf8Default(state, buffer, index, limit);
+    }
+
+    @Override
+    int encodeUtf8(String in, byte[] out, int offset, int length) {
+      int utf16Length = in.length();
+      int j = offset;
+      int i = 0;
+      int limit = offset + length;
+      // Designed to take advantage of
+      // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+      for (char c; i < utf16Length && i + j < limit && (c = in.charAt(i)) < 0x80; i++) {
+        out[j + i] = (byte) c;
+      }
+      if (i == utf16Length) {
+        return j + utf16Length;
+      }
+      j += i;
+      for (char c; i < utf16Length; i++) {
+        c = in.charAt(i);
+        if (c < 0x80 && j < limit) {
+          out[j++] = (byte) c;
+        } else if (c < 0x800 && j <= limit - 2) { // 11 bits, two UTF-8 bytes
+          out[j++] = (byte) ((0xF << 6) | (c >>> 6));
+          out[j++] = (byte) (0x80 | (0x3F & c));
+        } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c) && j <= limit - 3) {
+          // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+          out[j++] = (byte) ((0xF << 5) | (c >>> 12));
+          out[j++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+          out[j++] = (byte) (0x80 | (0x3F & c));
+        } else if (j <= limit - 4) {
+          // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
+          // four UTF-8 bytes
+          final char low;
+          if (i + 1 == in.length() || !Character.isSurrogatePair(c, (low = in.charAt(++i)))) {
+            throw new UnpairedSurrogateException((i - 1), utf16Length);
+          }
+          int codePoint = Character.toCodePoint(c, low);
+          out[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+          out[j++] = (byte) (0x80 | (0x3F & codePoint));
+        } else {
+          // If we are surrogates and we're not a surrogate pair, always throw an
+          // UnpairedSurrogateException instead of an ArrayOutOfBoundsException.
+          if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
+              && (i + 1 == in.length() || !Character.isSurrogatePair(c, in.charAt(i + 1)))) {
+            throw new UnpairedSurrogateException(i, utf16Length);
+          }
+          throw new ArrayIndexOutOfBoundsException("Failed writing " + c + " at index " + j);
+        }
+      }
+      return j;
+    }
+
+    @Override
+    void encodeUtf8Direct(String in, ByteBuffer out) {
+      // For safe processing, we have to use the ByteBuffer API.
+      encodeUtf8Default(in, out);
+    }
+
+    private static int partialIsValidUtf8(byte[] bytes, int index, int limit) {
+      // Optimize for 100% ASCII (Hotspot loves small simple top-level loops like this).
+      // This simple loop stops when we encounter a byte >= 0x80 (i.e. non-ASCII).
+      while (index < limit && bytes[index] >= 0) {
+        index++;
+      }
+
+      return (index >= limit) ? COMPLETE : partialIsValidUtf8NonAscii(bytes, index, limit);
+    }
+
+    private static int partialIsValidUtf8NonAscii(byte[] bytes, int index, int limit) {
+      for (; ; ) {
+        int byte1;
+        int byte2;
+
+        // Optimize for interior runs of ASCII bytes.
+        do {
+          if (index >= limit) {
+            return COMPLETE;
+          }
+        } while ((byte1 = bytes[index++]) >= 0);
+
+        if (byte1 < (byte) 0xE0) {
+          // two-byte form
+
+          if (index >= limit) {
+            // Incomplete sequence
+            return byte1;
+          }
+
+          // Simultaneously checks for illegal trailing-byte in
+          // leading position and overlong 2-byte form.
+          if (byte1 < (byte) 0xC2 || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else if (byte1 < (byte) 0xF0) {
+          // three-byte form
+
+          if (index >= limit - 1) { // incomplete sequence
+            return incompleteStateFor(bytes, index, limit);
+          }
+          if ((byte2 = bytes[index++]) > (byte) 0xBF
+              // overlong? 5 most significant bits must not all be zero
+              || (byte1 == (byte) 0xE0 && byte2 < (byte) 0xA0)
+              // check for illegal surrogate codepoints
+              || (byte1 == (byte) 0xED && byte2 >= (byte) 0xA0)
+              // byte3 trailing-byte test
+              || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        } else {
+          // four-byte form
+
+          if (index >= limit - 2) { // incomplete sequence
+            return incompleteStateFor(bytes, index, limit);
+          }
+          if ((byte2 = bytes[index++]) > (byte) 0xBF
+              // Check that 1 <= plane <= 16.  Tricky optimized form of:
+              // if (byte1 > (byte) 0xF4 ||
+              //     byte1 == (byte) 0xF0 && byte2 < (byte) 0x90 ||
+              //     byte1 == (byte) 0xF4 && byte2 > (byte) 0x8F)
+              || (((byte1 << 28) + (byte2 - (byte) 0x90)) >> 30) != 0
+              // byte3 trailing-byte test
+              || bytes[index++] > (byte) 0xBF
+              // byte4 trailing-byte test
+              || bytes[index++] > (byte) 0xBF) {
+            return MALFORMED;
+          }
+        }
+      }
+    }
+  }
+
+  private Utf8() {}
+}

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/JsonUtil.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/JsonUtil.java
@@ -18,7 +18,7 @@ final class JsonUtil {
     try {
       return JSON_FACTORY.createGenerator(stringWriter);
     } catch (IOException e) {
-      throw new IllegalStateException("Unable to create in-memory JsonGenerator, can't happen.", e);
+      throw new IllegalStateException("Unable to createIntoDynamicList in-memory JsonGenerator, can't happen.", e);
     }
   }
 

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -12,6 +12,7 @@ otelJava.moduleName.set("io.opentelemetry.exporter.otlp")
 base.archivesName.set("opentelemetry-exporter-otlp")
 
 dependencies {
+  api(project(":sdk:common"))
   api(project(":sdk:trace"))
   api(project(":sdk:metrics"))
   api(project(":sdk:logs"))

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -14,6 +14,7 @@ import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
@@ -45,6 +46,8 @@ public final class OtlpHttpMetricExporterBuilder {
 
   private DefaultAggregationSelector defaultAggregationSelector =
       DefaultAggregationSelector.getDefault();
+
+  private MemoryMode memoryMode = MemoryMode.IMMUTABLE_DATA;
 
   OtlpHttpMetricExporterBuilder(HttpExporterBuilder<MetricsRequestMarshaler> delegate) {
     this.delegate = delegate;
@@ -222,6 +225,15 @@ public final class OtlpHttpMetricExporterBuilder {
     return this;
   }
 
+  // TODO Asaf: Go over this properly
+  /**
+   * Sets the {@link MemoryMode} to use for this exporter's associated reader.
+   */
+  public OtlpHttpMetricExporterBuilder setMemoryMode(MemoryMode memoryMode) {
+    this.memoryMode = memoryMode;
+    return this;
+  }
+
   OtlpHttpMetricExporterBuilder exportAsJson() {
     delegate.exportAsJson();
     return this;
@@ -234,6 +246,10 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporter build() {
     return new OtlpHttpMetricExporter(
-        delegate, delegate.build(), aggregationTemporalitySelector, defaultAggregationSelector);
+        delegate,
+        delegate.build(),
+        aggregationTemporalitySelector,
+        defaultAggregationSelector,
+        memoryMode);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ImmutableKeyValueMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ImmutableKeyValueMarshaler.java
@@ -1,0 +1,113 @@
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.AnyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.ArrayAnyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.BoolAnyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.DoubleAnyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.IntAnyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.StringAnyValueMarshaler;
+import io.opentelemetry.extension.incubator.logs.KeyAnyValue;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class ImmutableKeyValueMarshaler extends KeyValueMarshaler {
+  private final String key;
+  private final Marshaler value;
+
+  private final int size;
+
+  public static ImmutableKeyValueMarshaler createForKeyAnyValue(KeyAnyValue keyAnyValue) {
+    return new ImmutableKeyValueMarshaler(
+        keyAnyValue.getKey(),
+        // TODO Asaf: Change to immutable
+        AnyValueMarshaler.create(keyAnyValue.getAnyValue()));
+  }
+
+  /** Returns Marshalers for the given Attributes. */
+  @SuppressWarnings("AvoidObjectArrays")
+  public static List<KeyValueMarshaler> createForAttributes(Attributes attributes) {
+    if (attributes.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<KeyValueMarshaler> marshalers = new ArrayList<>(attributes.size());
+    attributes.forEach(
+            (attributeKey, o) -> marshalers.add(create(attributeKey, o)));
+    return marshalers;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static KeyValueMarshaler create(AttributeKey<?> attributeKey, Object value) {
+    String key;
+    if (attributeKey.getKey().isEmpty()) {
+      key = "";
+    } else {
+      key = attributeKey.getKey();
+    }
+    switch (attributeKey.getType()) {
+      case STRING:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, StringAnyValueMarshaler.create((String) value));
+      case LONG:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, IntAnyValueMarshaler.create((long) value));
+      case BOOLEAN:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, BoolAnyValueMarshaler.create((boolean) value));
+      case DOUBLE:
+        return new ImmutableKeyValueMarshaler(
+            key, DoubleAnyValueMarshaler.create((double) value));
+      case STRING_ARRAY:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, ArrayAnyValueMarshaler.createString((List<String>) value));
+      case LONG_ARRAY:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, ArrayAnyValueMarshaler.createInt((List<Long>) value));
+      case BOOLEAN_ARRAY:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, ArrayAnyValueMarshaler.createBool((List<Boolean>) value));
+      case DOUBLE_ARRAY:
+        // TODO Asaf: Change to immutable
+        return new ImmutableKeyValueMarshaler(
+            key, ArrayAnyValueMarshaler.createDouble((List<Double>) value));
+    }
+    // Error prone ensures the switch statement is complete, otherwise only can happen with
+    // unaligned versions which are not supported.
+    throw new IllegalArgumentException("Unsupported attribute type.");
+  }
+
+  private ImmutableKeyValueMarshaler(String key, Marshaler value) {
+    this.key = key;
+    this.value = value;
+    this.size = calculateSize(key, value);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  String getKey() {
+    return key;
+  }
+
+  @Override
+  Marshaler getValue() {
+    return value;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/InstrumentationScopeMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/InstrumentationScopeMarshaler.java
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 
 /**
  * A Marshaler of {@link InstrumentationScopeInfo}.
@@ -37,8 +38,8 @@ public final class InstrumentationScopeMarshaler extends MarshalerWithSize {
       // a few times until the cache gets filled which is fine.
       byte[] name = MarshalerUtil.toBytes(scopeInfo.getName());
       byte[] version = MarshalerUtil.toBytes(scopeInfo.getVersion());
-      KeyValueMarshaler[] attributes =
-          KeyValueMarshaler.createForAttributes(scopeInfo.getAttributes());
+      List<KeyValueMarshaler> attributes =
+          ImmutableKeyValueMarshaler.createForAttributes(scopeInfo.getAttributes());
 
       RealInstrumentationScopeMarshaler realMarshaler =
           new RealInstrumentationScopeMarshaler(name, version, attributes);
@@ -73,12 +74,14 @@ public final class InstrumentationScopeMarshaler extends MarshalerWithSize {
   }
 
   private static final class RealInstrumentationScopeMarshaler extends MarshalerWithSize {
-
     private final byte[] name;
     private final byte[] version;
-    private final KeyValueMarshaler[] attributes;
+    private final List<KeyValueMarshaler> attributes;
 
-    RealInstrumentationScopeMarshaler(byte[] name, byte[] version, KeyValueMarshaler[] attributes) {
+    RealInstrumentationScopeMarshaler(
+        byte[] name,
+        byte[] version,
+        List<KeyValueMarshaler> attributes) {
       super(computeSize(name, version, attributes));
       this.name = name;
       this.version = version;
@@ -92,7 +95,10 @@ public final class InstrumentationScopeMarshaler extends MarshalerWithSize {
       output.serializeRepeatedMessage(InstrumentationScope.ATTRIBUTES, attributes);
     }
 
-    private static int computeSize(byte[] name, byte[] version, KeyValueMarshaler[] attributes) {
+    private static int computeSize(
+        byte[] name,
+        byte[] version,
+        List<KeyValueMarshaler> attributes) {
       return MarshalerUtil.sizeBytes(InstrumentationScope.NAME, name)
           + MarshalerUtil.sizeBytes(InstrumentationScope.VERSION, version)
           + MarshalerUtil.sizeRepeatedMessage(InstrumentationScope.ATTRIBUTES, attributes);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueMarshaler.java
@@ -10,7 +10,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
-import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.extension.incubator.logs.KeyAnyValue;
 import io.opentelemetry.proto.common.v1.internal.KeyValue;
@@ -25,92 +24,22 @@ import java.util.function.BiConsumer;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class KeyValueMarshaler extends MarshalerWithSize {
+public abstract class KeyValueMarshaler extends Marshaler {
 
-  private static final byte[] EMPTY_BYTES = new byte[0];
-  private static final KeyValueMarshaler[] EMPTY_REPEATED = new KeyValueMarshaler[0];
-
-  private final byte[] keyUtf8;
-  private final Marshaler value;
-
-  private KeyValueMarshaler(byte[] keyUtf8, Marshaler value) {
-    super(calculateSize(keyUtf8, value));
-    this.keyUtf8 = keyUtf8;
-    this.value = value;
-  }
+  abstract String getKey();
+  abstract Marshaler getValue();
 
   /** Returns Marshaler for the given KeyAnyValue. */
-  public static KeyValueMarshaler createForKeyAnyValue(KeyAnyValue keyAnyValue) {
-    return new KeyValueMarshaler(
-        keyAnyValue.getKey().getBytes(StandardCharsets.UTF_8),
-        AnyValueMarshaler.create(keyAnyValue.getAnyValue()));
-  }
-
-  /** Returns Marshalers for the given Attributes. */
-  @SuppressWarnings("AvoidObjectArrays")
-  public static KeyValueMarshaler[] createForAttributes(Attributes attributes) {
-    if (attributes.isEmpty()) {
-      return EMPTY_REPEATED;
-    }
-
-    KeyValueMarshaler[] marshalers = new KeyValueMarshaler[attributes.size()];
-    attributes.forEach(
-        new BiConsumer<AttributeKey<?>, Object>() {
-          int index = 0;
-
-          @Override
-          public void accept(AttributeKey<?> attributeKey, Object o) {
-            marshalers[index++] = create(attributeKey, o);
-          }
-        });
-    return marshalers;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static KeyValueMarshaler create(AttributeKey<?> attributeKey, Object value) {
-    byte[] keyUtf8;
-    if (attributeKey.getKey().isEmpty()) {
-      keyUtf8 = EMPTY_BYTES;
-    } else if (attributeKey instanceof InternalAttributeKeyImpl) {
-      keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
-    } else {
-      keyUtf8 = attributeKey.getKey().getBytes(StandardCharsets.UTF_8);
-    }
-    switch (attributeKey.getType()) {
-      case STRING:
-        return new KeyValueMarshaler(keyUtf8, StringAnyValueMarshaler.create((String) value));
-      case LONG:
-        return new KeyValueMarshaler(keyUtf8, IntAnyValueMarshaler.create((long) value));
-      case BOOLEAN:
-        return new KeyValueMarshaler(keyUtf8, BoolAnyValueMarshaler.create((boolean) value));
-      case DOUBLE:
-        return new KeyValueMarshaler(keyUtf8, DoubleAnyValueMarshaler.create((double) value));
-      case STRING_ARRAY:
-        return new KeyValueMarshaler(
-            keyUtf8, ArrayAnyValueMarshaler.createString((List<String>) value));
-      case LONG_ARRAY:
-        return new KeyValueMarshaler(keyUtf8, ArrayAnyValueMarshaler.createInt((List<Long>) value));
-      case BOOLEAN_ARRAY:
-        return new KeyValueMarshaler(
-            keyUtf8, ArrayAnyValueMarshaler.createBool((List<Boolean>) value));
-      case DOUBLE_ARRAY:
-        return new KeyValueMarshaler(
-            keyUtf8, ArrayAnyValueMarshaler.createDouble((List<Double>) value));
-    }
-    // Error prone ensures the switch statement is complete, otherwise only can happen with
-    // unaligned versions which are not supported.
-    throw new IllegalArgumentException("Unsupported attribute type.");
-  }
 
   @Override
   public void writeTo(Serializer output) throws IOException {
-    output.serializeString(KeyValue.KEY, keyUtf8);
-    output.serializeMessage(KeyValue.VALUE, value);
+    output.serializeString(KeyValue.KEY, getKey());
+    output.serializeMessage(KeyValue.VALUE, getValue());
   }
 
-  private static int calculateSize(byte[] keyUtf8, Marshaler value) {
+  protected static int calculateSize(String key, Marshaler value) {
     int size = 0;
-    size += MarshalerUtil.sizeBytes(KeyValue.KEY, keyUtf8);
+    size += MarshalerUtil.sizeStringUtf8(KeyValue.KEY, key);
     size += MarshalerUtil.sizeMessage(KeyValue.VALUE, value);
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/MarshallerObjectPools.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/MarshallerObjectPools.java
@@ -1,0 +1,81 @@
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableExemplarMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableInstrumentationScopeMetricsMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableMetricMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableMetricsRequestMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableNumberDataPointMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableResourceMetricsMarshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.MutableSumMarshaler;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.internal.state.ObjectPool;
+
+public final class MarshallerObjectPools {
+  private final ObjectPool<DynamicList> dynamicListObjectPool
+      = new ObjectPool<>(DynamicList::new);
+  private final ObjectPool<MutableNumberDataPointMarshaler> mutableNumberDataPointMarshalerPool
+      = new ObjectPool<>(MutableNumberDataPointMarshaler::new);
+  private final ObjectPool<MutableExemplarMarshaler> mutableExemplarMarshallerPool
+      = new ObjectPool<>(MutableExemplarMarshaler::new);
+  private final ObjectPool<MutableMetricsRequestMarshaler> mutableMetricsRequestMarshallerPool
+      = new ObjectPool<>(MutableMetricsRequestMarshaler::new);
+  private final ObjectPool<MutableKeyValueMarshaler> mutableKeyValueMarshallerPool
+      = new ObjectPool<>(MutableKeyValueMarshaler::new);
+  private final ObjectPool<MutableResourceMetricsMarshaler> mutableResourceMetricsMarshalerPool
+      = new ObjectPool<>(MutableResourceMetricsMarshaler::new);
+  private final ObjectPool<MutableInstrumentationScopeMetricsMarshaler>
+      mutableInstrumentationScopeMetricsMarshalerPool
+      = new ObjectPool<>(MutableInstrumentationScopeMetricsMarshaler::new);
+  private final ObjectPool<MutableMetricMarshaler> mutableMetricMarshalerPool
+      = new ObjectPool<>(MutableMetricMarshaler::new);
+  private final ObjectPool<MutableSumMarshaler> mutableSumMarshalerPool
+      = new ObjectPool<>(MutableSumMarshaler::new);
+
+
+  // Accepts listSize to enable choosing the right size reusable list from the pool
+  // in the future
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public <T> DynamicList<T> borrowDynamicList(int listSize) {
+    DynamicList dynamicList = dynamicListObjectPool.borrowObject();
+    dynamicList.resizeAndClear(listSize);
+    return dynamicList;
+  }
+
+  @SuppressWarnings("rawtypes")
+  void returnDynamicList(DynamicList dynamicList) {
+    dynamicListObjectPool.returnObject(dynamicList);
+  }
+
+  public ObjectPool<MutableNumberDataPointMarshaler> getMutableNumberDataPointMarshallerPool() {
+    return mutableNumberDataPointMarshalerPool;
+  }
+
+  public ObjectPool<MutableExemplarMarshaler> getMutableExemplarMarshallerPool() {
+    return mutableExemplarMarshallerPool;
+  }
+
+  public ObjectPool<MutableMetricsRequestMarshaler> getMutableMetricsRequestMarshallerPool() {
+    return mutableMetricsRequestMarshallerPool;
+  }
+
+  public ObjectPool<MutableKeyValueMarshaler> getMutableKeyValueMarshallerPool() {
+    return mutableKeyValueMarshallerPool;
+  }
+
+  public ObjectPool<MutableResourceMetricsMarshaler> getMutableResourceMetricsMarshallerPool() {
+    return mutableResourceMetricsMarshalerPool;
+  }
+
+  public ObjectPool<MutableInstrumentationScopeMetricsMarshaler>
+  getMutableInstrumentationScopeMetricsMarshalerPool() {
+    return mutableInstrumentationScopeMetricsMarshalerPool;
+  }
+
+  public ObjectPool<MutableMetricMarshaler> getMutableMetricMarshalerPool() {
+    return mutableMetricMarshalerPool;
+  }
+
+  public ObjectPool<MutableSumMarshaler> getMutableSumMarshalerPool() {
+    return mutableSumMarshalerPool;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/MutableKeyValueMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/MutableKeyValueMarshaler.java
@@ -1,0 +1,129 @@
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.extension.incubator.logs.KeyAnyValue;
+import io.opentelemetry.sdk.internal.DynamicList;
+import java.util.Collections;
+import java.util.List;
+
+public class MutableKeyValueMarshaler extends KeyValueMarshaler {
+  private String key;
+  private Marshaler value;
+
+  private int size;
+
+  public static ImmutableKeyValueMarshaler createForKeyAnyValue(
+      KeyAnyValue keyAnyValue,
+      MarshallerObjectPools marshallerObjectPools) {
+    MutableKeyValueMarshaler mutableKeyValueMarshaler = marshallerObjectPools
+        .getMutableKeyValueMarshallerPool()
+        .borrowObject();
+
+    mutableKeyValueMarshaler.set(
+        keyAnyValue.getKey(),
+        // TODO Asaf: Change to Mutable
+        AnyValueMarshaler.create(keyAnyValue.getAnyValue()));
+  }
+
+  /** Returns Marshalers for the given Attributes. */
+  @SuppressWarnings("AvoidObjectArrays")
+  public static void createForAttributesIntoDynamicList(
+      Attributes attributes,
+      DynamicList<KeyValueMarshaler> keyValueMarshalersDynamicList,
+      MarshallerObjectPools marshallerObjectPools) {
+    if (attributes.isEmpty()) {
+      keyValueMarshalersDynamicList.resizeAndClear(0);
+    }
+
+    keyValueMarshalersDynamicList.resizeAndClear(attributes.size());
+    attributes.forEach(
+        (attributeKey, o) ->
+            keyValueMarshalersDynamicList.add(create(attributeKey, o, marshallerObjectPools)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static KeyValueMarshaler create(
+      AttributeKey<?> attributeKey,
+      Object value,
+      MarshallerObjectPools marshallerObjectPools) {
+
+    MutableKeyValueMarshaler mutableKeyValueMarshaler = marshallerObjectPools
+        .getMutableKeyValueMarshallerPool()
+        .borrowObject();
+
+    String key;
+    if (attributeKey.getKey().isEmpty()) {
+      key = "";
+    } else {
+      key = attributeKey.getKey();
+    }
+    switch (attributeKey.getType()) {
+      case STRING:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to mutable
+            key, StringAnyValueMarshaler.create((String) value));
+        return mutableKeyValueMarshaler;
+      case LONG:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, IntAnyValueMarshaler.create((long) value));
+        return mutableKeyValueMarshaler;
+      case BOOLEAN:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, BoolAnyValueMarshaler.create((boolean) value));
+        return mutableKeyValueMarshaler;
+      case DOUBLE:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, DoubleAnyValueMarshaler.create((double) value));
+        return mutableKeyValueMarshaler;
+      case STRING_ARRAY:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, ArrayAnyValueMarshaler.createString((List<String>) value));
+        return mutableKeyValueMarshaler;
+      case LONG_ARRAY:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, ArrayAnyValueMarshaler.createInt((List<Long>) value));
+        return mutableKeyValueMarshaler;
+      case BOOLEAN_ARRAY:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, ArrayAnyValueMarshaler.createBool((List<Boolean>) value));
+        return mutableKeyValueMarshaler;
+      case DOUBLE_ARRAY:
+        mutableKeyValueMarshaler.set(
+            // TODO Asaf: Change to immutable
+            key, ArrayAnyValueMarshaler.createDouble((List<Double>) value));
+        return mutableKeyValueMarshaler;
+    }
+    // Error-prone ensures the switch statement is complete, otherwise only can happen with
+    // unaligned versions which are not supported.
+    throw new IllegalArgumentException("Unsupported attribute type.");
+  }
+
+  void set(String key, Marshaler value) {
+    this.key = key;
+    this.value = value;
+    this.size = calculateSize(key, value);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  String getKey() {
+    return key;
+  }
+
+  @Override
+  Marshaler getValue() {
+    return value;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ResourceMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ResourceMarshaler.java
@@ -13,6 +13,7 @@ import io.opentelemetry.proto.resource.v1.internal.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 
 /**
  * A Marshaler of {@link io.opentelemetry.sdk.resources.Resource}.
@@ -37,7 +38,7 @@ public final class ResourceMarshaler extends MarshalerWithSize {
 
       RealResourceMarshaler realMarshaler =
           new RealResourceMarshaler(
-              KeyValueMarshaler.createForAttributes(resource.getAttributes()));
+              ImmutableKeyValueMarshaler.createForAttributes(resource.getAttributes()));
 
       ByteArrayOutputStream binaryBos =
           new ByteArrayOutputStream(realMarshaler.getBinarySerializedSize());
@@ -69,9 +70,9 @@ public final class ResourceMarshaler extends MarshalerWithSize {
   }
 
   private static final class RealResourceMarshaler extends MarshalerWithSize {
-    private final KeyValueMarshaler[] attributes;
+    private final List<KeyValueMarshaler> attributes;
 
-    private RealResourceMarshaler(KeyValueMarshaler[] attributes) {
+    private RealResourceMarshaler(List<KeyValueMarshaler> attributes) {
       super(calculateSize(attributes));
       this.attributes = attributes;
     }
@@ -81,7 +82,7 @@ public final class ResourceMarshaler extends MarshalerWithSize {
       output.serializeRepeatedMessage(Resource.ATTRIBUTES, attributes);
     }
 
-    private static int calculateSize(KeyValueMarshaler[] attributeMarshalers) {
+    private static int calculateSize(List<KeyValueMarshaler> attributeMarshalers) {
       return MarshalerUtil.sizeRepeatedMessage(Resource.ATTRIBUTES, attributeMarshalers);
     }
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableExemplarMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableExemplarMarshaler.java
@@ -1,0 +1,94 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.otlp.ImmutableKeyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import java.util.ArrayList;
+import java.util.List;
+
+ final class ImmutableExemplarMarshaler extends ExemplarMarshaler {
+  private final long timeUnixNano;
+  private final ExemplarData value;
+  private final ProtoFieldInfo valueField;
+  private final SpanContext spanContext;
+  private final List<KeyValueMarshaler> filteredAttributeMarshalers;
+  private final int size;
+
+  static List<ExemplarMarshaler> createRepeated(List<? extends ExemplarData> exemplars) {
+    int numExemplars = exemplars.size();
+    List<ExemplarMarshaler> marshalers = new ArrayList<>(numExemplars);
+    for (int i = 0; i < numExemplars; i++) {
+      marshalers.add(ImmutableExemplarMarshaler.create(exemplars.get(i)));
+    }
+    return marshalers;
+  }
+
+  private static ExemplarMarshaler create(ExemplarData exemplar) {
+    List<KeyValueMarshaler> attributeMarshalers =
+        ImmutableKeyValueMarshaler.createForAttributes(exemplar.getFilteredAttributes());
+
+    ProtoFieldInfo valueField;
+    if (exemplar instanceof LongExemplarData) {
+      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT;
+    } else {
+      assert exemplar instanceof DoubleExemplarData;
+      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_DOUBLE;
+    }
+
+    return new ImmutableExemplarMarshaler(
+        exemplar.getEpochNanos(),
+        exemplar,
+        valueField,
+        exemplar.getSpanContext(),
+        attributeMarshalers);
+  }
+
+  private ImmutableExemplarMarshaler(
+      long timeUnixNano,
+      ExemplarData value,
+      ProtoFieldInfo valueField,
+      SpanContext spanContext,
+      List<KeyValueMarshaler> filteredAttributeMarshalers) {
+    this.timeUnixNano = timeUnixNano;
+    this.value = value;
+    this.valueField = valueField;
+    this.spanContext = spanContext;
+    this.filteredAttributeMarshalers = filteredAttributeMarshalers;
+    this.size = calculateSize(
+        timeUnixNano, valueField, value, spanContext, filteredAttributeMarshalers);
+  }
+
+   @Override
+   public int getBinarySerializedSize() {
+     return size;
+   }
+
+   @Override
+   long getTimeUnixNano() {
+     return timeUnixNano;
+   }
+
+   @Override
+   ExemplarData getValue() {
+     return value;
+   }
+
+   @Override
+   ProtoFieldInfo getValueField() {
+     return valueField;
+   }
+
+   @Override
+   SpanContext getSpanContext() {
+     return spanContext;
+   }
+
+   @Override
+   List<KeyValueMarshaler> getFilteredAttributes() {
+     return filteredAttributeMarshalers;
+   }
+ }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableInstrumentationScopeMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableInstrumentationScopeMetricsMarshaler.java
@@ -1,0 +1,42 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import java.util.List;
+
+public class ImmutableInstrumentationScopeMetricsMarshaler extends InstrumentationScopeMetricsMarshaler {
+  private final InstrumentationScopeMarshaler instrumentationScope;
+  private final List<Marshaler> metricMarshalers;
+  private final String schemaUrl;
+  private final int size;
+
+  ImmutableInstrumentationScopeMetricsMarshaler(
+      InstrumentationScopeMarshaler instrumentationScope,
+      String schemaUrl,
+      List<Marshaler> metricMarshalers) {
+    this.instrumentationScope = instrumentationScope;
+    this.schemaUrl = schemaUrl;
+    this.metricMarshalers = metricMarshalers;
+    this.size = calculateSize(instrumentationScope, schemaUrl, metricMarshalers);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected InstrumentationScopeMarshaler getInstrumentationScope() {
+    return instrumentationScope;
+  }
+
+  @Override
+  protected String getSchemaUrl() {
+    return schemaUrl;
+  }
+
+  @Override
+  protected List<Marshaler> getMetricMarshalers() {
+    return metricMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableMetricMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableMetricMarshaler.java
@@ -1,0 +1,111 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.proto.metrics.v1.internal.Metric;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+
+final class ImmutableMetricMarshaler extends MetricMarshaler {
+  private final String name;
+  private final String description;
+  private final String unit;
+
+  private final Marshaler dataMarshaler;
+  private final ProtoFieldInfo dataField;
+  private final int size;
+
+  static Marshaler create(MetricData metric) {
+    Marshaler dataMarshaler = null;
+    ProtoFieldInfo dataField = null;
+    switch (metric.getType()) {
+      case LONG_GAUGE:
+        // TODO Asaf: Change to immutable
+        dataMarshaler = GaugeMarshaler.create(metric.getLongGaugeData());
+        dataField = Metric.GAUGE;
+        break;
+      case DOUBLE_GAUGE:
+        // TODO Asaf: Change to immutable
+        dataMarshaler = GaugeMarshaler.create(metric.getDoubleGaugeData());
+        dataField = Metric.GAUGE;
+        break;
+      case LONG_SUM:
+        dataMarshaler = ImmutableSumMarshaler.create(metric.getLongSumData());
+        dataField = Metric.SUM;
+        break;
+      case DOUBLE_SUM:
+        dataMarshaler = ImmutableSumMarshaler.create(metric.getDoubleSumData());
+        dataField = Metric.SUM;
+        break;
+      case SUMMARY:
+        // TODO Asaf: Change to immutable
+        dataMarshaler = SummaryMarshaler.create(metric.getSummaryData());
+        dataField = Metric.SUMMARY;
+        break;
+      case HISTOGRAM:
+        // TODO Asaf: Change to immutable
+        dataMarshaler = HistogramMarshaler.create(metric.getHistogramData());
+        dataField = Metric.HISTOGRAM;
+        break;
+      case EXPONENTIAL_HISTOGRAM:
+        // TODO Asaf: Change to immutable
+        dataMarshaler = ExponentialHistogramMarshaler.create(metric.getExponentialHistogramData());
+        dataField = Metric.EXPONENTIAL_HISTOGRAM;
+    }
+
+    if (dataMarshaler == null || dataField == null) {
+      // Someone not using BOM to align versions as we require. Just skip the metric.
+      return NoopMarshaler.INSTANCE;
+    }
+
+    return new ImmutableMetricMarshaler(
+        metric.getName(),
+        metric.getDescription(),
+        metric.getUnit(),
+        dataMarshaler,
+        dataField);
+  }
+
+  protected ImmutableMetricMarshaler(
+      String name,
+      String description,
+      String unit,
+      Marshaler dataMarshaler,
+      ProtoFieldInfo dataField) {
+    this.name = name;
+    this.description = description;
+    this.unit = unit;
+    this.dataMarshaler = dataMarshaler;
+    this.dataField = dataField;
+    this.size = calculateSize(name, description, unit, dataMarshaler, dataField);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected String getName() {
+    return name;
+  }
+
+  @Override
+  protected String getDescription() {
+    return description;
+  }
+
+  @Override
+  protected String getUnit() {
+    return unit;
+  }
+
+  @Override
+  protected Marshaler getDataMarshaler() {
+    return dataMarshaler;
+  }
+
+  @Override
+  protected ProtoFieldInfo getDataField() {
+    return dataField;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableMetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableMetricsRequestMarshaler.java
@@ -1,0 +1,36 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Collection;
+import java.util.List;
+
+public class ImmutableMetricsRequestMarshaler extends MetricsRequestMarshaler {
+  private final List<ResourceMetricsMarshaler> resourceMetricsMarshalers;
+  private final int size;
+
+  /**
+   * Returns a {@link MetricsRequestMarshaler} that can be used to convert the provided {@link
+   * MetricData} into a serialized OTLP ExportMetricsServiceRequest.
+   */
+  public static MetricsRequestMarshaler create(Collection<MetricData> metricDataList) {
+    return new ImmutableMetricsRequestMarshaler(
+        ImmutableResourceMetricsMarshaler.create(metricDataList));
+  }
+
+  protected ImmutableMetricsRequestMarshaler(
+      List<ResourceMetricsMarshaler> resourceMetricsMarshalers) {
+    this.resourceMetricsMarshalers = resourceMetricsMarshalers;
+    this.size = calculateSize(resourceMetricsMarshalers);
+  }
+
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  List<ResourceMetricsMarshaler> getResourceMetricsMarshalers() {
+    return resourceMetricsMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableNumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableNumberDataPointMarshaler.java
@@ -1,0 +1,111 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.otlp.ImmutableKeyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.NumberDataPoint;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class ImmutableNumberDataPointMarshaler extends NumberDataPointMarshaler {
+  private final long startTimeUnixNano;
+  private final long timeUnixNano;
+
+  private final PointData value;
+
+  private final ProtoFieldInfo valueField;
+
+  private final List<ExemplarMarshaler> exemplars;
+
+  private final List<KeyValueMarshaler> attributes;
+
+  private final int size;
+
+  static List<NumberDataPointMarshaler> createRepeated(Collection<? extends PointData> points) {
+    int numPoints = points.size();
+    List<NumberDataPointMarshaler> marshalers = new ArrayList<>(numPoints);
+    for (PointData point : points) {
+      marshalers.add(ImmutableNumberDataPointMarshaler.create(point));
+    }
+    return marshalers;
+  }
+
+  static NumberDataPointMarshaler create(PointData point) {
+    List<ExemplarMarshaler> exemplarMarshalers = ImmutableExemplarMarshaler.createRepeated(
+        point.getExemplars());
+    List<KeyValueMarshaler> attributeMarshalers =
+        ImmutableKeyValueMarshaler.createForAttributes(point.getAttributes());
+
+    ProtoFieldInfo valueField;
+    if (point instanceof LongPointData) {
+      valueField = NumberDataPoint.AS_INT;
+    } else {
+      assert point instanceof DoublePointData;
+      valueField = NumberDataPoint.AS_DOUBLE;
+    }
+
+    return new ImmutableNumberDataPointMarshaler(
+        point.getStartEpochNanos(),
+        point.getEpochNanos(),
+        point,
+        valueField,
+        exemplarMarshalers,
+        attributeMarshalers);
+  }
+
+  private ImmutableNumberDataPointMarshaler(
+      long startTimeUnixNano,
+      long timeUnixNano,
+      PointData value,
+      ProtoFieldInfo valueField,
+      List<ExemplarMarshaler> exemplars,
+      List<KeyValueMarshaler> attributes) {
+    this.startTimeUnixNano = startTimeUnixNano;
+    this.timeUnixNano = timeUnixNano;
+    this.value = value;
+    this.valueField = valueField;
+    this.exemplars = exemplars;
+    this.attributes = attributes;
+    this.size = calculateSize(startTimeUnixNano, timeUnixNano, valueField, value, exemplars,
+        attributes);
+  }
+
+  @Override
+  protected long getStartTimeUnixNano() {
+    return startTimeUnixNano;
+  }
+
+  @Override
+  protected long getTimeUnixNano() {
+    return timeUnixNano;
+  }
+
+  @Override
+  protected PointData getValue() {
+    return value;
+  }
+
+  @Override
+  protected ProtoFieldInfo getValueField() {
+    return valueField;
+  }
+
+  @Override
+  protected List<ExemplarMarshaler> getExemplars() {
+    return exemplars;
+  }
+
+  @Override
+  protected List<KeyValueMarshaler> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableResourceMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableResourceMetricsMarshaler.java
@@ -1,0 +1,93 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class ImmutableResourceMetricsMarshaler extends ResourceMetricsMarshaler {
+  private final ResourceMarshaler resourceMarshaler;
+  private final String schemaUrl;
+  private final List<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalers;
+  private final int size;
+
+
+  /** Returns Marshalers of ResourceMetrics created by grouping the provided metricData. */
+  @SuppressWarnings("AvoidObjectArrays")
+  public static List<ResourceMetricsMarshaler> create(Collection<MetricData> metricDataList) {
+    Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> resourceAndScopeMap =
+        groupByResourceAndScope(metricDataList);
+
+    List<ResourceMetricsMarshaler> resourceMetricsMarshalers =
+        new ArrayList<>(resourceAndScopeMap.size());
+
+    for (Map.Entry<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> entry :
+        resourceAndScopeMap.entrySet()) {
+      List<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalerArrayList =
+          new ArrayList<>(entry.getValue().size());
+      for (Map.Entry<InstrumentationScopeInfo, List<Marshaler>> entryIs :
+          entry.getValue().entrySet()) {
+        instrumentationScopeMetricsMarshalerArrayList.add(
+            new ImmutableInstrumentationScopeMetricsMarshaler(
+                InstrumentationScopeMarshaler.create(entryIs.getKey()),
+                entryIs.getKey().getSchemaUrl(),
+                entryIs.getValue()));
+      }
+      resourceMetricsMarshalers.add(
+          new ImmutableResourceMetricsMarshaler(
+              ResourceMarshaler.create(entry.getKey()),
+              entry.getKey().getSchemaUrl(),
+              instrumentationScopeMetricsMarshalerArrayList));
+    }
+
+    return resourceMetricsMarshalers;
+  }
+
+  protected static Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>>
+  groupByResourceAndScope(Collection<MetricData> metricDataList) {
+    return MarshalerUtil.groupByResourceAndScope(
+        metricDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        MetricData::getResource,
+        MetricData::getInstrumentationScopeInfo,
+        ImmutableMetricMarshaler::create);
+  }
+
+  public ImmutableResourceMetricsMarshaler(
+      ResourceMarshaler resourceMarshaler,
+      String schemaUrl,
+      List<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalers) {
+    this.resourceMarshaler = resourceMarshaler;
+    this.schemaUrl = schemaUrl;
+    this.instrumentationScopeMetricsMarshalers = instrumentationScopeMetricsMarshalers;
+    this.size = calculateSize(resourceMarshaler, schemaUrl, instrumentationScopeMetricsMarshalers);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected ResourceMarshaler getResourceMarshaler() {
+    return resourceMarshaler;
+  }
+
+  @Override
+  protected String getSchemaUrl() {
+    return schemaUrl;
+  }
+
+  @Override
+  protected List<InstrumentationScopeMetricsMarshaler> getInstrumentationScopeMetricsMarshalers() {
+    return instrumentationScopeMetricsMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableSumMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ImmutableSumMarshaler.java
@@ -1,0 +1,53 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.ProtoEnumInfo;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import java.util.List;
+
+public class ImmutableSumMarshaler extends SumMarshaler {
+  private final List<NumberDataPointMarshaler> dataPoints;
+  private final ProtoEnumInfo aggregationTemporality;
+  private final boolean isMonotonic;
+  private final int size;
+
+  static SumMarshaler create(SumData<? extends PointData> sum) {
+    List<NumberDataPointMarshaler> dataPointMarshalers =
+        ImmutableNumberDataPointMarshaler.createRepeated(sum.getPoints());
+
+    return new ImmutableSumMarshaler(
+        dataPointMarshalers,
+        MetricsMarshalerUtil.mapToTemporality(sum.getAggregationTemporality()),
+        sum.isMonotonic());
+  }
+
+  protected ImmutableSumMarshaler(
+      List<NumberDataPointMarshaler> dataPoints,
+      ProtoEnumInfo aggregationTemporality,
+      boolean isMonotonic) {
+    this.dataPoints = dataPoints;
+    this.aggregationTemporality = aggregationTemporality;
+    this.isMonotonic = isMonotonic;
+    this.size = calculateSize(dataPoints, aggregationTemporality, isMonotonic);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  List<NumberDataPointMarshaler> getDataPoints() {
+    return dataPoints;
+  }
+
+  @Override
+  ProtoEnumInfo getAggregationTemporality() {
+    return aggregationTemporality;
+  }
+
+  @Override
+  boolean getIsMonotonic() {
+    return isMonotonic;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsMarshaler.java
@@ -14,35 +14,28 @@ import io.opentelemetry.proto.metrics.v1.internal.ScopeMetrics;
 import java.io.IOException;
 import java.util.List;
 
-final class InstrumentationScopeMetricsMarshaler extends MarshalerWithSize {
-  private final InstrumentationScopeMarshaler instrumentationScope;
-  private final List<Marshaler> metricMarshalers;
-  private final byte[] schemaUrlUtf8;
+public abstract class InstrumentationScopeMetricsMarshaler extends Marshaler {
 
-  InstrumentationScopeMetricsMarshaler(
-      InstrumentationScopeMarshaler instrumentationScope,
-      byte[] schemaUrlUtf8,
-      List<Marshaler> metricMarshalers) {
-    super(calculateSize(instrumentationScope, schemaUrlUtf8, metricMarshalers));
-    this.instrumentationScope = instrumentationScope;
-    this.schemaUrlUtf8 = schemaUrlUtf8;
-    this.metricMarshalers = metricMarshalers;
-  }
+  abstract protected InstrumentationScopeMarshaler getInstrumentationScope();
+
+  abstract protected String getSchemaUrl();
+
+  abstract protected List<Marshaler> getMetricMarshalers();
 
   @Override
   public void writeTo(Serializer output) throws IOException {
-    output.serializeMessage(ScopeMetrics.SCOPE, instrumentationScope);
-    output.serializeRepeatedMessage(ScopeMetrics.METRICS, metricMarshalers);
-    output.serializeString(ScopeMetrics.SCHEMA_URL, schemaUrlUtf8);
+    output.serializeMessage(ScopeMetrics.SCOPE, getInstrumentationScope());
+    output.serializeRepeatedMessage(ScopeMetrics.METRICS, getMetricMarshalers());
+    output.serializeString(ScopeMetrics.SCHEMA_URL, getSchemaUrl());
   }
 
-  private static int calculateSize(
+  protected static int calculateSize(
       InstrumentationScopeMarshaler instrumentationScope,
-      byte[] schemaUrlUtf8,
+      String schemaUrl,
       List<Marshaler> metricMarshalers) {
     int size = 0;
     size += MarshalerUtil.sizeMessage(ScopeMetrics.SCOPE, instrumentationScope);
-    size += MarshalerUtil.sizeBytes(ScopeMetrics.SCHEMA_URL, schemaUrlUtf8);
+    size += MarshalerUtil.sizeStringUtf8(ScopeMetrics.SCHEMA_URL, schemaUrl);
     size += MarshalerUtil.sizeRepeatedMessage(ScopeMetrics.METRICS, metricMarshalers);
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricMarshaler.java
@@ -7,99 +7,37 @@ package io.opentelemetry.exporter.internal.otlp.metrics;
 
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
-import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.proto.metrics.v1.internal.Metric;
-import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 
-final class MetricMarshaler extends MarshalerWithSize {
-  private final byte[] nameUtf8;
-  private final byte[] descriptionUtf8;
-  private final byte[] unitUtf8;
+abstract class MetricMarshaler extends Marshaler {
 
-  private final Marshaler dataMarshaler;
-  private final ProtoFieldInfo dataField;
-
-  static Marshaler create(MetricData metric) {
-    // TODO(anuraaga): Cache these as they should be effectively singleton.
-    byte[] name = MarshalerUtil.toBytes(metric.getName());
-    byte[] description = MarshalerUtil.toBytes(metric.getDescription());
-    byte[] unit = MarshalerUtil.toBytes(metric.getUnit());
-
-    Marshaler dataMarshaler = null;
-    ProtoFieldInfo dataField = null;
-    switch (metric.getType()) {
-      case LONG_GAUGE:
-        dataMarshaler = GaugeMarshaler.create(metric.getLongGaugeData());
-        dataField = Metric.GAUGE;
-        break;
-      case DOUBLE_GAUGE:
-        dataMarshaler = GaugeMarshaler.create(metric.getDoubleGaugeData());
-        dataField = Metric.GAUGE;
-        break;
-      case LONG_SUM:
-        dataMarshaler = SumMarshaler.create(metric.getLongSumData());
-        dataField = Metric.SUM;
-        break;
-      case DOUBLE_SUM:
-        dataMarshaler = SumMarshaler.create(metric.getDoubleSumData());
-        dataField = Metric.SUM;
-        break;
-      case SUMMARY:
-        dataMarshaler = SummaryMarshaler.create(metric.getSummaryData());
-        dataField = Metric.SUMMARY;
-        break;
-      case HISTOGRAM:
-        dataMarshaler = HistogramMarshaler.create(metric.getHistogramData());
-        dataField = Metric.HISTOGRAM;
-        break;
-      case EXPONENTIAL_HISTOGRAM:
-        dataMarshaler = ExponentialHistogramMarshaler.create(metric.getExponentialHistogramData());
-        dataField = Metric.EXPONENTIAL_HISTOGRAM;
-    }
-
-    if (dataMarshaler == null || dataField == null) {
-      // Someone not using BOM to align versions as we require. Just skip the metric.
-      return NoopMarshaler.INSTANCE;
-    }
-
-    return new MetricMarshaler(name, description, unit, dataMarshaler, dataField);
-  }
-
-  private MetricMarshaler(
-      byte[] nameUtf8,
-      byte[] descriptionUtf8,
-      byte[] unitUtf8,
-      Marshaler dataMarshaler,
-      ProtoFieldInfo dataField) {
-    super(calculateSize(nameUtf8, descriptionUtf8, unitUtf8, dataMarshaler, dataField));
-    this.nameUtf8 = nameUtf8;
-    this.descriptionUtf8 = descriptionUtf8;
-    this.unitUtf8 = unitUtf8;
-    this.dataMarshaler = dataMarshaler;
-    this.dataField = dataField;
-  }
+  abstract protected String getName();
+  abstract protected String getDescription();
+  abstract protected String getUnit();
+  abstract protected Marshaler getDataMarshaler();
+  abstract protected ProtoFieldInfo getDataField();
 
   @Override
   public void writeTo(Serializer output) throws IOException {
-    output.serializeString(Metric.NAME, nameUtf8);
-    output.serializeString(Metric.DESCRIPTION, descriptionUtf8);
-    output.serializeString(Metric.UNIT, unitUtf8);
-    output.serializeMessage(dataField, dataMarshaler);
+    output.serializeString(Metric.NAME, getName());
+    output.serializeString(Metric.DESCRIPTION, getDescription());
+    output.serializeString(Metric.UNIT, getName());
+    output.serializeMessage(getDataField(), getDataMarshaler());
   }
 
-  private static int calculateSize(
-      byte[] nameUtf8,
-      byte[] descriptionUtf8,
-      byte[] unitUtf8,
+  protected static int calculateSize(
+      String name,
+      String description,
+      String unit,
       Marshaler dataMarshaler,
       ProtoFieldInfo dataField) {
     int size = 0;
-    size += MarshalerUtil.sizeBytes(Metric.NAME, nameUtf8);
-    size += MarshalerUtil.sizeBytes(Metric.DESCRIPTION, descriptionUtf8);
-    size += MarshalerUtil.sizeBytes(Metric.UNIT, unitUtf8);
+    size += MarshalerUtil.sizeStringUtf8(Metric.NAME, name);
+    size += MarshalerUtil.sizeStringUtf8(Metric.DESCRIPTION, description);
+    size += MarshalerUtil.sizeStringUtf8(Metric.UNIT, unit);
     size += MarshalerUtil.sizeMessage(dataField, dataMarshaler);
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshaler.java
@@ -13,6 +13,7 @@ import io.opentelemetry.proto.collector.metrics.v1.internal.ExportMetricsService
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * {@link Marshaler} to convert SDK {@link MetricData} to OTLP ExportMetricsServiceRequest.
@@ -20,30 +21,20 @@ import java.util.Collection;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class MetricsRequestMarshaler extends MarshalerWithSize {
+public abstract class MetricsRequestMarshaler extends Marshaler {
 
-  private final ResourceMetricsMarshaler[] resourceMetricsMarshalers;
+  abstract List<ResourceMetricsMarshaler> getResourceMetricsMarshalers();
 
-  /**
-   * Returns a {@link MetricsRequestMarshaler} that can be used to convert the provided {@link
-   * MetricData} into a serialized OTLP ExportMetricsServiceRequest.
-   */
-  public static MetricsRequestMarshaler create(Collection<MetricData> metricDataList) {
-    return new MetricsRequestMarshaler(ResourceMetricsMarshaler.create(metricDataList));
-  }
-
-  private MetricsRequestMarshaler(ResourceMetricsMarshaler[] resourceMetricsMarshalers) {
-    super(calculateSize(resourceMetricsMarshalers));
-    this.resourceMetricsMarshalers = resourceMetricsMarshalers;
+  protected MetricsRequestMarshaler() {
   }
 
   @Override
   public void writeTo(Serializer output) throws IOException {
     output.serializeRepeatedMessage(
-        ExportMetricsServiceRequest.RESOURCE_METRICS, resourceMetricsMarshalers);
+        ExportMetricsServiceRequest.RESOURCE_METRICS, getResourceMetricsMarshalers());
   }
 
-  private static int calculateSize(ResourceMetricsMarshaler[] resourceMetricsMarshalers) {
+  protected static int calculateSize(List<ResourceMetricsMarshaler> resourceMetricsMarshalers) {
     int size = 0;
     size +=
         MarshalerUtil.sizeRepeatedMessage(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableExemplarMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableExemplarMarshaler.java
@@ -1,0 +1,114 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.exporter.internal.otlp.MutableKeyValueMarshaler;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import java.util.List;
+
+public final class MutableExemplarMarshaler extends ExemplarMarshaler {
+  private long timeUnixNano;
+  private ExemplarData value;
+  private ProtoFieldInfo valueField;
+  private SpanContext spanContext;
+  private DynamicList<KeyValueMarshaler> filteredAttributeMarshalers = DynamicList.empty();
+  private int size;
+
+  static void createRepeatedIntoDynamicList(
+      List<? extends ExemplarData> exemplars,
+      DynamicList<ExemplarMarshaler> exemplarMarshalers,
+      MarshallerObjectPools marshallerObjectPools) {
+    int numExemplars = exemplars.size();
+    exemplarMarshalers.resizeAndClear(numExemplars);
+    for (int i = 0; i < numExemplars; i++) {
+      exemplarMarshalers.add(create(exemplars.get(i), marshallerObjectPools));
+    }
+  }
+
+  private static ExemplarMarshaler create(
+      ExemplarData exemplar,
+      MarshallerObjectPools marshallerObjectPools) {
+
+    MutableExemplarMarshaler mutableExemplarMarshaler =
+        marshallerObjectPools.getMutableExemplarMarshallerPool().borrowObject();
+
+    DynamicList<KeyValueMarshaler> attributeMarshallersDynamicList =
+        mutableExemplarMarshaler.filteredAttributeMarshalers;
+
+    MutableKeyValueMarshaler.createForAttributesIntoDynamicList(
+            exemplar.getFilteredAttributes(),
+            attributeMarshallersDynamicList,
+            marshallerObjectPools);
+
+    ProtoFieldInfo valueField;
+    if (exemplar instanceof LongExemplarData) {
+      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT;
+    } else {
+      assert exemplar instanceof DoubleExemplarData;
+      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_DOUBLE;
+    }
+
+    mutableExemplarMarshaler.set(
+        exemplar.getEpochNanos(),
+        exemplar,
+        valueField,
+        exemplar.getSpanContext(),
+        attributeMarshallersDynamicList);
+
+    return mutableExemplarMarshaler;
+  }
+
+  private void set(
+      long timeUnixNano,
+      ExemplarData value,
+      ProtoFieldInfo valueField,
+      SpanContext spanContext,
+      DynamicList<KeyValueMarshaler> filteredAttributeMarshalers) {
+    this.timeUnixNano = timeUnixNano;
+    this.value = value;
+    this.valueField = valueField;
+    this.spanContext = spanContext;
+    this.filteredAttributeMarshalers = filteredAttributeMarshalers;
+    this.size = calculateSize(
+        timeUnixNano,
+        valueField,
+        value,
+        spanContext,
+        filteredAttributeMarshalers);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  long getTimeUnixNano() {
+    return timeUnixNano;
+  }
+
+  @Override
+  ExemplarData getValue() {
+    return value;
+  }
+
+  @Override
+  ProtoFieldInfo getValueField() {
+    return valueField;
+  }
+
+  @Override
+  SpanContext getSpanContext() {
+    return spanContext;
+  }
+
+  @Override
+  List<KeyValueMarshaler> getFilteredAttributes() {
+    return filteredAttributeMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableInstrumentationScopeMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableInstrumentationScopeMetricsMarshaler.java
@@ -1,0 +1,50 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import io.opentelemetry.sdk.internal.DynamicList;
+import java.util.Collections;
+import java.util.List;
+
+public class MutableInstrumentationScopeMetricsMarshaler extends InstrumentationScopeMetricsMarshaler {
+  private InstrumentationScopeMarshaler instrumentationScope;
+
+  // TODO Asaf: Change to nullable DynamicList
+  private List<Marshaler> metricMarshalers = Collections.emptyList();
+
+  private String schemaUrl;
+  private int size;
+
+  public MutableInstrumentationScopeMetricsMarshaler() {
+  }
+
+  void set(
+      InstrumentationScopeMarshaler instrumentationScope,
+      String schemaUrl,
+      List<Marshaler> metricMarshalers) {
+    this.instrumentationScope = instrumentationScope;
+    this.schemaUrl = schemaUrl;
+    this.metricMarshalers = metricMarshalers;
+    this.size = calculateSize(instrumentationScope, schemaUrl, metricMarshalers);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected InstrumentationScopeMarshaler getInstrumentationScope() {
+    return instrumentationScope;
+  }
+
+  @Override
+  protected String getSchemaUrl() {
+    return schemaUrl;
+  }
+
+  @Override
+  protected List<Marshaler> getMetricMarshalers() {
+    return metricMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableMetricMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableMetricMarshaler.java
@@ -1,0 +1,117 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.proto.metrics.v1.internal.Metric;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+
+public final class MutableMetricMarshaler extends MetricMarshaler {
+  private String name;
+  private String description;
+  private String unit;
+  private Marshaler dataMarshaler;
+  private ProtoFieldInfo dataField;
+  private int size;
+
+  static Marshaler create(MetricData metric, MarshallerObjectPools marshallerObjectPools) {
+    Marshaler dataMarshaler = null;
+    ProtoFieldInfo dataField = null;
+    switch (metric.getType()) {
+      case LONG_GAUGE:
+        // TODO Asaf: Change to mutable
+        dataMarshaler = GaugeMarshaler.create(metric.getLongGaugeData());
+        dataField = Metric.GAUGE;
+        break;
+      case DOUBLE_GAUGE:
+        // TODO Asaf: Change to mutable
+        dataMarshaler = GaugeMarshaler.create(metric.getDoubleGaugeData());
+        dataField = Metric.GAUGE;
+        break;
+      case LONG_SUM:
+        dataMarshaler = MutableSumMarshaler.create(metric.getLongSumData());
+        dataField = Metric.SUM;
+        break;
+      case DOUBLE_SUM:
+        dataMarshaler = MutableSumMarshaler.create(metric.getDoubleSumData());
+        dataField = Metric.SUM;
+        break;
+      case SUMMARY:
+        // TODO Asaf: Change to mutable
+        dataMarshaler = SummaryMarshaler.create(metric.getSummaryData());
+        dataField = Metric.SUMMARY;
+        break;
+      case HISTOGRAM:
+        // TODO Asaf: Change to mutable
+        dataMarshaler = HistogramMarshaler.create(metric.getHistogramData());
+        dataField = Metric.HISTOGRAM;
+        break;
+      case EXPONENTIAL_HISTOGRAM:
+        // TODO Asaf: Change to mutable
+        dataMarshaler = ExponentialHistogramMarshaler.create(metric.getExponentialHistogramData());
+        dataField = Metric.EXPONENTIAL_HISTOGRAM;
+    }
+
+    if (dataMarshaler == null || dataField == null) {
+      // Someone not using BOM to align versions as we require. Just skip the metric.
+      return NoopMarshaler.INSTANCE;
+    }
+
+    MutableMetricMarshaler mutableMetricMarshaler = marshallerObjectPools
+        .getMutableMetricMarshalerPool()
+        .borrowObject();
+
+    mutableMetricMarshaler.set(
+        metric.getName(),
+        metric.getDescription(),
+        metric.getUnit(),
+        dataMarshaler,
+        dataField);
+
+    return mutableMetricMarshaler;
+  }
+
+  void set(
+      String name,
+      String description,
+      String unit,
+      Marshaler dataMarshaler,
+      ProtoFieldInfo dataField) {
+    this.name = name;
+    this.description = description;
+    this.unit = unit;
+    this.dataMarshaler = dataMarshaler;
+    this.dataField = dataField;
+    this.size = calculateSize(name, description, unit, dataMarshaler, dataField);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected String getName() {
+    return name;
+  }
+
+  @Override
+  protected String getDescription() {
+    return description;
+  }
+
+  @Override
+  protected String getUnit() {
+    return unit;
+  }
+
+  @Override
+  protected Marshaler getDataMarshaler() {
+    return dataMarshaler;
+  }
+
+  @Override
+  protected ProtoFieldInfo getDataField() {
+    return dataField;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableMetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableMetricsRequestMarshaler.java
@@ -1,0 +1,53 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Collection;
+import java.util.List;
+
+public class MutableMetricsRequestMarshaler extends MetricsRequestMarshaler {
+  private DynamicList<ResourceMetricsMarshaler> resourceMetricsMarshalers = DynamicList.empty();
+  private int size;
+
+    /**
+    * Returns a {@link MetricsRequestMarshaler} that can be used to convert the provided {@link
+    * MetricData} into a serialized OTLP ExportMetricsServiceRequest.
+    */
+    public static MetricsRequestMarshaler create(
+        Collection<MetricData> metricDataList,
+        MarshallerObjectPools marshallerObjectPools) {
+
+      MutableMetricsRequestMarshaler mutableMetricsRequestMarshaler =
+          marshallerObjectPools
+              .getMutableMetricsRequestMarshallerPool()
+              .borrowObject();
+
+      DynamicList<ResourceMetricsMarshaler> dynamicList =
+          mutableMetricsRequestMarshaler.resourceMetricsMarshalers;
+
+      MutableResourceMetricsMarshaler.createIntoDynamicList(
+          metricDataList,
+          dynamicList,
+          marshallerObjectPools);
+
+      mutableMetricsRequestMarshaler.set(dynamicList);
+
+      return mutableMetricsRequestMarshaler;
+    }
+
+  @Override
+  List<ResourceMetricsMarshaler> getResourceMetricsMarshalers() {
+    return resourceMetricsMarshalers;
+  }
+
+  private void set(DynamicList<ResourceMetricsMarshaler> resourceMetrics) {
+    this.resourceMetricsMarshalers = resourceMetrics;
+    this.size = calculateSize(resourceMetrics);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableNumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableNumberDataPointMarshaler.java
@@ -1,0 +1,136 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.otlp.KeyValueMarshaler;
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.exporter.internal.otlp.MutableKeyValueMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.NumberDataPoint;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public final class MutableNumberDataPointMarshaler extends NumberDataPointMarshaler {
+  private long startTimeUnixNano;
+  private long timeUnixNano;
+
+  @Nullable
+  private PointData value;
+
+  @Nullable
+  private ProtoFieldInfo valueField;
+
+  private DynamicList<ExemplarMarshaler> exemplars = DynamicList.empty();
+
+  private DynamicList<KeyValueMarshaler> attributes = DynamicList.empty();
+
+  private int size;
+
+  static DynamicList<NumberDataPointMarshaler> createRepeated(
+      Collection<? extends PointData> points,
+      MarshallerObjectPools marshallerObjectPools) {
+    int numPoints = points.size();
+    DynamicList<NumberDataPointMarshaler> marshalers =
+        marshallerObjectPools.borrowDynamicList(numPoints);
+    for (PointData point : points) {
+      marshalers.add(create(point, marshallerObjectPools));
+    }
+    return marshalers;
+  }
+
+  static NumberDataPointMarshaler create(
+      PointData point,
+      MarshallerObjectPools marshallerObjectPools) {
+
+    MutableNumberDataPointMarshaler mutableNumberDataPointMarshaler =
+        marshallerObjectPools.getMutableNumberDataPointMarshallerPool().borrowObject();
+
+    DynamicList<ExemplarMarshaler> exemplarMarshalersDynamicList =
+        mutableNumberDataPointMarshaler.getExemplars();
+    MutableExemplarMarshaler.createRepeatedIntoDynamicList(
+        point.getExemplars(),
+        exemplarMarshalersDynamicList,
+        marshallerObjectPools);
+
+    DynamicList<KeyValueMarshaler> keyValueMarshalersDynamicList =
+        mutableNumberDataPointMarshaler.getAttributes();
+    MutableKeyValueMarshaler.createForAttributesIntoDynamicList(
+        point.getAttributes(),
+        keyValueMarshalersDynamicList,
+        marshallerObjectPools);
+
+    ProtoFieldInfo valueField;
+    if (point instanceof LongPointData) {
+      valueField = NumberDataPoint.AS_INT;
+    } else {
+      assert point instanceof DoublePointData;
+      valueField = NumberDataPoint.AS_DOUBLE;
+    }
+
+    mutableNumberDataPointMarshaler.set(
+        point.getStartEpochNanos(),
+        point.getEpochNanos(),
+        point,
+        valueField,
+        exemplarMarshalersDynamicList,
+        keyValueMarshalersDynamicList);
+
+    return mutableNumberDataPointMarshaler;
+  }
+
+  private void set(
+      long startTimeUnixNano,
+      long timeUnixNano,
+      PointData value,
+      ProtoFieldInfo valueField,
+      DynamicList<ExemplarMarshaler> exemplars,
+      DynamicList<KeyValueMarshaler> attributes) {
+    this.startTimeUnixNano = startTimeUnixNano;
+    this.timeUnixNano = timeUnixNano;
+    this.value = value;
+    this.valueField = valueField;
+    this.exemplars = exemplars;
+    this.attributes = attributes;
+    this.size = calculateSize(startTimeUnixNano, timeUnixNano, valueField, value, exemplars,
+        attributes);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected long getStartTimeUnixNano() {
+    return startTimeUnixNano;
+  }
+
+  @Override
+  protected long getTimeUnixNano() {
+    return timeUnixNano;
+  }
+
+  @Nullable
+  @Override
+  protected PointData getValue() {
+    return value;
+  }
+
+  @Nullable
+  @Override
+  protected ProtoFieldInfo getValueField() {
+    return valueField;
+  }
+
+  @Override
+  protected DynamicList<ExemplarMarshaler> getExemplars() {
+    return exemplars;
+  }
+
+  @Override
+  protected DynamicList<KeyValueMarshaler> getAttributes() {
+    return attributes;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableResourceMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableResourceMetricsMarshaler.java
@@ -1,0 +1,118 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class MutableResourceMetricsMarshaler extends ResourceMetricsMarshaler {
+  private ResourceMarshaler resourceMarshaler;
+  private String schemaUrl;
+  private DynamicList<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalers
+      = DynamicList.empty();
+  private int size;
+
+  /** Returns Marshalers of ResourceMetrics created by grouping the provided metricData. */
+  public static void createIntoDynamicList(Collection<MetricData> metricDataList,
+      DynamicList<ResourceMetricsMarshaler> resourceMetricsMarshalers,
+      MarshallerObjectPools marshallerObjectPools) {
+
+    Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> resourceAndScopeMap =
+        groupByResourceAndScope(metricDataList, marshallerObjectPools);
+
+    resourceMetricsMarshalers.resizeAndClear(resourceAndScopeMap.size());
+
+    for (Map.Entry<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> entry :
+        resourceAndScopeMap.entrySet()) {
+      MutableResourceMetricsMarshaler mutableResourceMetricsMarshaler = marshallerObjectPools
+          .getMutableResourceMetricsMarshallerPool()
+          .borrowObject();
+
+      DynamicList<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalersList =
+          mutableResourceMetricsMarshaler.instrumentationScopeMetricsMarshalers;
+      instrumentationScopeMetricsMarshalersList.resizeAndClear(entry.getValue().size());
+
+      for (Map.Entry<InstrumentationScopeInfo, List<Marshaler>> entryIs :
+          entry.getValue().entrySet()) {
+        MutableInstrumentationScopeMetricsMarshaler mutableInstrumentationScopeMetricsMarshaler =
+            marshallerObjectPools
+                .getMutableInstrumentationScopeMetricsMarshalerPool()
+                .borrowObject();
+
+        mutableInstrumentationScopeMetricsMarshaler.set(
+            // Has internal cache and probably low cardinality hence no need to make it mutable
+            InstrumentationScopeMarshaler.create(entryIs.getKey()),
+
+            entryIs.getKey().getSchemaUrl(),
+            entryIs.getValue());
+
+        instrumentationScopeMetricsMarshalersList.add(mutableInstrumentationScopeMetricsMarshaler);
+      }
+
+      mutableResourceMetricsMarshaler.set(
+          // Has internal cache and probably low cardinality hence no need to make it mutable
+          ResourceMarshaler.create(entry.getKey()),
+
+          entry.getKey().getSchemaUrl(),
+          instrumentationScopeMetricsMarshalersList);
+
+      resourceMetricsMarshalers.add(mutableResourceMetricsMarshaler);
+    }
+  }
+
+  protected static Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>>
+  groupByResourceAndScope(
+      Collection<MetricData> metricDataList,
+      MarshallerObjectPools marshallerObjectPools) {
+    // TODO Asaf: Change the implementation to accept a provider of list so we can use dynamic list
+    // or duplicate the logic
+    return MarshalerUtil.groupByResourceAndScope(
+        metricDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        MetricData::getResource,
+        MetricData::getInstrumentationScopeInfo,
+        metricData -> MutableMetricMarshaler.create(metricData, marshallerObjectPools));
+  }
+
+  public MutableResourceMetricsMarshaler() {
+  }
+
+  private void set(
+      ResourceMarshaler resourceMarshaler,
+      String schemaUrl,
+      DynamicList<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalers) {
+    this.resourceMarshaler = resourceMarshaler;
+    this.schemaUrl = schemaUrl;
+    this.instrumentationScopeMetricsMarshalers = instrumentationScopeMetricsMarshalers;
+    this.size = calculateSize(resourceMarshaler, schemaUrl, instrumentationScopeMetricsMarshalers);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  protected ResourceMarshaler getResourceMarshaler() {
+    return resourceMarshaler;
+  }
+
+  @Override
+  protected String getSchemaUrl() {
+    return schemaUrl;
+  }
+
+  @Override
+  protected List<InstrumentationScopeMetricsMarshaler> getInstrumentationScopeMetricsMarshalers() {
+    return instrumentationScopeMetricsMarshalers;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableSumMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MutableSumMarshaler.java
@@ -1,0 +1,42 @@
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.ProtoEnumInfo;
+import io.opentelemetry.exporter.internal.otlp.MarshallerObjectPools;
+import io.opentelemetry.sdk.internal.DynamicList;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import java.util.List;
+
+public class MutableSumMarshaler extends SumMarshaler {
+  private DynamicList<NumberDataPointMarshaler> dataPoints;
+  private ProtoEnumInfo aggregationTemporality;
+  private boolean isMonotonic;
+  private int size;
+
+  static SumMarshaler create(
+      SumData<? extends PointData> sum,
+      MarshallerObjectPools marshallerObjectPools) {
+    DynamicList<NumberDataPointMarshaler> dataPointMarshalers =
+        MutableNumberDataPointMarshaler.createRepeated(sum.getPoints(), marshallerObjectPools);
+
+    MutableSumMarshaler mutableSumMarshaler = marshallerObjectPools
+        .getMutableSumMarshalerPool()
+        .borrowObject();
+
+    mutableSumMarshaler.set(
+        dataPointMarshalers,
+        MetricsMarshalerUtil.mapToTemporality(sum.getAggregationTemporality()),
+        sum.isMonotonic());
+    return mutableSumMarshaler;
+  }
+
+  void set(
+      DynamicList<NumberDataPointMarshaler> dataPoints,
+      ProtoEnumInfo aggregationTemporality,
+      boolean isMonotonic) {
+    this.dataPoints = dataPoints;
+    this.aggregationTemporality = aggregationTemporality;
+    this.isMonotonic = isMonotonic;
+    this.size = calculateSize(dataPoints, aggregationTemporality, isMonotonic);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointMarshaler.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.internal.otlp.metrics;
 
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
@@ -15,86 +16,43 @@ import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
-final class NumberDataPointMarshaler extends MarshalerWithSize {
-  private final long startTimeUnixNano;
-  private final long timeUnixNano;
+public abstract class NumberDataPointMarshaler extends Marshaler {
 
-  private final PointData value;
-  private final ProtoFieldInfo valueField;
-
-  private final ExemplarMarshaler[] exemplars;
-  private final KeyValueMarshaler[] attributes;
-
-  static NumberDataPointMarshaler[] createRepeated(Collection<? extends PointData> points) {
-    int numPoints = points.size();
-    NumberDataPointMarshaler[] marshalers = new NumberDataPointMarshaler[numPoints];
-    int index = 0;
-    for (PointData point : points) {
-      marshalers[index++] = NumberDataPointMarshaler.create(point);
-    }
-    return marshalers;
+  protected NumberDataPointMarshaler() {
+    super();
   }
 
-  static NumberDataPointMarshaler create(PointData point) {
-    ExemplarMarshaler[] exemplarMarshalers = ExemplarMarshaler.createRepeated(point.getExemplars());
-    KeyValueMarshaler[] attributeMarshalers =
-        KeyValueMarshaler.createForAttributes(point.getAttributes());
-
-    ProtoFieldInfo valueField;
-    if (point instanceof LongPointData) {
-      valueField = NumberDataPoint.AS_INT;
-    } else {
-      assert point instanceof DoublePointData;
-      valueField = NumberDataPoint.AS_DOUBLE;
-    }
-
-    return new NumberDataPointMarshaler(
-        point.getStartEpochNanos(),
-        point.getEpochNanos(),
-        point,
-        valueField,
-        exemplarMarshalers,
-        attributeMarshalers);
-  }
-
-  private NumberDataPointMarshaler(
-      long startTimeUnixNano,
-      long timeUnixNano,
-      PointData value,
-      ProtoFieldInfo valueField,
-      ExemplarMarshaler[] exemplars,
-      KeyValueMarshaler[] attributes) {
-    super(calculateSize(startTimeUnixNano, timeUnixNano, valueField, value, exemplars, attributes));
-    this.startTimeUnixNano = startTimeUnixNano;
-    this.timeUnixNano = timeUnixNano;
-    this.value = value;
-    this.valueField = valueField;
-    this.exemplars = exemplars;
-    this.attributes = attributes;
-  }
+  protected abstract long getStartTimeUnixNano();
+  protected abstract long getTimeUnixNano();
+  protected abstract PointData getValue();
+  protected abstract ProtoFieldInfo getValueField();
+  protected abstract List<ExemplarMarshaler> getExemplars();
+  protected abstract List<KeyValueMarshaler> getAttributes();
 
   @Override
   public void writeTo(Serializer output) throws IOException {
-    output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
-    output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);
-    if (valueField == NumberDataPoint.AS_INT) {
-      output.serializeFixed64Optional(valueField, ((LongPointData) value).getValue());
+    output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, getStartTimeUnixNano());
+    output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, getTimeUnixNano());
+    if (getValueField() == NumberDataPoint.AS_INT) {
+      output.serializeFixed64Optional(getValueField(), ((LongPointData) getValue()).getValue());
     } else {
-      output.serializeDoubleOptional(valueField, ((DoublePointData) value).getValue());
+      output.serializeDoubleOptional(getValueField(), ((DoublePointData) getValue()).getValue());
     }
-    output.serializeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
-    output.serializeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);
+    output.serializeRepeatedMessage(NumberDataPoint.EXEMPLARS, getExemplars());
+    output.serializeRepeatedMessage(NumberDataPoint.ATTRIBUTES, getAttributes());
   }
 
-  private static int calculateSize(
+  protected static int calculateSize(
       long startTimeUnixNano,
       long timeUnixNano,
       ProtoFieldInfo valueField,
       PointData value,
-      ExemplarMarshaler[] exemplars,
-      KeyValueMarshaler[] attributes) {
+      List<ExemplarMarshaler> exemplars,
+      List<KeyValueMarshaler> attributes) {
     int size = 0;
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, timeUnixNano);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsMarshaler.java
@@ -9,16 +9,10 @@ import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
-import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
 import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.ResourceMetrics;
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A Marshaler of ResourceMetrics.
@@ -26,82 +20,31 @@ import java.util.Map;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class ResourceMetricsMarshaler extends MarshalerWithSize {
-  private final ResourceMarshaler resourceMarshaler;
-  private final byte[] schemaUrl;
-  private final InstrumentationScopeMetricsMarshaler[] instrumentationScopeMetricsMarshalers;
+public abstract class ResourceMetricsMarshaler extends Marshaler {
 
-  /** Returns Marshalers of ResourceMetrics created by grouping the provided metricData. */
-  @SuppressWarnings("AvoidObjectArrays")
-  public static ResourceMetricsMarshaler[] create(Collection<MetricData> metricDataList) {
-    Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> resourceAndScopeMap =
-        groupByResourceAndScope(metricDataList);
-
-    ResourceMetricsMarshaler[] resourceMetricsMarshalers =
-        new ResourceMetricsMarshaler[resourceAndScopeMap.size()];
-    int posResource = 0;
-    for (Map.Entry<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>> entry :
-        resourceAndScopeMap.entrySet()) {
-      InstrumentationScopeMetricsMarshaler[] instrumentationLibrarySpansMarshalers =
-          new InstrumentationScopeMetricsMarshaler[entry.getValue().size()];
-      int posInstrumentation = 0;
-      for (Map.Entry<InstrumentationScopeInfo, List<Marshaler>> entryIs :
-          entry.getValue().entrySet()) {
-        instrumentationLibrarySpansMarshalers[posInstrumentation++] =
-            new InstrumentationScopeMetricsMarshaler(
-                InstrumentationScopeMarshaler.create(entryIs.getKey()),
-                MarshalerUtil.toBytes(entryIs.getKey().getSchemaUrl()),
-                entryIs.getValue());
-      }
-      resourceMetricsMarshalers[posResource++] =
-          new ResourceMetricsMarshaler(
-              ResourceMarshaler.create(entry.getKey()),
-              MarshalerUtil.toBytes(entry.getKey().getSchemaUrl()),
-              instrumentationLibrarySpansMarshalers);
-    }
-
-    return resourceMetricsMarshalers;
-  }
-
-  ResourceMetricsMarshaler(
-      ResourceMarshaler resourceMarshaler,
-      byte[] schemaUrl,
-      InstrumentationScopeMetricsMarshaler[] instrumentationScopeMetricsMarshalers) {
-    super(calculateSize(resourceMarshaler, schemaUrl, instrumentationScopeMetricsMarshalers));
-    this.resourceMarshaler = resourceMarshaler;
-    this.schemaUrl = schemaUrl;
-    this.instrumentationScopeMetricsMarshalers = instrumentationScopeMetricsMarshalers;
-  }
+  abstract protected ResourceMarshaler getResourceMarshaler();
+  abstract protected String getSchemaUrl();
+  abstract protected List<InstrumentationScopeMetricsMarshaler>
+    getInstrumentationScopeMetricsMarshalers();
 
   @Override
   public void writeTo(Serializer output) throws IOException {
-    output.serializeMessage(ResourceMetrics.RESOURCE, resourceMarshaler);
+    output.serializeMessage(ResourceMetrics.RESOURCE, getResourceMarshaler());
     output.serializeRepeatedMessage(
-        ResourceMetrics.SCOPE_METRICS, instrumentationScopeMetricsMarshalers);
-    output.serializeString(ResourceMetrics.SCHEMA_URL, schemaUrl);
+        ResourceMetrics.SCOPE_METRICS, getInstrumentationScopeMetricsMarshalers());
+    output.serializeString(ResourceMetrics.SCHEMA_URL, getSchemaUrl());
   }
 
-  private static int calculateSize(
+  protected static int calculateSize(
       ResourceMarshaler resourceMarshaler,
-      byte[] schemaUrl,
-      InstrumentationScopeMetricsMarshaler[] instrumentationScopeMetricsMarshalers) {
+      String schemaUrl,
+      List<InstrumentationScopeMetricsMarshaler> instrumentationScopeMetricsMarshalers) {
     int size = 0;
     size += MarshalerUtil.sizeMessage(ResourceMetrics.RESOURCE, resourceMarshaler);
-    size += MarshalerUtil.sizeBytes(ResourceMetrics.SCHEMA_URL, schemaUrl);
+    size += MarshalerUtil.sizeStringUtf8(ResourceMetrics.SCHEMA_URL, schemaUrl);
     size +=
         MarshalerUtil.sizeRepeatedMessage(
             ResourceMetrics.SCOPE_METRICS, instrumentationScopeMetricsMarshalers);
     return size;
-  }
-
-  private static Map<Resource, Map<InstrumentationScopeInfo, List<Marshaler>>>
-      groupByResourceAndScope(Collection<MetricData> metricDataList) {
-    return MarshalerUtil.groupByResourceAndScope(
-        metricDataList,
-        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
-        // two.
-        MetricData::getResource,
-        MetricData::getInstrumentationScopeInfo,
-        MetricMarshaler::create);
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DynamicList.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DynamicList.java
@@ -1,0 +1,93 @@
+package io.opentelemetry.sdk.internal;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+
+public class DynamicList<T> extends AbstractList<T> {
+
+  private static final int DEFAULT_SUBARRAY_CAPACITY = 10;
+  private final int subarrayCapacity;
+  private Object[][] arrays;
+  private int size;
+  private int arrayCount;
+
+  @SafeVarargs
+  public static <T> DynamicList<T> of(T... values) {
+    DynamicList<T> list = new DynamicList<>();
+    list.resizeAndClear(values.length);
+    for (int i = 0; i < values.length; i++) {
+      list.set(i, values[i]);
+    }
+    return list;
+  }
+
+  public static <T> DynamicList<T> empty() {
+    return new DynamicList<>();
+  }
+
+  public DynamicList() {
+    this(DEFAULT_SUBARRAY_CAPACITY);
+  }
+
+  public DynamicList(int subarrayCapacity) {
+    if (subarrayCapacity <= 0) {
+      throw new IllegalArgumentException("Subarray capacity must be positive");
+    }
+    this.subarrayCapacity = subarrayCapacity;
+    arrays = new Object[0][subarrayCapacity];
+    arrayCount = 0;
+    size = 0;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T get(int index) {
+    rangeCheck(index);
+    return (T) arrays[index / subarrayCapacity][index % subarrayCapacity];
+  }
+
+  @Override
+  public T set(int index, T element) {
+    rangeCheck(index);
+    T oldValue = get(index);
+    arrays[index / subarrayCapacity][index % subarrayCapacity] = element;
+    return oldValue;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  public void resizeAndClear(int newSize) {
+    if (newSize < 0) {
+      throw new IllegalArgumentException("New size must be non-negative");
+    }
+    ensureCapacity(newSize);
+    size = newSize;
+    for (int i = 0; i < newSize; i++) {
+      set(i, null);
+    }
+  }
+
+  private void ensureCapacity(int minCapacity) {
+    int requiredArrays = (minCapacity + subarrayCapacity - 1) / subarrayCapacity;
+    if (requiredArrays > arrayCount) {
+      arrays = Arrays.copyOf(arrays, requiredArrays);
+      for (int i = arrayCount; i < requiredArrays; i++) {
+        arrays[i] = new Object[subarrayCapacity];
+      }
+      arrayCount = requiredArrays;
+    }
+  }
+
+  private void rangeCheck(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException(outOfBoundsMsg(index));
+    }
+  }
+
+  private String outOfBoundsMsg(int index) {
+    return "Index: " + index + ", Size: " + size;
+  }
+}


### PR DESCRIPTION
This PR aims to showcase the idea of using pooled *mutable* Marshaler objects instead of immutable ones to add support to Memory Mode.

I created two classes for each `Marshaler`: a mutable and an immutable version. Both inherit from a base class containing the shared logic of serializing and computing the size.

This was a definitive rabbit hole. I started with `MetricsRequestMarshaller` and ended up much deeper than I wanted :)
So I simply stopped at some point, marking with TODOs where to continue, and left many code sections uncompiled.

The main goal is to see if this pattern makes sense.

Notable things:
* I wanted to eliminate byte[], so I switched it all to `String` since it already exists in the original `MetricData` input so that we can avoid memory allocation. I needed to convert the String to a `UTF-8` byte array without memory allocation. I copied the `Utf8` class from the protobuf library and trimmed it, only to have a conversion method from String to ByteBuffer containing the utf8 bytes. I reuse that ByteBuffer using thread-local. You don't need more than one.
* I switched from primitive array to List everywhere since I needed the same data structure between the immutable and mutable. I'm using a new `DynamicList` in the mutable version, which is like the `DynamicPrimitiveLongList.`  The idea is that whenever I need more room, I add a small ten-item array instead of duplicating it, which can sometimes be wasteful in space.

In short, the code is a rough draft, and attention must still be paid to the scope of methods and many other things - but in the future.
