### PR TITLE
add new ResourceDetector

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ResourceDetector.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ResourceDetector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi.internal;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface ResourceDetector<D> extends Ordered {
+  /** Read the data for the resource attributes. */
+  Optional<D> readData(ConfigProperties config);
+
+  /** Registers the attributes that this resource detector can provide. */
+  void registerAttributes(Builder<D> builder);
+
+  /** Greater order means lower priority. The default order is 0. */
+  @Override
+  int order();
+
+  /** Returns the name of this resource detector. */
+  String name();
+
+  /**
+   * Returns whether this resource detector is enabled by default. If not, it will only be used if
+   * explicitly enabled in the configuration.
+   */
+  default boolean defaultEnabled() {
+    return true;
+  }
+
+  /** A builder for registering attributes that a resource detector can provide. */
+  interface Builder<D> {
+    /**
+     * Adds an attribute to the resource.
+     *
+     * @param key the attribute key
+     * @param getter a function that returns the value of the attribute from the data that is read
+     *     by {@link ResourceDetector#readData(ConfigProperties)}
+     * @return this builder
+     * @param <T> the type of the attribute
+     */
+    <T> Builder<D> add(AttributeKey<T> key, Function<D, Optional<T>> getter);
+  }
+}

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ResourceDetector.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ResourceDetector.java
@@ -20,7 +20,9 @@ public interface ResourceDetector<D> extends Ordered {
 
   /** Greater order means lower priority. The default order is 0. */
   @Override
-  int order();
+  default int order() {
+    return 0;
+  }
 
   /** Returns the name of this resource detector. */
   String name();

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -230,7 +230,7 @@ class ConfigPropertiesTest {
     expectedMap.put("bear", "growl");
 
     Map<String, String> map = makeTestProps();
-    ConfigProperties properties = DefaultConfigProperties.create(map);
+    ConfigProperties properties = DefaultConfigProperties.createFromMap(map);
     assertThat(properties.getBoolean("test.boolean", false)).isTrue();
     assertThat(properties.getString("test.string", "nah")).isEqualTo("str");
     assertThat(properties.getDouble("test.double", 65.535)).isEqualTo(5.4);
@@ -244,7 +244,7 @@ class ConfigPropertiesTest {
 
   @Test
   void defaultMethodsFallBack() {
-    ConfigProperties properties = DefaultConfigProperties.create(emptyMap());
+    ConfigProperties properties = DefaultConfigProperties.createFromMap(emptyMap());
     assertThat(properties.getBoolean("foo", true)).isTrue();
     assertThat(properties.getString("foo", "bar")).isEqualTo("bar");
     assertThat(properties.getDouble("foo", 65.535)).isEqualTo(65.535);
@@ -255,7 +255,7 @@ class ConfigPropertiesTest {
 
   @Test
   void defaultCollectionTypes() {
-    ConfigProperties properties = DefaultConfigProperties.create(emptyMap());
+    ConfigProperties properties = DefaultConfigProperties.createFromMap(emptyMap());
     assertThat(properties.getList("foo", Arrays.asList("1", "2", "3")))
         .containsExactly("1", "2", "3");
     assertThat(properties.getList("foo")).isEmpty();

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/ResourceDetectorReader.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/ResourceDetectorReader.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.internal;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public final class ResourceDetectorReader<D> {
+
+  private final ResourceDetector<D> resourceDetector;
+
+  public class AttributeBuilder implements ResourceDetector.Builder<D> {
+
+    private AttributeBuilder() {}
+
+    @Override
+    public <T> AttributeBuilder add(AttributeKey<T> key, Function<D, Optional<T>> getter) {
+      attributeGetters.put((AttributeKey) key, Objects.requireNonNull((Function) getter));
+      return this;
+    }
+  }
+
+  private final Map<AttributeKey<Object>, Function<D, Optional<?>>> attributeGetters =
+      new HashMap<>();
+
+  public ResourceDetectorReader(ResourceDetector<D> resourceDetector) {
+    this.resourceDetector = resourceDetector;
+    resourceDetector.registerAttributes(new AttributeBuilder());
+  }
+
+  public boolean shouldApply(ConfigProperties config, Resource existing) {
+    Map<String, String> resourceAttributes = getResourceAttributes(config);
+    return attributeGetters.keySet().stream()
+        .allMatch(key -> shouldUpdate(config, existing, key, resourceAttributes));
+  }
+
+  public Resource createResource(ConfigProperties config, Resource existing) {
+    return resourceDetector
+        .readData(config)
+        .map(
+            data -> {
+              Map<String, String> resourceAttributes = getResourceAttributes(config);
+              AttributesBuilder builder = Attributes.builder();
+              attributeGetters.entrySet().stream()
+                  .filter(e -> shouldUpdate(config, existing, e.getKey(), resourceAttributes))
+                  .forEach(
+                      e ->
+                          e.getValue()
+                              .apply(data)
+                              .ifPresent(value -> putAttribute(builder, e.getKey(), value)));
+              return Resource.create(builder.build());
+            })
+        .orElse(Resource.empty());
+  }
+
+  private static <T> void putAttribute(AttributesBuilder builder, AttributeKey<T> key, T value) {
+    builder.put(key, value);
+  }
+
+  private static Map<String, String> getResourceAttributes(ConfigProperties config) {
+    return config.getMap("otel.resource.attributes");
+  }
+
+  private static boolean shouldUpdate(
+      ConfigProperties config,
+      Resource existing,
+      AttributeKey<?> key,
+      Map<String, String> resourceAttributes) {
+    if (resourceAttributes.containsKey(key.getKey())) {
+      return false;
+    }
+
+    Object value = existing.getAttribute(key);
+
+    if (key.getKey().equals("service.name")) {
+      return config.getString("otel.service.name") == null && "unknown_service:java".equals(value);
+    }
+
+    return value == null;
+  }
+}

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -41,7 +41,7 @@ class ResourceConfigurationTest {
 
     assertThat(
             ResourceConfiguration.configureResource(
-                DefaultConfigProperties.create(props),
+                DefaultConfigProperties.createFromMap(props),
                 SpiHelper.create(ResourceConfigurationTest.class.getClassLoader()),
                 (r, c) -> r))
         .isEqualTo(

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFullTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationFullTest.java
@@ -83,7 +83,16 @@ class ResourceConfigurationFullTest {
   @Test
   void configureResource_UserConfiguredService() {
     Map<String, String> customConfigs = new HashMap<>(1);
-    customConfigs.put("service.name", "user");
+    customConfigs.put("otel.resource.attributes", "service.name=user");
+    Attributes attributes = configureResource(customConfigs);
+
+    assertThat(attributes.get(AttributeKey.stringKey("service.name"))).isEqualTo("user");
+  }
+
+  @Test
+  void configureResource_UserConfiguredServiceUsingService() {
+    Map<String, String> customConfigs = new HashMap<>(1);
+    customConfigs.put("otel.service.name", "user");
     Attributes attributes = configureResource(customConfigs);
 
     assertThat(attributes.get(AttributeKey.stringKey("service.name"))).isEqualTo("user");

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -68,9 +68,7 @@ class ResourceConfigurationTest {
     customConfigs.put(
         "otel.java.enabled.resource.providers",
         "io.opentelemetry.sdk.autoconfigure.provider.TestAnimalResourceProvider");
-    customConfigs.put(
-        "otel.java.disabled.resource.providers",
-        "io.opentelemetry.sdk.extension.resources.TestColorResourceProvider");
+    customConfigs.put("otel.resource.provider.color.enabled", "false");
     Attributes attributes =
         ResourceConfiguration.configureResource(
                 DefaultConfigProperties.create(customConfigs), spiHelper, (r, c) -> r)
@@ -83,9 +81,7 @@ class ResourceConfigurationTest {
   @Test
   void configureResource_OnlyDisabled() {
     Map<String, String> customConfigs = new HashMap<>(1);
-    customConfigs.put(
-        "otel.java.disabled.resource.providers",
-        "io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider");
+    customConfigs.put("otel.resource.provider.color.enabled", "false");
     Attributes attributes =
         ResourceConfiguration.configureResource(
                 DefaultConfigProperties.create(customConfigs), spiHelper, (r, c) -> r)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceDetector.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceDetector.java
@@ -10,7 +10,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector;
 import java.util.Optional;
 
-public class TestColorResourceProvider implements ResourceDetector<String> {
+public class TestColorResourceDetector implements ResourceDetector<String> {
 
   @Override
   public Optional<String> readData(ConfigProperties config) {

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceProvider.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestColorResourceProvider.java
@@ -6,14 +6,24 @@
 package io.opentelemetry.sdk.autoconfigure.provider;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
-import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector;
+import java.util.Optional;
 
-public class TestColorResourceProvider implements ResourceProvider {
+public class TestColorResourceProvider implements ResourceDetector<String> {
+
   @Override
-  public Resource createResource(ConfigProperties config) {
-    return Resource.create(Attributes.of(AttributeKey.stringKey("color"), "blue"));
+  public Optional<String> readData(ConfigProperties config) {
+    return Optional.of("blue");
+  }
+
+  @Override
+  public void registerAttributes(Builder<String> builder) {
+    builder.add(AttributeKey.stringKey("color"), Optional::of);
+  }
+
+  @Override
+  public String name() {
+    return "color";
   }
 }

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestServiceNameResourceDetector.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/provider/TestServiceNameResourceDetector.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.provider;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector;
+import java.util.Optional;
+
+public class TestServiceNameResourceDetector implements ResourceDetector<String> {
+
+  @Override
+  public Optional<String> readData(ConfigProperties config) {
+    return Optional.of("cart");
+  }
+
+  @Override
+  public void registerAttributes(Builder<String> builder) {
+    builder.add(AttributeKey.stringKey("service.name"), Optional::of);
+  }
+
+  @Override
+  public String name() {
+    return "name";
+  }
+}

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,2 +1,1 @@
 io.opentelemetry.sdk.autoconfigure.provider.TestAnimalResourceProvider
-io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider

--- a/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ResourceDetector
@@ -1,1 +1,2 @@
-io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceProvider
+io.opentelemetry.sdk.autoconfigure.provider.TestColorResourceDetector
+io.opentelemetry.sdk.autoconfigure.provider.TestServiceNameResourceDetector


### PR DESCRIPTION
Based on 
- a [discussion](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1074) about having resource providers that can be disabled by default
- and common pitfalls when implementing resource providers

This PR proposes an alternative interface for `ResourceProvider`, called `ResourceDetector`.

- [`name` and `defaultEnabled`](https://github.com/open-telemetry/opentelemetry-java/pull/6250/files#diff-fbde8a1a93c350dce1c56d4bab5639faab75e1cfd714bc8ab12b16964075000fR27-R36) implement the "disabled by default" feature in the same pattern as for instrumentations, as suggested [here](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1074#issuecomment-1960098684)
- [`readData` and `registerAttributes`](https://github.com/open-telemetry/opentelemetry-java/pull/6250/files#diff-fbde8a1a93c350dce1c56d4bab5639faab75e1cfd714bc8ab12b16964075000fR16-R19) address the common pitfalls.

Separating both aspects into different PRs would be possible, but would probably make the end result harder to understand.

Note: maybe `ResourceProvider` should be deprecated - but that's a separate question. 