### PR TITLE
optimize resource detection 

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.resources.Resource  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.resources.Resource mergeReverse(io.opentelemetry.sdk.resources.Resource)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.util.Set<io.opentelemetry.api.common.AttributeKey<?>> supportedKeys()

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.sdk.autoconfigure.spi;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * A service provider interface (SPI) for providing a {@link Resource} that is merged into the
@@ -14,4 +17,15 @@ import io.opentelemetry.sdk.resources.Resource;
 public interface ResourceProvider extends Ordered {
 
   Resource createResource(ConfigProperties config);
+
+  /**
+   * Returns the set of attribute keys that this provider supports. This is used to determine if a
+   * provider should be used to create a resource.
+   *
+   * @return the set of attribute keys that this provider supports - an empty set indicates that the
+   *     provider should always be used
+   */
+  default Set<AttributeKey<?>> supportedKeys() {
+    return Collections.emptySet();
+  }
 }

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/FirstResourceProvider.java
@@ -7,16 +7,25 @@ package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.Set;
 
-public class FirstResourceProvider implements ConditionalResourceProvider {
+public class FirstResourceProvider implements ResourceProvider {
+
+  @SuppressWarnings("NonFinalStaticField")
+  public static int calls = 0;
+
+  public static final AttributeKey<String> KEY = stringKey("service.name");
 
   @Override
   public Resource createResource(ConfigProperties config) {
-    return Resource.create(Attributes.of(stringKey("service.name"), "test-service"));
+    calls++;
+    return Resource.create(Attributes.of(KEY, "test-service"));
   }
 
   @Override
@@ -25,7 +34,7 @@ public class FirstResourceProvider implements ConditionalResourceProvider {
   }
 
   @Override
-  public boolean shouldApply(ConfigProperties config, Resource existing) {
-    return !config.getBoolean("skip-first-resource-provider", false);
+  public Set<AttributeKey<?>> supportedKeys() {
+    return Collections.singleton(KEY);
   }
 }

--- a/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testConditionalResourceProvider/java/io/opentelemetry/sdk/autoconfigure/provider/SecondResourceProvider.java
@@ -7,16 +7,21 @@ package io.opentelemetry.sdk.autoconfigure.provider;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.Set;
 
 public class SecondResourceProvider implements ConditionalResourceProvider {
 
+  public static final AttributeKey<String> KEY = stringKey("service.name");
+
   @Override
   public Resource createResource(ConfigProperties config) {
-    return Resource.create(Attributes.of(stringKey("service.name"), "test-service-2"));
+    return Resource.create(Attributes.of(KEY, "test-service-2"));
   }
 
   @Override
@@ -25,8 +30,12 @@ public class SecondResourceProvider implements ConditionalResourceProvider {
   }
 
   @Override
+  public Set<AttributeKey<?>> supportedKeys() {
+    return Collections.singleton(KEY);
+  }
+
+  @Override
   public boolean shouldApply(ConfigProperties config, Resource existing) {
-    String serviceName = existing.getAttribute(stringKey("service.name"));
-    return serviceName == null || "unknown_service:java".equals(serviceName);
+    return !config.getBoolean("skip-second-resource-provider", false);
   }
 }


### PR DESCRIPTION
optimize resource detection by skipping providers that would add no new keys

Most of the functionality is already working with the following pattern: give the lower priority detector a higher order, so that it runs later an can check if it should be skipped 

- use [shouldApply](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java#L70C18-L70C29)
- use [later order](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java#L131-L134)

However, the [environment resource](https://github.com/open-telemetry/opentelemetry-java/blob/bcec7e9380c943be3c3764efa22fbb10ddd6473f/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/EnvironmentResourceProvider.java#L17) provider runs last - so if the user adds the service name using `service.name` - the jar service name provider would still be run in vain. 