### PR TITLE
Use shared CODECOV_TOKEN

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,9 +89,6 @@ The following credentials are required for building or publishing (and automatic
   * To obtain `SONATYPE_USER` and `SONATYPE_KEY` for your account, login
     to [oss.sonatype.org](https://oss.sonatype.org/) and navigate to Profile -> User Token -> Access
     User Token.
-* `CODECOV_TOKEN`: Token used for uploading codecov reports. Each maintainer can obtain their own
-  credential from codecov as
-  described [here](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions).
 
 Additionally, credentials are stored with maintainers via
 the [OpenTelemetry 1Password](https://opentelemetry.1password.com/signin) account. The following


### PR DESCRIPTION
An organization wide `CODECOV_TOKEN` [was added](https://github.com/open-telemetry/community/issues/1926) removing the need for us to use my personal token.

I've removed the secret from the repository settings and this PR removes references to it from our docs.