### PR TITLE
Use synchronized instead of reentrant lock in explicit bucket histogram

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,14 @@ uses [google-java-format](https://github.com/google/google-java-format) library:
 * Adding `toString()` overrides on classes is encouraged, but we only use `toString()` to provide
   debugging assistance. The implementations of all `toString()` methods should be considered to be
   unstable unless explicitly documented otherwise.
+* Avoid synchronizing using a class's intrinsic lock. Instead, synchronize on a dedicated lock object. E.g:
+  ```java
+  private final Object lock = new Object();
+
+  public void doSomething() {
+    synchronized (lock) { ... }
+  }
+  ```
 
 If you notice any practice being applied in the project consistently that isn't listed here, please
 consider a pull request to add it.


### PR DESCRIPTION
Was doing some analysis and noticed a small amount of allocations occurring when recording to explicit bucket histogram.

Tracked it down and determine that ReentrantLock actually performs some small amount of allocations for synchronization. See the screenshot below from my profiler. Replaced it with the `synchronized` keyword and the allocations went away. Also noticed a modest increase in performance.

<img width="2322" alt="Screenshot 2024-03-19 at 2 35 04 PM" src="https://github.com/open-telemetry/opentelemetry-java/assets/34418638/3ae6789f-133a-4076-a72a-b9e83cce61d1">

## HistogramBenchmark

Before
```
Benchmark                                                            (aggregation)                (valueGen)  Mode  Cnt      Score       Error   Units
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  36837.809 ± 14387.103   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.005 ±     0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.020 ±     0.007    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  45622.392 ±  4692.903   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.005 ±     0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.026 ±     0.002    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  47397.833 ±  3943.018   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.005 ±     0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.026 ±     0.002    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  26015.096 ±   896.893   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.001 ±     0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.014 ±     0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  34910.477 ±  1182.348   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.001 ±     0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.019 ±     0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  36557.168 ±   427.892   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.001 ±     0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.020 ±     0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  27350.339 ±  2304.589   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.003 ±     0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.016 ±     0.002    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  34618.320 ±   595.322   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.003 ±     0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.020 ±     0.001    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0              counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  37097.321 ±   534.516   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.003 ±     0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.021 ±     0.001    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0              counts

```

After
```
Benchmark                                                            (aggregation)                (valueGen)  Mode  Cnt      Score     Error   Units
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  30270.564 ± 927.032   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.005 ±   0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.017 ±   0.001    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  38952.976 ± 970.539   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.005 ±   0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.022 ±   0.001    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_10Threads                     EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  38415.200 ± 983.709   ns/op
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate       EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.005 ±   0.001  MB/sec
HistogramBenchmark.aggregate_10Threads:gc.alloc.rate.norm  EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.022 ±   0.001    B/op
HistogramBenchmark.aggregate_10Threads:gc.count            EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  25116.150 ± 299.397   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.001 ±   0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.014 ±   0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  32274.696 ± 744.840   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.001 ±   0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.017 ±   0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_1Threads                      EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  31970.603 ± 807.993   ns/op
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.001 ±   0.001  MB/sec
HistogramBenchmark.aggregate_1Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.017 ±   0.001    B/op
HistogramBenchmark.aggregate_1Threads:gc.count             EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10  23826.553 ± 350.842   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.003 ±   0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10      0.014 ±   0.001    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET   FIXED_BUCKET_BOUNDARIES  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10  29492.544 ± 556.613   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.003 ±   0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10      0.017 ±   0.001    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET  UNIFORM_RANDOM_WITHIN_2K  avgt   10        ≈ 0            counts
HistogramBenchmark.aggregate_5Threads                      EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10  31819.090 ± 562.777   ns/op
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate        EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.003 ±   0.001  MB/sec
HistogramBenchmark.aggregate_5Threads:gc.alloc.rate.norm   EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10      0.018 ±   0.001    B/op
HistogramBenchmark.aggregate_5Threads:gc.count             EXPLICIT_DEFAULT_BUCKET          GAUSSIAN_LATENCY  avgt   10        ≈ 0            counts
```

Notice the small improvement in `gc.alloc.rate.norm` and the larger-than-expected improvement in `ns/op`. 