### PR TITLE
Return AutoConfiguredOpenTelemetrySdkBuilder instead of the base type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ instead.
 
 * Autoconfigure accepts encoded header values for OTLP exporters
   ([#6164](https://github.com/open-telemetry/opentelemetry-java/pull/6164))
+* Return implementation type from `AutoConfiguredOpenTelemetrySdkBuilder.addLogRecordProcessorCustomizer`
+  ([#6248](https://github.com/open-telemetry/opentelemetry-java/pull/6248))
 
 #### Incubator
 

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -54,6 +54,16 @@ class AllowNewAbstractMethodOnAutovalueClasses : AbstractRecordingSeenMembers() 
 class SourceIncompatibleRule : AbstractRecordingSeenMembers() {
   override fun maybeAddViolation(member: JApiCompatibility): Violation? {
     if (!member.isSourceCompatible()) {
+
+      // TODO: remove after 1.36.0 is released, see https://github.com/open-telemetry/opentelemetry-java/pull/6248
+      if (member.compatibilityChanges.isEmpty() &&
+        member is JApiClass &&
+        member.newClass.get().name.equals("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder")
+      ) {
+        return null
+      }
+      // end of suppression
+
       return Violation.error(member, "Not source compatible")
     }
     return null

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -1,16 +1,8 @@
 import com.google.auto.value.AutoValue
-import japicmp.model.JApiChangeStatus
-import japicmp.model.JApiClass
-import japicmp.model.JApiCompatibility
-import japicmp.model.JApiCompatibilityChange
-import japicmp.model.JApiMethod
+import japicmp.model.*
 import me.champeau.gradle.japicmp.JapicmpTask
 import me.champeau.gradle.japicmp.report.Violation
-import me.champeau.gradle.japicmp.report.stdrules.AbstractRecordingSeenMembers
-import me.champeau.gradle.japicmp.report.stdrules.BinaryIncompatibleRule
-import me.champeau.gradle.japicmp.report.stdrules.RecordSeenMembersSetup
-import me.champeau.gradle.japicmp.report.stdrules.SourceCompatibleRule
-import me.champeau.gradle.japicmp.report.stdrules.UnchangedMemberRule
+import me.champeau.gradle.japicmp.report.stdrules.*
 
 
 plugins {
@@ -52,19 +44,56 @@ class AllowNewAbstractMethodOnAutovalueClasses : AbstractRecordingSeenMembers() 
 }
 
 class SourceIncompatibleRule : AbstractRecordingSeenMembers() {
+
+  fun ignoreAddLogRecordProcessorCustomizerReturnTypeChange(member: JApiCompatibility): Violation? {
+    if (member is JApiClass &&
+      member.newClass.get().name.equals("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder") &&
+      member.isChangeCausedByClassElement
+    ) {
+      // member.isChangeCausedByClassElement check above
+      // limits source of changes to fields, methods and constructors
+
+      for (method in member.methods) {
+        if (!method.isSourceCompatible()) {
+          // addLogRecordProcessorCustomizer method had a return type change from base to impl class,
+          // japicmp (correctly) doesn't consider it as a METHOD_RETURN_TYPE_CHANGED
+          // compatibility issue. But still thinks that something wrong.
+          // Since it thinks that method did not change, it reports it as class-level violation,
+          // and we need to suppress it, but keep other checks on.
+          if (method.name.equals("addLogRecordProcessorCustomizer") &&
+            method.compatibilityChanges.isEmpty() &&
+            method.changeStatus == JApiChangeStatus.UNCHANGED) {
+            return null;
+          }
+          return Violation.error(method, "Method is not source compatible: $method")
+        }
+      }
+
+      for (field in member.fields) {
+        if (!field.isSourceCompatible()) {
+          return Violation.error(field, "Field is not source compatible: $field")
+        }
+      }
+
+      for (constructor in member.constructors) {
+        if (!constructor.isSourceCompatible()) {
+          return Violation.error(constructor, "Constructor is not source compatible: $constructor")
+        }
+      }
+    }
+
+    return Violation.error(member, "Not source compatible: $member")
+  }
+
   override fun maybeAddViolation(member: JApiCompatibility): Violation? {
     if (!member.isSourceCompatible()) {
-
       // TODO: remove after 1.36.0 is released, see https://github.com/open-telemetry/opentelemetry-java/pull/6248
-      if (member.compatibilityChanges.isEmpty() &&
-        member is JApiClass &&
-        member.newClass.get().name.equals("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder")
-      ) {
-        return null
+      if (member.compatibilityChanges.isEmpty()) {
+        return ignoreAddLogRecordProcessorCustomizerReturnTypeChange(member)
       }
       // end of suppression
 
-      return Violation.error(member, "Not source compatible")
+      return Violation.error(member, "Not source compatible: $member")
     }
     return null
   }

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-extension-autoconfigure.txt
@@ -1,4 +1,5 @@
 Comparing source compatibility of  against 
-***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder  (not serializable)
+**** MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===* UNCHANGED METHOD: PUBLIC SYNTHETIC (<- NON_SYNTHETIC) BRIDGE (<- NON_BRIDGE) io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer addLogRecordProcessorCustomizer(java.util.function.BiFunction(<- <? super io.opentelemetry.sdk.logs.LogRecordProcessor,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.logs.LogRecordProcessor>))
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder addMetricReaderCustomizer(java.util.function.BiFunction<? super io.opentelemetry.sdk.metrics.export.MetricReader,io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties,? extends io.opentelemetry.sdk.metrics.export.MetricReader>)

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -344,7 +344,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
    * <p>Multiple calls will execute the customizers in order.
    */
   @Override
-  public AutoConfigurationCustomizer addLogRecordProcessorCustomizer(
+  public AutoConfiguredOpenTelemetrySdkBuilder addLogRecordProcessorCustomizer(
       BiFunction<? super LogRecordProcessor, ConfigProperties, ? extends LogRecordProcessor>
           logRecordProcessorCustomizer) {
     requireNonNull(logRecordProcessorCustomizer, "logRecordProcessorCustomizer");


### PR DESCRIPTION
Nit: `AutoConfiguredOpenTelemetrySdkBuilder.addLogRecordProcessorCustomizer` returned base type `AutoConfigurationCustomizer` instead of impl one breaking the return chaining.

```java
sdkBuilder
  .addLogRecordProcessorCustomizer((processor, props) -> ...)
  .build() // not found :(
```

This PR fixes the return type.