### PR TITLE
Memory mode: Adding support for synchronous instruments - Counter

### DIFF
--- a/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/InstrumentGarbageCollectionBenchmarkTest.java
+++ b/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/InstrumentGarbageCollectionBenchmarkTest.java
@@ -108,6 +108,10 @@ public class InstrumentGarbageCollectionBenchmarkTest {
                 assertThat(immutableDataAllocRate).isNotNull().isNotZero();
                 assertThat(reusableDataAllocRate).isNotNull().isNotZero();
 
+                float dataAllocRateReductionPercentage =
+                    TestInstrumentType.valueOf(testInstrumentType)
+                        .getDataAllocRateReductionPercentage();
+
                 // If this test suddenly fails for you this means you have changed the code in a way
                 // that allocates more memory than before. You can find out where, by running
                 // ProfileBenchmark class and looking at the flame graph. Make sure to
@@ -116,7 +120,7 @@ public class InstrumentGarbageCollectionBenchmarkTest {
                     .describedAs(
                         "Aggregation temporality = %s, testInstrumentType = %s",
                         aggregationTemporality, testInstrumentType)
-                    .isCloseTo(99.8, Offset.offset(2.0));
+                    .isCloseTo(dataAllocRateReductionPercentage, Offset.offset(2.0));
               });
         });
   }

--- a/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/TestInstrumentType.java
+++ b/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/TestInstrumentType.java
@@ -9,8 +9,10 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.internal.state.tester.AsyncCounterTester;
+import io.opentelemetry.sdk.metrics.internal.state.tester.DoubleSumTester;
 import io.opentelemetry.sdk.metrics.internal.state.tester.ExplicitBucketHistogramTester;
 import io.opentelemetry.sdk.metrics.internal.state.tester.ExponentialHistogramTester;
+import io.opentelemetry.sdk.metrics.internal.state.tester.LongSumTester;
 import java.util.List;
 import java.util.Random;
 
@@ -32,11 +34,36 @@ public enum TestInstrumentType {
     InstrumentTester createInstrumentTester() {
       return new ExplicitBucketHistogramTester();
     }
+  },
+  LONG_SUM(/* dataAllocRateReductionPercentage= */ 97.3f) {
+    @Override
+    InstrumentTester createInstrumentTester() {
+      return new LongSumTester();
+    }
+  },
+  DOUBLE_SUM(/* dataAllocRateReductionPercentage= */ 97.3f) {
+    @Override
+    InstrumentTester createInstrumentTester() {
+      return new DoubleSumTester();
+    }
   };
 
-  abstract InstrumentTester createInstrumentTester();
+  private final float dataAllocRateReductionPercentage;
 
-  TestInstrumentType() {}
+  TestInstrumentType() {
+    this.dataAllocRateReductionPercentage = 99.8f; // default
+  }
+
+  // Some instruments have different reduction percentage.
+  TestInstrumentType(float dataAllocRateReductionPercentage) {
+    this.dataAllocRateReductionPercentage = dataAllocRateReductionPercentage;
+  }
+
+  float getDataAllocRateReductionPercentage() {
+    return dataAllocRateReductionPercentage;
+  }
+
+  abstract InstrumentTester createInstrumentTester();
 
   public interface InstrumentTester {
     Aggregation testedAggregation();

--- a/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/tester/DoubleSumTester.java
+++ b/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/tester/DoubleSumTester.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.state.tester;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.internal.state.TestInstrumentType;
+import java.util.List;
+import java.util.Random;
+
+public class DoubleSumTester implements TestInstrumentType.InstrumentTester {
+  private static final int measurementsPerAttributeSet = 1_000;
+
+  static class DoubleSumState implements TestInstrumentType.TestInstrumentsState {
+    DoubleCounter doubleCounter;
+  }
+
+  @Override
+  public Aggregation testedAggregation() {
+    return Aggregation.sum();
+  }
+
+  @Override
+  public TestInstrumentType.TestInstrumentsState buildInstruments(
+      double instrumentCount,
+      SdkMeterProvider sdkMeterProvider,
+      List<Attributes> attributesList,
+      Random random) {
+    DoubleSumState doubleSumState = new DoubleSumState();
+
+    Meter meter = sdkMeterProvider.meterBuilder("meter").build();
+    doubleSumState.doubleCounter = meter.counterBuilder("test.double.sum").ofDoubles().build();
+
+    return doubleSumState;
+  }
+
+  @SuppressWarnings("ForLoopReplaceableByForEach") // This is for GC sensitivity testing: no streams
+  @Override
+  public void recordValuesInInstruments(
+      TestInstrumentType.TestInstrumentsState testInstrumentsState,
+      List<Attributes> attributesList,
+      Random random) {
+    DoubleSumState state = (DoubleSumState) testInstrumentsState;
+
+    for (int j = 0; j < attributesList.size(); j++) {
+      Attributes attributes = attributesList.get(j);
+      for (int i = 0; i < measurementsPerAttributeSet; i++) {
+        state.doubleCounter.add(1.2f, attributes);
+      }
+    }
+  }
+}

--- a/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/tester/LongSumTester.java
+++ b/sdk/metrics/src/jmhBasedTest/java/io/opentelemetry/sdk/metrics/internal/state/tester/LongSumTester.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.internal.state.tester;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.internal.state.TestInstrumentType;
+import java.util.List;
+import java.util.Random;
+
+public class LongSumTester implements TestInstrumentType.InstrumentTester {
+  private static final int measurementsPerAttributeSet = 1_000;
+
+  static class LongSumState implements TestInstrumentType.TestInstrumentsState {
+    LongCounter longCounter;
+  }
+
+  @Override
+  public Aggregation testedAggregation() {
+    return Aggregation.sum();
+  }
+
+  @Override
+  public TestInstrumentType.TestInstrumentsState buildInstruments(
+      double instrumentCount,
+      SdkMeterProvider sdkMeterProvider,
+      List<Attributes> attributesList,
+      Random random) {
+    LongSumState longSumState = new LongSumState();
+
+    Meter meter = sdkMeterProvider.meterBuilder("meter").build();
+    longSumState.longCounter = meter.counterBuilder("test.long.sum").build();
+
+    return longSumState;
+  }
+
+  @SuppressWarnings("ForLoopReplaceableByForEach") // This is for GC sensitivity testing: no streams
+  @Override
+  public void recordValuesInInstruments(
+      TestInstrumentType.TestInstrumentsState testInstrumentsState,
+      List<Attributes> attributesList,
+      Random random) {
+    LongSumState state = (LongSumState) testInstrumentsState;
+
+    for (int j = 0; j < attributesList.size(); j++) {
+      Attributes attributes = attributesList.get(j);
+      for (int i = 0; i < measurementsPerAttributeSet; i++) {
+        state.longCounter.add(1, attributes);
+      }
+    }
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableDoublePointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableDoublePointData.java
@@ -93,15 +93,15 @@ public class MutableDoublePointData implements DoublePointData {
     if (this == o) {
       return true;
     }
-    if (o == null || !(o instanceof MutableDoublePointData)) {
+    if (!(o instanceof DoublePointData)) {
       return false;
     }
-    MutableDoublePointData pointData = (MutableDoublePointData) o;
-    return startEpochNanos == pointData.startEpochNanos
-        && epochNanos == pointData.epochNanos
-        && Double.doubleToLongBits(value) == Double.doubleToLongBits(pointData.value)
-        && Objects.equals(attributes, pointData.attributes)
-        && Objects.equals(exemplars, pointData.exemplars);
+    DoublePointData pointData = (DoublePointData) o;
+    return startEpochNanos == pointData.getStartEpochNanos()
+        && epochNanos == pointData.getEpochNanos()
+        && Double.doubleToLongBits(value) == Double.doubleToLongBits(pointData.getValue())
+        && Objects.equals(attributes, pointData.getAttributes())
+        && Objects.equals(exemplars, pointData.getExemplars());
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramBuckets.java
@@ -81,12 +81,12 @@ public final class MutableExponentialHistogramBuckets implements ExponentialHist
     if (o == this) {
       return true;
     }
-    if (o instanceof MutableExponentialHistogramBuckets) {
-      MutableExponentialHistogramBuckets that = (MutableExponentialHistogramBuckets) o;
+    if (o instanceof ExponentialHistogramBuckets) {
+      ExponentialHistogramBuckets that = (ExponentialHistogramBuckets) o;
       return this.scale == that.getScale()
           && this.offset == that.getOffset()
           && this.totalCount == that.getTotalCount()
-          && Objects.equals(this.bucketCounts, that.bucketCounts);
+          && Objects.equals(this.bucketCounts, that.getBucketCounts());
     }
     return false;
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableExponentialHistogramPointData.java
@@ -192,22 +192,22 @@ public final class MutableExponentialHistogramPointData implements ExponentialHi
     if (o == this) {
       return true;
     }
-    if (o instanceof MutableExponentialHistogramPointData) {
-      MutableExponentialHistogramPointData that = (MutableExponentialHistogramPointData) o;
-      return this.startEpochNanos == that.startEpochNanos
-          && this.epochNanos == that.epochNanos
-          && this.attributes.equals(that.attributes)
-          && this.scale == that.scale
-          && Double.doubleToLongBits(this.sum) == Double.doubleToLongBits(that.sum)
-          && this.count == that.count
-          && this.zeroCount == that.zeroCount
-          && this.hasMin == that.hasMin
-          && Double.doubleToLongBits(this.min) == Double.doubleToLongBits(that.min)
-          && this.hasMax == that.hasMax
-          && Double.doubleToLongBits(this.max) == Double.doubleToLongBits(that.max)
-          && this.positiveBuckets.equals(that.positiveBuckets)
-          && this.negativeBuckets.equals(that.negativeBuckets)
-          && this.exemplars.equals(that.exemplars);
+    if (o instanceof ExponentialHistogramPointData) {
+      ExponentialHistogramPointData that = (ExponentialHistogramPointData) o;
+      return this.startEpochNanos == that.getStartEpochNanos()
+          && this.epochNanos == that.getEpochNanos()
+          && this.attributes.equals(that.getAttributes())
+          && this.scale == that.getScale()
+          && Double.doubleToLongBits(this.sum) == Double.doubleToLongBits(that.getSum())
+          && this.count == that.getCount()
+          && this.zeroCount == that.getZeroCount()
+          && this.hasMin == that.hasMin()
+          && Double.doubleToLongBits(this.min) == Double.doubleToLongBits(that.getMin())
+          && this.hasMax == that.hasMax()
+          && Double.doubleToLongBits(this.max) == Double.doubleToLongBits(that.getMax())
+          && this.positiveBuckets.equals(that.getPositiveBuckets())
+          && this.negativeBuckets.equals(that.getNegativeBuckets())
+          && this.exemplars.equals(that.getExemplars());
     }
     return false;
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableLongPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/MutableLongPointData.java
@@ -91,15 +91,15 @@ public class MutableLongPointData implements LongPointData {
     if (this == o) {
       return true;
     }
-    if (o == null || !(o instanceof MutableLongPointData)) {
+    if (!(o instanceof LongPointData)) {
       return false;
     }
-    MutableLongPointData that = (MutableLongPointData) o;
-    return value == that.value
-        && startEpochNanos == that.startEpochNanos
-        && epochNanos == that.epochNanos
-        && Objects.equals(attributes, that.attributes)
-        && Objects.equals(exemplars, that.exemplars);
+    LongPointData that = (LongPointData) o;
+    return value == that.getValue()
+        && startEpochNanos == that.getStartEpochNanos()
+        && epochNanos == that.getEpochNanos()
+        && Objects.equals(attributes, that.getAttributes())
+        && Objects.equals(exemplars, that.getExemplars());
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/SumAggregation.java
@@ -54,7 +54,8 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
                           Clock.getDefault(),
                           Runtime.getRuntime().availableProcessors(),
                           RandomSupplier.platformDefault()));
-          return (Aggregator<T, U>) new LongSumAggregator(instrumentDescriptor, reservoirFactory);
+          return (Aggregator<T, U>)
+              new LongSumAggregator(instrumentDescriptor, reservoirFactory, memoryMode);
         }
       case DOUBLE:
         {
@@ -66,7 +67,8 @@ public final class SumAggregation implements Aggregation, AggregatorFactory {
                           Clock.getDefault(),
                           Runtime.getRuntime().availableProcessors(),
                           RandomSupplier.platformDefault()));
-          return (Aggregator<T, U>) new DoubleSumAggregator(instrumentDescriptor, reservoirFactory);
+          return (Aggregator<T, U>)
+              new DoubleSumAggregator(instrumentDescriptor, reservoirFactory, memoryMode);
         }
     }
     throw new IllegalArgumentException("Invalid instrument value type");


### PR DESCRIPTION
# Epic
This is one of many PRs that implement #5105. See the complete plan [here](https://github.com/open-telemetry/opentelemetry-java/issues/5105#issuecomment-1739237240).
Specifically, this PR adds the implementation of `MemoryMode` for the synchronous instrument: counter.

# What was done here?
This PR, relative to Exponential and Explicit Histogram PR, is rather trivial. It contains:
* Using a reusable point for returning the result on `doAggregateThenMaybeReset` for both `LongSumAggregator.Handle` and `DoubleSumAggregator.Handle`.
* Adding matching garbage collection benchmark tests
* Adjusting and adding tests for `LongSumAggregator` and `DoubleSumAggregator`
* Allowed to set the normalized allocate rate reduction percentage since, for both those aggregations, there was only a single allocation per Attributes, hence the reduction could not reach 99.8 as it did for the previous Exponential and Explicit Histogram aggregations.



