### PR TITLE
Define CODECOV token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         if: ${{ matrix.coverage }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.coverage }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,7 +77,7 @@ Create a PR against the main branch with the changes.
 
 ## Credentials
 
-The following credentials are required for publishing (and automatically set in Github Actions):
+The following credentials are required for building or publishing (and automatically set in Github Actions):
 
 * `GPG_PRIVATE_KEY` and `GPG_PASSWORD`: GPG private key and password for signing.
 * `SONATYPE_USER` and `SONATYPE_KEY`: Sonatype username and password.
@@ -89,6 +89,9 @@ The following credentials are required for publishing (and automatically set in 
   * To obtain `SONATYPE_USER` and `SONATYPE_KEY` for your account, login
     to [oss.sonatype.org](https://oss.sonatype.org/) and navigate to Profile -> User Token -> Access
     User Token.
+* `CODECOV_TOKEN`: Token used for uploading codecov reports. Each maintainer can obtain their own
+  credential from codecov as
+  described [here](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions).
 
 Additionally, credentials are stored with maintainers via
 the [OpenTelemetry 1Password](https://opentelemetry.1password.com/signin) account. The following


### PR DESCRIPTION
See @trask's comment here: https://github.com/open-telemetry/opentelemetry-java/pull/6183#issuecomment-1922296811

As of [codecov 4.0.0](https://github.com/codecov/codecov-action/releases/tag/v4.0.0): 

> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token). This [doc](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions) shows instructions on how to add the Codecov token.

My read of this is that builds for this repo will need the token to upload, but PRs from forks don't need it. 