### PR TITLE
Refactor Event API to reflect spec changes

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/DefaultEventLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/DefaultEventLogger.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.api.incubator.events;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.logs.AnyValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
@@ -20,10 +23,7 @@ class DefaultEventLogger implements EventLogger {
   }
 
   @Override
-  public void emit(String eventName, Attributes attributes) {}
-
-  @Override
-  public EventBuilder builder(String eventName, Attributes attributes) {
+  public EventBuilder builder(String eventName) {
     return NoOpEventBuilder.INSTANCE;
   }
 
@@ -32,12 +32,32 @@ class DefaultEventLogger implements EventLogger {
     public static final EventBuilder INSTANCE = new NoOpEventBuilder();
 
     @Override
+    public EventBuilder put(String key, AnyValue<?> value) {
+      return this;
+    }
+
+    @Override
     public EventBuilder setTimestamp(long timestamp, TimeUnit unit) {
       return this;
     }
 
     @Override
     public EventBuilder setTimestamp(Instant instant) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setContext(Context context) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setSeverity(Severity severity) {
+      return this;
+    }
+
+    @Override
+    public EventBuilder setAttributes(Attributes attributes) {
       return this;
     }
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventBuilder.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventBuilder.java
@@ -5,14 +5,79 @@
 
 package io.opentelemetry.api.incubator.events;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.logs.AnyValue;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /** The EventBuilder is used to {@link #emit()} events. */
 public interface EventBuilder {
 
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, String value) {
+    return put(key, AnyValue.of(value));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, long value) {
+    return put(key, AnyValue.of(value));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, double value) {
+    return put(key, AnyValue.of(value));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, boolean value) {
+    return put(key, AnyValue.of(value));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, String... value) {
+    List<AnyValue<?>> values = new ArrayList<>(value.length);
+    for (String val : value) {
+      values.add(AnyValue.of(val));
+    }
+    return put(key, AnyValue.of(values));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, long... value) {
+    List<AnyValue<?>> values = new ArrayList<>(value.length);
+    for (long val : value) {
+      values.add(AnyValue.of(val));
+    }
+    return put(key, AnyValue.of(values));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, double... value) {
+    List<AnyValue<?>> values = new ArrayList<>(value.length);
+    for (double val : value) {
+      values.add(AnyValue.of(val));
+    }
+    return put(key, AnyValue.of(values));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  default EventBuilder put(String key, boolean... value) {
+    List<AnyValue<?>> values = new ArrayList<>(value.length);
+    for (boolean val : value) {
+      values.add(AnyValue.of(val));
+    }
+    return put(key, AnyValue.of(values));
+  }
+
+  /** Put the given {@code key} and {@code value} in the payload. */
+  EventBuilder put(String key, AnyValue<?> value);
+
   /**
-   * Set the epoch {@code timestamp} for the event, using the timestamp and unit.
+   * Set the epoch {@code timestamp}, using the timestamp and unit.
    *
    * <p>The {@code timestamp} is the time at which the event occurred. If unset, it will be set to
    * the current time when {@link #emit()} is called.
@@ -20,12 +85,26 @@ public interface EventBuilder {
   EventBuilder setTimestamp(long timestamp, TimeUnit unit);
 
   /**
-   * Set the epoch {@code timestamp} for the event, using the instant.
+   * Set the epoch {@code timestamp}, using the instant.
    *
    * <p>The {@code timestamp} is the time at which the event occurred. If unset, it will be set to
    * the current time when {@link #emit()} is called.
    */
   EventBuilder setTimestamp(Instant instant);
+
+  /** Set the context. */
+  EventBuilder setContext(Context context);
+
+  /** Set the severity. */
+  EventBuilder setSeverity(Severity severity);
+
+  /**
+   * Set the attributes.
+   *
+   * <p>Event {@link io.opentelemetry.api.common.Attributes} provide additional details about the
+   * Event which are not part of the well-defined {@link AnyValue} {@code payload}.
+   */
+  EventBuilder setAttributes(Attributes attributes);
 
   /** Emit an event. */
   void emit();

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/events/EventLogger.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.incubator.events;
 
-import io.opentelemetry.api.common.Attributes;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -20,10 +19,10 @@ import javax.annotation.concurrent.ThreadSafe;
  *         .build();
  *
  *   void doWork() {
- *     eventLogger.emit("my-namespace.my-event", Attributes.builder()
+ *     eventLogger.builder("my-namespace.my-event")
  *         .put("key1", "value1")
  *         .put("key2", "value2")
- *         .build())
+ *         .emit();
  *     // do work
  *   }
  * }
@@ -33,18 +32,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface EventLogger {
 
   /**
-   * Emit an event.
-   *
-   * @param eventName the event name, which identifies the class or type of event. Event with the
-   *     same name are structurally similar to one another. Event names are subject to the same
-   *     naming rules as attribute names. Notably, they are namespaced to avoid collisions. See <a
-   *     href="https://opentelemetry.io/docs/specs/semconv/general/events/">event.name semantic
-   *     conventions</a> for more details.
-   * @param attributes attributes associated with the event
-   */
-  void emit(String eventName, Attributes attributes);
-
-  /**
    * Return a {@link EventBuilder} to emit an event.
    *
    * @param eventName the event name, which identifies the class or type of event. Event with the
@@ -52,7 +39,6 @@ public interface EventLogger {
    *     naming rules as attribute names. Notably, they are namespaced to avoid collisions. See <a
    *     href="https://opentelemetry.io/docs/specs/semconv/general/events/">event.name semantic
    *     conventions</a> for more details.
-   * @param attributes attributes associated with the event
    */
-  EventBuilder builder(String eventName, Attributes attributes);
+  EventBuilder builder(String eventName);
 }

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/AnyValue.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/AnyValue.java
@@ -62,6 +62,11 @@ public interface AnyValue<T> {
     return AnyValueArray.create(value);
   }
 
+  /** Returns an {@link AnyValue} for the list of {@link AnyValue} values. */
+  static AnyValue<List<AnyValue<?>>> of(List<AnyValue<?>> value) {
+    return AnyValueArray.create(value);
+  }
+
   /**
    * Returns an {@link AnyValue} for the array of {@link KeyAnyValue} values. {@link
    * KeyAnyValue#getKey()} values should not repeat - duplicates may be dropped.

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/AnyValueArray.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/AnyValueArray.java
@@ -28,6 +28,10 @@ final class AnyValueArray implements AnyValue<List<AnyValue<?>>> {
     return new AnyValueArray(Collections.unmodifiableList(list));
   }
 
+  static AnyValue<List<AnyValue<?>>> create(List<AnyValue<?>> value) {
+    return new AnyValueArray(Collections.unmodifiableList(value));
+  }
+
   @Override
   public AnyValueType getType() {
     return AnyValueType.ARRAY;

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/events/DefaultEventLoggerProviderTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/events/DefaultEventLoggerProviderTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.api.incubator.events;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.opentelemetry.api.common.Attributes;
 import org.junit.jupiter.api.Test;
 
 class DefaultEventLoggerProviderTest {
@@ -33,7 +32,8 @@ class DefaultEventLoggerProviderTest {
                 provider
                     .eventLoggerBuilder("scope-name")
                     .build()
-                    .emit("event-name", Attributes.empty()))
+                    .builder("namespace.event-name")
+                    .emit())
         .doesNotThrowAnyException();
   }
 }

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/events/DefaultEventLoggerTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/events/DefaultEventLoggerTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.api.incubator.events;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -15,28 +17,18 @@ import org.junit.jupiter.api.Test;
 class DefaultEventLoggerTest {
 
   @Test
-  void emit() {
-    assertThatCode(() -> DefaultEventLogger.getInstance().emit("event-name", Attributes.empty()))
-        .doesNotThrowAnyException();
-    assertThatCode(
-            () ->
-                DefaultEventLogger.getInstance()
-                    .emit(
-                        "event-domain.event-name",
-                        Attributes.builder().put("key1", "value1").build()))
-        .doesNotThrowAnyException();
-  }
-
-  @Test
   void builder() {
-    Attributes attributes = Attributes.builder().put("key1", "value1").build();
     EventLogger eventLogger = DefaultEventLogger.getInstance();
     assertThatCode(
             () ->
                 eventLogger
-                    .builder("com.example.MyEvent", attributes)
+                    .builder("namespace.myEvent")
+                    .put("key", "value")
                     .setTimestamp(123456L, TimeUnit.NANOSECONDS)
                     .setTimestamp(Instant.now())
+                    .setContext(Context.current())
+                    .setSeverity(Severity.DEBUG)
+                    .setAttributes(Attributes.empty())
                     .emit())
         .doesNotThrowAnyException();
   }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilder.java
@@ -5,35 +5,83 @@
 
 package io.opentelemetry.sdk.logs.internal;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.events.EventBuilder;
+import io.opentelemetry.api.incubator.logs.AnyValue;
+import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
 import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.Clock;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 class SdkEventBuilder implements EventBuilder {
+
+  private static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
+
+  private final Map<String, AnyValue<?>> payload = new HashMap<>();
+  private final Clock clock;
   private final LogRecordBuilder logRecordBuilder;
   private final String eventName;
+  private boolean hasTimestamp = false;
 
-  SdkEventBuilder(LogRecordBuilder logRecordBuilder, String eventName) {
+  SdkEventBuilder(Clock clock, LogRecordBuilder logRecordBuilder, String eventName) {
+    this.clock = clock;
     this.logRecordBuilder = logRecordBuilder;
     this.eventName = eventName;
   }
 
   @Override
+  public EventBuilder put(String key, AnyValue<?> value) {
+    payload.put(key, value);
+    return this;
+  }
+
+  @Override
   public EventBuilder setTimestamp(long timestamp, TimeUnit unit) {
     this.logRecordBuilder.setTimestamp(timestamp, unit);
+    this.hasTimestamp = true;
     return this;
   }
 
   @Override
   public EventBuilder setTimestamp(Instant instant) {
     this.logRecordBuilder.setTimestamp(instant);
+    this.hasTimestamp = true;
+    return this;
+  }
+
+  @Override
+  public EventBuilder setContext(Context context) {
+    logRecordBuilder.setContext(context);
+    return this;
+  }
+
+  @Override
+  public EventBuilder setSeverity(Severity severity) {
+    logRecordBuilder.setSeverity(severity);
+    return this;
+  }
+
+  @Override
+  public EventBuilder setAttributes(Attributes attributes) {
+    logRecordBuilder.setAllAttributes(attributes);
     return this;
   }
 
   @Override
   public void emit() {
-    SdkEventLoggerProvider.addEventName(logRecordBuilder, eventName);
+    if (!payload.isEmpty()) {
+      ((ExtendedLogRecordBuilder) logRecordBuilder).setBody(AnyValue.of(payload));
+    }
+    if (!hasTimestamp) {
+      logRecordBuilder.setTimestamp(clock.now(), TimeUnit.NANOSECONDS);
+    }
+    logRecordBuilder.setAttribute(EVENT_NAME, eventName);
     logRecordBuilder.emit();
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventBuilderTest.java
@@ -8,14 +8,15 @@ package io.opentelemetry.sdk.logs.internal;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.Clock;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -29,16 +30,26 @@ class SdkEventBuilderTest {
     LogRecordBuilder logRecordBuilder = mock(LogRecordBuilder.class);
     when(logRecordBuilder.setTimestamp(anyLong(), any())).thenReturn(logRecordBuilder);
     when(logRecordBuilder.setAttribute(any(), any())).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setContext(any())).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setSeverity(any())).thenReturn(logRecordBuilder);
+    when(logRecordBuilder.setAllAttributes(any())).thenReturn(logRecordBuilder);
 
     Instant instant = Instant.now();
-    new SdkEventBuilder(logRecordBuilder, eventName)
+    Context context = Context.root();
+    Attributes attributes = Attributes.builder().put("extra-attribute", "value").build();
+    new SdkEventBuilder(Clock.getDefault(), logRecordBuilder, eventName)
         .setTimestamp(123456L, TimeUnit.NANOSECONDS)
         .setTimestamp(instant)
+        .setContext(context)
+        .setSeverity(Severity.DEBUG)
+        .setAttributes(attributes)
         .emit();
-    verify(logRecordBuilder, never()).setAttribute(eq(stringKey("event.domain")), anyString());
     verify(logRecordBuilder).setAttribute(stringKey("event.name"), eventName);
     verify(logRecordBuilder).setTimestamp(123456L, TimeUnit.NANOSECONDS);
     verify(logRecordBuilder).setTimestamp(instant);
+    verify(logRecordBuilder).setContext(context);
+    verify(logRecordBuilder).setSeverity(Severity.DEBUG);
+    verify(logRecordBuilder).setAllAttributes(attributes);
     verify(logRecordBuilder).emit();
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProviderTest.java
@@ -82,12 +82,12 @@ class SdkEventLoggerProviderTest {
         .builder("namespace.my-event-name")
         // Helper methods to set primitive types
         .put("stringKey", "value")
-        .put("longKey", 1)
+        .put("longKey", 1L)
         .put("doubleKey", 1.0)
         .put("boolKey", true)
         // Helper methods to set primitive array types
         .put("stringArrKey", "value1", "value2")
-        .put("longArrKey", 1, 2)
+        .put("longArrKey", 1L, 2L)
         .put("doubleArrKey", 1.0, 2.0)
         .put("boolArrKey", true, false)
         // Set AnyValue types to encode complex data
@@ -101,12 +101,12 @@ class SdkEventLoggerProviderTest {
 
     Map<String, AnyValue<?>> expectedPayload = new HashMap<>();
     expectedPayload.put("stringKey", AnyValue.of("value"));
-    expectedPayload.put("longKey", AnyValue.of(1));
+    expectedPayload.put("longKey", AnyValue.of(1L));
     expectedPayload.put("doubleKey", AnyValue.of(1.0));
     expectedPayload.put("boolKey", AnyValue.of(true));
     expectedPayload.put(
         "stringArrKey", AnyValue.of(Arrays.asList(AnyValue.of("value1"), AnyValue.of("value2"))));
-    expectedPayload.put("longArrKey", AnyValue.of(Arrays.asList(AnyValue.of(1), AnyValue.of("2"))));
+    expectedPayload.put("longArrKey", AnyValue.of(Arrays.asList(AnyValue.of(1L), AnyValue.of(2L))));
     expectedPayload.put(
         "doubleArrKey", AnyValue.of(Arrays.asList(AnyValue.of(1.0), AnyValue.of(2.0))));
     expectedPayload.put(
@@ -117,7 +117,7 @@ class SdkEventLoggerProviderTest {
             ImmutableMap.of(
                 "childKey1", AnyValue.of("value"),
                 "childKey2", AnyValue.of("value"))));
-    assertThat(((AnyValueBody) seenLog.get().toLogRecordData().getBody()).asAnyValue().toString())
-        .isEqualTo(AnyValue.of(expectedPayload).toString());
+    assertThat(((AnyValueBody) seenLog.get().toLogRecordData().getBody()).asAnyValue())
+        .isEqualTo(AnyValue.of(expectedPayload));
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProviderTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/internal/SdkEventLoggerProviderTest.java
@@ -5,18 +5,24 @@
 
 package io.opentelemetry.sdk.logs.internal;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.events.EventLogger;
+import io.opentelemetry.api.incubator.logs.AnyValue;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -28,7 +34,7 @@ class SdkEventLoggerProviderTest {
 
   private final Clock clock = mock(Clock.class);
   private final AtomicReference<ReadWriteLogRecord> seenLog = new AtomicReference<>();
-  private final SdkEventLoggerProvider eventLoggerProvider =
+  private final SdkEventLoggerProvider eventEmitterProvider =
       SdkEventLoggerProvider.create(
           SdkLoggerProvider.builder()
               .setResource(RESOURCE)
@@ -37,44 +43,81 @@ class SdkEventLoggerProviderTest {
           clock);
 
   @Test
-  void emit() {
+  void builder() {
     when(clock.now()).thenReturn(10L);
 
-    eventLoggerProvider
-        .eventLoggerBuilder("test-scope")
-        .build()
-        .emit(
-            "event-name",
-            Attributes.builder()
-                .put("key1", "value1")
-                // should be overridden by the eventName argument passed to emit
-                .put("event.name", "foo")
-                .build());
+    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
+    EventLogger eventLogger = eventEmitterProvider.eventLoggerBuilder("test-scope").build();
+
+    eventLogger
+        .builder("namespace.event-name")
+        .put("key1", "value1")
+        .setTimestamp(yesterday, TimeUnit.NANOSECONDS)
+        .setSeverity(Severity.DEBUG)
+        .setAttributes(Attributes.builder().put("extra-attribute", "value").build())
+        .emit();
 
     assertThat(seenLog.get().toLogRecordData())
         .hasResource(RESOURCE)
         .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
-        .hasTimestamp(10L)
+        .hasTimestamp(yesterday)
+        .hasSeverity(Severity.DEBUG)
         .hasAttributes(
-            Attributes.builder().put("key1", "value1").put("event.name", "event-name").build());
+            Attributes.builder()
+                .put("event.name", "namespace.event-name")
+                .put("extra-attribute", "value")
+                .build());
+    assertThat(seenLog.get().toLogRecordData().getObservedTimestampEpochNanos()).isPositive();
+    AnyValue<?> expectedPayload =
+        AnyValue.of(Collections.singletonMap("key1", AnyValue.of("value1")));
+    assertThat(((AnyValueBody) seenLog.get().toLogRecordData().getBody()).asAnyValue())
+        .isEqualTo(expectedPayload);
   }
 
   @Test
-  void builder() {
-    long yesterday = System.nanoTime() - TimeUnit.DAYS.toNanos(1);
-    Attributes attributes = Attributes.of(stringKey("foo"), "bar");
+  void eventBuilder_FullPayload() {
+    EventLogger eventLogger = eventEmitterProvider.get("test-scoe");
 
-    EventLogger eventLogger = eventLoggerProvider.eventLoggerBuilder("test-scope").build();
+    eventLogger
+        .builder("namespace.my-event-name")
+        // Helper methods to set primitive types
+        .put("stringKey", "value")
+        .put("longKey", 1)
+        .put("doubleKey", 1.0)
+        .put("boolKey", true)
+        // Helper methods to set primitive array types
+        .put("stringArrKey", "value1", "value2")
+        .put("longArrKey", 1, 2)
+        .put("doubleArrKey", 1.0, 2.0)
+        .put("boolArrKey", true, false)
+        // Set AnyValue types to encode complex data
+        .put(
+            "anyValueKey",
+            AnyValue.of(
+                ImmutableMap.of(
+                    "childKey1", AnyValue.of("value"),
+                    "childKey2", AnyValue.of("value"))))
+        .emit();
 
-    eventLogger.builder("testing", attributes).setTimestamp(yesterday, TimeUnit.NANOSECONDS).emit();
-    verifySeen(yesterday, attributes);
-  }
-
-  private void verifySeen(long timestamp, Attributes attributes) {
-    assertThat(seenLog.get().toLogRecordData())
-        .hasResource(RESOURCE)
-        .hasInstrumentationScope(InstrumentationScopeInfo.create("test-scope"))
-        .hasTimestamp(timestamp)
-        .hasAttributes(attributes.toBuilder().put("event.name", "testing").build());
+    Map<String, AnyValue<?>> expectedPayload = new HashMap<>();
+    expectedPayload.put("stringKey", AnyValue.of("value"));
+    expectedPayload.put("longKey", AnyValue.of(1));
+    expectedPayload.put("doubleKey", AnyValue.of(1.0));
+    expectedPayload.put("boolKey", AnyValue.of(true));
+    expectedPayload.put(
+        "stringArrKey", AnyValue.of(Arrays.asList(AnyValue.of("value1"), AnyValue.of("value2"))));
+    expectedPayload.put("longArrKey", AnyValue.of(Arrays.asList(AnyValue.of(1), AnyValue.of("2"))));
+    expectedPayload.put(
+        "doubleArrKey", AnyValue.of(Arrays.asList(AnyValue.of(1.0), AnyValue.of(2.0))));
+    expectedPayload.put(
+        "boolArrKey", AnyValue.of(Arrays.asList(AnyValue.of(true), AnyValue.of(false))));
+    expectedPayload.put(
+        "anyValueKey",
+        AnyValue.of(
+            ImmutableMap.of(
+                "childKey1", AnyValue.of("value"),
+                "childKey2", AnyValue.of("value"))));
+    assertThat(((AnyValueBody) seenLog.get().toLogRecordData().getBody()).asAnyValue().toString())
+        .isEqualTo(AnyValue.of(expectedPayload).toString());
   }
 }


### PR DESCRIPTION
Reflects changes in https://github.com/open-telemetry/opentelemetry-specification/pull/3772 and https://github.com/open-telemetry/opentelemetry-specification/pull/3749.

Previously attempted in #6001.

Summary of changes:

- Restructure API to put payload into log record AnyValue body. There are now a series of `put(String key, ? value)` types added which add information to the body. The spec currently [seems to be thinking](https://github.com/open-telemetry/semantic-conventions/issues/505) that fields in an event body are _not_ attributes. Because of this, there are not overloads for put which accept the attributes.
- You can still set attributes on an event via `setAttributes`. 
- You can now explicitly set the timestamp, context, and severity. Severity defaults to `INFO=9`.

Usage example of the API:

```
EventLogger eventLogger = eventEmitterProvider.get("test-scoe");

eventLogger
    .builder("namespace.my-event-name")
    // Helper methods to set primitive types
    .put("stringKey", "value")
    .put("longKey", 1)
    .put("doubleKey", 1.0)
    .put("boolKey", true)
    // Helper methods to set primitive array types
    .put("stringArrKey", "value1", "value2")
    .put("longArrKey", 1, 2)
    .put("doubleArrKey", 1.0, 2.0)
    .put("boolArrKey", true, false)
    // Set AnyValue types to encode complex data
    .put(
        "anyValueKey",
        AnyValue.of(
            ImmutableMap.of(
                "childKey1", AnyValue.of("value"),
                "childKey2", AnyValue.of("value"))))
    .emit();
```
Part of the [goal of bundling several breaking changes](https://github.com/open-telemetry/opentelemetry-java/pull/6253#issuecomment-1971346317) into a single release to reduce churn.

cc @breedx-splk 