### PR TITLE
Fault in SdkSpan.events

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -521,7 +521,7 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
 
   @GuardedBy("lock")
   private List<EventData> getImmutableTimedEvents() {
-    if (events == null || events.isEmpty()) {
+    if (events == null) {
       return Collections.emptyList();
     }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -72,7 +72,7 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
   // List of recorded events.
   @GuardedBy("lock")
   @Nullable
-  private List<EventData> events; // faulted in
+  private List<EventData> events;
 
   // Number of events recorded.
   @GuardedBy("lock")

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -71,7 +71,8 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
 
   // List of recorded events.
   @GuardedBy("lock")
-  private final List<EventData> events;
+  @Nullable
+  private List<EventData> events; // faulted in
 
   // Number of events recorded.
   @GuardedBy("lock")
@@ -126,7 +127,6 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
     this.clock = clock;
     this.startEpochNanos = startEpochNanos;
     this.attributes = attributes;
-    this.events = new ArrayList<>();
     this.spanLimits = spanLimits;
   }
 
@@ -378,6 +378,9 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
         logger.log(Level.FINE, "Calling addEvent() on an ended Span.");
         return;
       }
+      if (events == null) {
+        events = new ArrayList<>();
+      }
       if (events.size() < spanLimits.getMaxNumberOfEvents()) {
         events.add(timedEvent);
       }
@@ -518,7 +521,7 @@ final class SdkSpan implements ReadWriteSpan, ExtendedSpan {
 
   @GuardedBy("lock")
   private List<EventData> getImmutableTimedEvents() {
-    if (events.isEmpty()) {
+    if (events == null || events.isEmpty()) {
       return Collections.emptyList();
     }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -655,7 +655,6 @@ class SdkSpanTest {
   @Test
   void addEvent() {
     SdkSpan span = createTestRootSpan();
-    assertThat(span.toSpanData().getEvents()).isEmpty();
     try {
       span.addEvent("event1");
       span.addEvent("event2", Attributes.of(stringKey("e1key"), "e1Value"));

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanTest.java
@@ -655,6 +655,7 @@ class SdkSpanTest {
   @Test
   void addEvent() {
     SdkSpan span = createTestRootSpan();
+    assertThat(span.toSpanData().getEvents()).isEmpty();
     try {
       span.addEvent("event1");
       span.addEvent("event2", Attributes.of(stringKey("e1key"), "e1Value"));


### PR DESCRIPTION
Most spans don't have events [citation needed].  So, fault it in like `attributes` and `links` rather than waste time/GC thrash allocating the storage for them.