### PR TITLE
Remove domain from event api.

### DIFF
--- a/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitterProvider.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/DefaultEventEmitterProvider.java
@@ -35,11 +35,6 @@ class DefaultEventEmitterProvider implements EventEmitterProvider {
     }
 
     @Override
-    public EventEmitterBuilder setEventDomain(String eventDomain) {
-      return this;
-    }
-
-    @Override
     public EventEmitter build() {
       return DefaultEventEmitter.getInstance();
     }

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitter.java
@@ -15,8 +15,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <pre>{@code
  * class MyClass {
- *   private final EventEmitter eventEmitter = openTelemetryEventEmitterProvider.eventEmitterBuilder("scope-name")
- *         .setEventDomain("acme.observability")
+ *   private final EventEmitter eventEmitter = openTelemetryEventEmitterProvider
+ *         .eventEmitterBuilder("scope-name")
  *         .build();
  *
  *   void doWork() {

--- a/api/events/src/main/java/io/opentelemetry/api/events/EventEmitterBuilder.java
+++ b/api/events/src/main/java/io/opentelemetry/api/events/EventEmitterBuilder.java
@@ -15,15 +15,6 @@ package io.opentelemetry.api.events;
 public interface EventEmitterBuilder {
 
   /**
-   * Sets the event domain. Event domain is not part of {@link EventEmitter} identity.
-   *
-   * @param eventDomain The event domain, which acts as a namespace for event names. Within a
-   *     particular event domain, event name defines a particular class or type of event.
-   * @return this
-   */
-  EventEmitterBuilder setEventDomain(String eventDomain);
-
-  /**
    * Set the scope schema URL of the resulting {@link EventEmitter}. Schema URL is part of {@link
    * EventEmitter} identity.
    *

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterProviderTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterProviderTest.java
@@ -23,7 +23,6 @@ class DefaultEventEmitterProviderTest {
             () ->
                 provider
                     .eventEmitterBuilder("scope-name")
-                    .setEventDomain("event-domain")
                     .setInstrumentationVersion("1.0")
                     .setSchemaUrl("http://schema.com")
                     .build())

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -22,7 +22,7 @@ class DefaultEventEmitterTest {
             () ->
                 DefaultEventEmitter.getInstance()
                     .emit(
-                        "otel.scope.event-name",
+                        "event-domain.event-name",
                         Attributes.builder().put("key1", "value1").build()))
         .doesNotThrowAnyException();
   }

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -21,7 +21,9 @@ class DefaultEventEmitterTest {
     assertThatCode(
             () ->
                 DefaultEventEmitter.getInstance()
-                    .emit("otel.scope.event-name", Attributes.builder().put("key1", "value1").build()))
+                    .emit(
+                        "otel.scope.event-name",
+                        Attributes.builder().put("key1", "value1").build()))
         .doesNotThrowAnyException();
   }
 

--- a/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
+++ b/api/events/src/test/java/io/opentelemetry/api/events/DefaultEventEmitterTest.java
@@ -21,7 +21,7 @@ class DefaultEventEmitterTest {
     assertThatCode(
             () ->
                 DefaultEventEmitter.getInstance()
-                    .emit("event-name", Attributes.builder().put("key1", "value1").build()))
+                    .emit("otel.scope.event-name", Attributes.builder().put("key1", "value1").build()))
         .doesNotThrowAnyException();
   }
 
@@ -32,7 +32,7 @@ class DefaultEventEmitterTest {
     assertThatCode(
             () ->
                 emitter
-                    .builder("myEvent", attributes)
+                    .builder("com.example.MyEvent", attributes)
                     .setTimestamp(123456L, TimeUnit.NANOSECONDS)
                     .setTimestamp(Instant.now())
                     .emit())

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -536,7 +536,6 @@ abstract class OtlpExporterIntegrationTest {
     EventEmitter eventEmitter =
         SdkEventEmitterProvider.create(loggerProvider)
             .eventEmitterBuilder(OtlpExporterIntegrationTest.class.getName())
-            .setEventDomain("event-domain")
             .build();
 
     SpanContext spanContext =
@@ -712,10 +711,6 @@ abstract class OtlpExporterIntegrationTest {
     assertThat(protoLog2.getBody().getStringValue()).isEmpty();
     assertThat(protoLog2.getAttributesList())
         .containsExactlyInAnyOrder(
-            KeyValue.newBuilder()
-                .setKey("event.domain")
-                .setValue(AnyValue.newBuilder().setStringValue("event-domain").build())
-                .build(),
             KeyValue.newBuilder()
                 .setKey("event.name")
                 .setValue(AnyValue.newBuilder().setStringValue("event-name").build())

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -207,9 +207,7 @@ class FullConfigTest {
     logger.logRecordBuilder().setBody("info log message").setSeverity(Severity.INFO).emit();
 
     EventEmitter eventEmitter =
-        GlobalEventEmitterProvider.get()
-            .eventEmitterBuilder("test")
-            .build();
+        GlobalEventEmitterProvider.get().eventEmitterBuilder("test").build();
     eventEmitter.emit("test-name", Attributes.builder().put("cow", "moo").build());
 
     openTelemetrySdk.getSdkTracerProvider().forceFlush().join(10, TimeUnit.SECONDS);

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FullConfigTest.java
@@ -209,7 +209,6 @@ class FullConfigTest {
     EventEmitter eventEmitter =
         GlobalEventEmitterProvider.get()
             .eventEmitterBuilder("test")
-            .setEventDomain("test-domain")
             .build();
     eventEmitter.emit("test-name", Attributes.builder().put("cow", "moo").build());
 
@@ -336,10 +335,6 @@ class FullConfigTest {
             logRecord ->
                 assertThat(logRecord.getAttributesList())
                     .containsExactlyInAnyOrder(
-                        KeyValue.newBuilder()
-                            .setKey("event.domain")
-                            .setValue(AnyValue.newBuilder().setStringValue("test-domain").build())
-                            .build(),
                         KeyValue.newBuilder()
                             .setKey("event.name")
                             .setValue(AnyValue.newBuilder().setStringValue("test-name").build())

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -12,12 +12,10 @@ import java.util.concurrent.TimeUnit;
 
 class SdkEventBuilder implements EventBuilder {
   private final LogRecordBuilder logRecordBuilder;
-  private final String eventDomain;
   private final String eventName;
 
-  SdkEventBuilder(LogRecordBuilder logRecordBuilder, String eventDomain, String eventName) {
+  SdkEventBuilder(LogRecordBuilder logRecordBuilder, String eventName) {
     this.logRecordBuilder = logRecordBuilder;
-    this.eventDomain = eventDomain;
     this.eventName = eventName;
   }
 
@@ -35,7 +33,7 @@ class SdkEventBuilder implements EventBuilder {
 
   @Override
   public void emit() {
-    SdkEventEmitterProvider.addEventNameAndDomain(logRecordBuilder, eventDomain, eventName);
+    SdkEventEmitterProvider.addEventName(logRecordBuilder, eventName);
     logRecordBuilder.emit();
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
@@ -26,10 +26,7 @@ import java.util.concurrent.TimeUnit;
  */
 public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
-  static final AttributeKey<String> EVENT_DOMAIN = AttributeKey.stringKey("event.domain");
   static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
-
-  static final String DEFAULT_EVENT_DOMAIN = "unknown";
 
   private final LoggerProvider delegateLoggerProvider;
   private final Clock clock;
@@ -56,7 +53,6 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
   @Override
   public EventEmitter get(String instrumentationScopeName) {
     return eventEmitterBuilder(instrumentationScopeName)
-        .setEventDomain(DEFAULT_EVENT_DOMAIN)
         .build();
   }
 
@@ -70,17 +66,10 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
     private final Clock clock;
     private final LoggerBuilder delegateLoggerBuilder;
-    private String eventDomain = DEFAULT_EVENT_DOMAIN;
 
     private SdkEventEmitterBuilder(Clock clock, LoggerBuilder delegateLoggerBuilder) {
       this.clock = clock;
       this.delegateLoggerBuilder = delegateLoggerBuilder;
-    }
-
-    @Override
-    public EventEmitterBuilder setEventDomain(String eventDomain) {
-      this.eventDomain = eventDomain;
-      return this;
     }
 
     @Override
@@ -97,7 +86,7 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
     @Override
     public EventEmitter build() {
-      return new SdkEventEmitter(clock, delegateLoggerBuilder.build(), eventDomain);
+      return new SdkEventEmitter(clock, delegateLoggerBuilder.build());
     }
   }
 
@@ -105,12 +94,10 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
     private final Clock clock;
     private final Logger delegateLogger;
-    private final String eventDomain;
 
-    private SdkEventEmitter(Clock clock, Logger delegateLogger, String eventDomain) {
+    private SdkEventEmitter(Clock clock, Logger delegateLogger) {
       this.clock = clock;
       this.delegateLogger = delegateLogger;
-      this.eventDomain = eventDomain;
     }
 
     @Override
@@ -120,7 +107,6 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
               .logRecordBuilder()
               .setTimestamp(clock.now(), TimeUnit.NANOSECONDS)
               .setAllAttributes(attributes),
-          eventDomain,
           eventName);
     }
 
@@ -131,13 +117,13 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
               .logRecordBuilder()
               .setTimestamp(clock.now(), TimeUnit.NANOSECONDS)
               .setAllAttributes(attributes);
-      addEventNameAndDomain(logRecordBuilder, eventDomain, eventName);
+      addEventName(logRecordBuilder, eventName);
       logRecordBuilder.emit();
     }
   }
 
-  static void addEventNameAndDomain(
-      LogRecordBuilder logRecordBuilder, String eventDomain, String eventName) {
-    logRecordBuilder.setAttribute(EVENT_DOMAIN, eventDomain).setAttribute(EVENT_NAME, eventName);
+  static void addEventName(
+      LogRecordBuilder logRecordBuilder, String eventName) {
+    logRecordBuilder.setAttribute(EVENT_NAME, eventName);
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProvider.java
@@ -52,8 +52,7 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
 
   @Override
   public EventEmitter get(String instrumentationScopeName) {
-    return eventEmitterBuilder(instrumentationScopeName)
-        .build();
+    return eventEmitterBuilder(instrumentationScopeName).build();
   }
 
   @Override
@@ -122,8 +121,7 @@ public final class SdkEventEmitterProvider implements EventEmitterProvider {
     }
   }
 
-  static void addEventName(
-      LogRecordBuilder logRecordBuilder, String eventName) {
+  static void addEventName(LogRecordBuilder logRecordBuilder, String eventName) {
     logRecordBuilder.setAttribute(EVENT_NAME, eventName);
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
@@ -8,7 +8,10 @@ package io.opentelemetry.sdk.logs.internal;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +24,6 @@ class SdkEventBuilderTest {
 
   @Test
   void emit() {
-    String eventDomain = "mydomain";
     String eventName = "banana";
 
     LogRecordBuilder logRecordBuilder = mock(LogRecordBuilder.class);
@@ -29,11 +31,11 @@ class SdkEventBuilderTest {
     when(logRecordBuilder.setAttribute(any(), any())).thenReturn(logRecordBuilder);
 
     Instant instant = Instant.now();
-    new SdkEventBuilder(logRecordBuilder, eventDomain, eventName)
+    new SdkEventBuilder(logRecordBuilder, eventName)
         .setTimestamp(123456L, TimeUnit.NANOSECONDS)
         .setTimestamp(instant)
         .emit();
-    verify(logRecordBuilder).setAttribute(stringKey("event.domain"), eventDomain);
+    verify(logRecordBuilder, never()).setAttribute(eq(stringKey("event.domain")), anyString());
     verify(logRecordBuilder).setAttribute(stringKey("event.name"), eventName);
     verify(logRecordBuilder).setTimestamp(123456L, TimeUnit.NANOSECONDS);
     verify(logRecordBuilder).setTimestamp(instant);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
@@ -37,37 +37,7 @@ class SdkEventEmitterProviderTest {
           clock);
 
   @Test
-  void emit_WithDomain() {
-    when(clock.now()).thenReturn(10L);
-
-    eventEmitterProvider
-        .eventEmitterBuilder("test-scope")
-        .setEventDomain("event-domain")
-        .build()
-        .emit(
-            "event-name",
-            Attributes.builder()
-                .put("key1", "value1")
-                // should be overridden by the eventName argument passed to emit
-                .put("event.name", "foo")
-                // should be overridden by the eventDomain
-                .put("event.domain", "foo")
-                .build());
-
-    assertThat(seenLog.get().toLogRecordData())
-        .hasResource(RESOURCE)
-        .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
-        .hasTimestamp(10L)
-        .hasAttributes(
-            Attributes.builder()
-                .put("key1", "value1")
-                .put("event.domain", "event-domain")
-                .put("event.name", "event-name")
-                .build());
-  }
-
-  @Test
-  void emit_NoDomain() {
+  void emit() {
     when(clock.now()).thenReturn(10L);
 
     eventEmitterProvider
@@ -79,8 +49,6 @@ class SdkEventEmitterProviderTest {
                 .put("key1", "value1")
                 // should be overridden by the eventName argument passed to emit
                 .put("event.name", "foo")
-                // should be overridden by the default eventDomain
-                .put("event.domain", "foo")
                 .build());
 
     assertThat(seenLog.get().toLogRecordData())
@@ -90,7 +58,6 @@ class SdkEventEmitterProviderTest {
         .hasAttributes(
             Attributes.builder()
                 .put("key1", "value1")
-                .put("event.domain", "unknown")
                 .put("event.name", "event-name")
                 .build());
   }
@@ -113,7 +80,6 @@ class SdkEventEmitterProviderTest {
         .hasTimestamp(timestamp)
         .hasAttributes(
             attributes.toBuilder()
-                .put("event.domain", "unknown")
                 .put("event.name", "testing")
                 .build());
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventEmitterProviderTest.java
@@ -56,10 +56,7 @@ class SdkEventEmitterProviderTest {
         .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
         .hasTimestamp(10L)
         .hasAttributes(
-            Attributes.builder()
-                .put("key1", "value1")
-                .put("event.name", "event-name")
-                .build());
+            Attributes.builder().put("key1", "value1").put("event.name", "event-name").build());
   }
 
   @Test
@@ -78,9 +75,6 @@ class SdkEventEmitterProviderTest {
         .hasResource(RESOURCE)
         .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
         .hasTimestamp(timestamp)
-        .hasAttributes(
-            attributes.toBuilder()
-                .put("event.name", "testing")
-                .build());
+        .hasAttributes(attributes.toBuilder().put("event.name", "testing").build());
   }
 }


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions/pull/473 for details. The events working group has combined the `event.name` and `event.domain` by just having dot-separated prefixes on event names. This updates the API to match that expectation.