### PR TITLE
Ignore TLS components (SSLContext, TrustManager, KeyManager) if plain HTTP protocol is used for exporting

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -195,6 +195,7 @@ public class GrpcExporterBuilder<T extends Marshaler> {
           return result;
         };
 
+    boolean isPlainHttp = "http".equals(endpoint.getScheme());
     GrpcSenderProvider grpcSenderProvider = resolveGrpcSenderProvider();
     GrpcSender<T> grpcSender =
         grpcSenderProvider.createSender(
@@ -207,8 +208,8 @@ public class GrpcExporterBuilder<T extends Marshaler> {
             grpcChannel,
             grpcStubFactory,
             retryPolicy,
-            tlsConfigHelper.getSslContext(),
-            tlsConfigHelper.getTrustManager());
+            isPlainHttp ? null : tlsConfigHelper.getSslContext(),
+            isPlainHttp ? null : tlsConfigHelper.getTrustManager());
     LOGGER.log(Level.FINE, "Using GrpcSender: " + grpcSender.getClass().getName());
 
     return new GrpcExporter<>(exporterName, type, grpcSender, meterProviderSupplier);

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -185,6 +185,7 @@ public final class HttpExporterBuilder<T extends Marshaler> {
           return result;
         };
 
+    boolean isPlainHttp = endpoint.startsWith("http://");
     HttpSenderProvider httpSenderProvider = resolveHttpSenderProvider();
     HttpSender httpSender =
         httpSenderProvider.createSender(
@@ -198,8 +199,8 @@ public final class HttpExporterBuilder<T extends Marshaler> {
             proxyOptions,
             authenticator,
             retryPolicy,
-            tlsConfigHelper.getSslContext(),
-            tlsConfigHelper.getTrustManager());
+            isPlainHttp ? null : tlsConfigHelper.getSslContext(),
+            isPlainHttp ? null : tlsConfigHelper.getTrustManager());
     LOGGER.log(Level.FINE, "Using HttpSender: " + httpSender.getClass().getName());
 
     return new HttpExporter<>(exporterName, type, httpSender, meterProviderSupplier, exportAsJson);

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -47,6 +47,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.ConnectionSpec;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -89,14 +90,18 @@ public final class OkHttpGrpcSender<T extends Marshaler> implements GrpcSender<T
       clientBuilder.addInterceptor(
           new RetryInterceptor(retryPolicy, OkHttpGrpcSender::isRetryable));
     }
-    if (sslContext != null && trustManager != null) {
-      clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
-    }
-    if (endpoint.startsWith("http://")) {
+
+    boolean isPlainHttp = endpoint.startsWith("http://");
+    if (isPlainHttp) {
+      clientBuilder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));
       clientBuilder.protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE));
     } else {
       clientBuilder.protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+      if (sslContext != null && trustManager != null) {
+        clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+      }
     }
+
     this.client = clientBuilder.build();
     this.headersSupplier = headersSupplier;
     this.url = HttpUrl.get(endpoint);


### PR DESCRIPTION
Even though plain HTTP protocol is used for exporting, still security components (SSLContext, TrustManager, KeyManager) are initialized. Most of the time, this is not a problem other than adding some minor startup overhead. 

But there might be some cases that security components should not be initialized initially by OTEL Java agent. Here is a case which effects one of our customers:
- They have their own custom `KeyStoreSpi` implementation.
- They bundle their Spring application as executable jar, so artifact layout is customized for Spring's custom Launcher classloader.
- OTEL Java agent is initialized at startup and so creates exporters. But even though traces are sent to OTEL collector over plain HTTP, still some security components are initialized by OTEL Java agent at system classloader level.
- Since artifact layout is customized for Spring's custom Launcher classloader as mentioned above, JDK level security components are initialized without custom `KeyStoreSpi` implementation, because custom `KeyStoreSpi` implementation is not visible to system classloader, but to Spring's custom Launcher classloader.
- Then security component usages (custom keystore import and SSL connection to remote service by using this keystore) at application level fails.

Also there is a similarity between the case I have mentioned above and this issue https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10921. They are not the same errors, but caused by the initialization of some JDK level SPIs at system classloader level instead of Launcher classloader for Spring applications. 