### PR TITLE
#6207 add check to ensure that StatusCode.OK cannot be overwritten

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -395,6 +395,9 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
         logger.log(Level.FINE, "Calling setStatus() on an ended Span.");
         return this;
       }
+      if (statusCode == StatusCode.OK) {
+        return this;
+      }
       this.status = StatusData.create(statusCode, description);
     }
     return this;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -395,7 +395,7 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
         logger.log(Level.FINE, "Calling setStatus() on an ended Span.");
         return this;
       }
-      if (statusCode == StatusCode.OK) {
+      if (this.status.getStatusCode() == StatusCode.OK) {
         return this;
       }
       this.status = StatusData.create(statusCode, description);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -1178,6 +1178,16 @@ class SdkSpanTest {
     verify(spanProcessor, never()).onEnd(any());
   }
 
+  @Test
+  void cannotOverrideStatusCodeOK() {
+    SdkSpan span = createTestRootSpan();
+    span.setStatus(StatusCode.OK);
+    span.setStatus(StatusCode.ERROR);
+    assertThat(span.toSpanData().getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+    span.setStatus(StatusCode.UNSET);
+    assertThat(span.toSpanData().getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+  }
+
   private SdkSpan createTestSpanWithAttributes(Map<AttributeKey, Object> attributes) {
     SpanLimits spanLimits = SpanLimits.getDefault();
     AttributesMap attributesMap =


### PR DESCRIPTION
Adds a check to ensure that StatusCode.OK cannot be overwritten in SdkSpan.java
Fix for #6207 