### PR TITLE
#6207 Ensure Span Status Cannot Be Updated After StatusCode.OK Is Set

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -394,6 +394,9 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
       if (hasEnded) {
         logger.log(Level.FINE, "Calling setStatus() on an ended Span.");
         return this;
+      } else if (this.status.getStatusCode() == StatusCode.OK) {
+        logger.log(Level.FINE, "Calling setStatus() on a Span that is already set to OK.");
+        return this;
       }
       this.status = StatusData.create(statusCode, description);
     }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -1178,6 +1178,17 @@ class SdkSpanTest {
     verify(spanProcessor, never()).onEnd(any());
   }
 
+  @Test
+  void setStatusCannotOverrideStatusOK() {
+    SdkSpan testSpan = createTestRootSpan();
+    testSpan.setStatus(StatusCode.OK);
+    assertThat(testSpan.toSpanData().getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+    testSpan.setStatus(StatusCode.ERROR);
+    assertThat(testSpan.toSpanData().getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+    testSpan.setStatus(StatusCode.UNSET);
+    assertThat(testSpan.toSpanData().getStatus().getStatusCode()).isEqualTo(StatusCode.OK);
+  }
+
   private SdkSpan createTestSpanWithAttributes(Map<AttributeKey, Object> attributes) {
     SpanLimits spanLimits = SpanLimits.getDefault();
     AttributesMap attributesMap =


### PR DESCRIPTION
Add a check to ensure that calling `Span.setStatus()` will do nothing if StatusCode.OK has previously been set on the Span.
Add a unit test to ensure this functionality is/remains correct.

Should fix #6207 