### PR TITLE
Add toBuilder() at PrometheusHttpServer

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -36,6 +36,7 @@ public final class PrometheusHttpServer implements MetricReader {
   private final PrometheusMetricReader prometheusMetricReader;
   private final PrometheusRegistry prometheusRegistry;
   private final String host;
+  private final PrometheusHttpServerBuilder builder;
 
   /**
    * Returns a new {@link PrometheusHttpServer} which can be registered to an {@link
@@ -52,12 +53,14 @@ public final class PrometheusHttpServer implements MetricReader {
   }
 
   PrometheusHttpServer(
+      PrometheusHttpServerBuilder builder,
       String host,
       int port,
       @Nullable ExecutorService executor,
       PrometheusRegistry prometheusRegistry,
       boolean otelScopeEnabled,
       @Nullable Predicate<String> allowedResourceAttributesFilter) {
+    this.builder = builder;
     this.prometheusMetricReader =
         new PrometheusMetricReader(otelScopeEnabled, allowedResourceAttributesFilter);
     this.host = host;
@@ -119,6 +122,13 @@ public final class PrometheusHttpServer implements MetricReader {
   @Override
   public String toString() {
     return "PrometheusHttpServer{address=" + getAddress() + "}";
+  }
+
+  /**
+   * Returns a new {@link PrometheusHttpServerBuilder} with the same configuration as this instance.
+   */
+  public PrometheusHttpServerBuilder toBuilder() {
+    return new PrometheusHttpServerBuilder(builder);
   }
 
   // Visible for testing.

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
@@ -49,6 +49,7 @@ public final class PrometheusHttpServerBuilder {
   }
 
   /** Sets the {@link PrometheusRegistry} to be used for {@link PrometheusHttpServer}. */
+  @SuppressWarnings("UnusedReturnValue")
   public PrometheusHttpServerBuilder setPrometheusRegistry(PrometheusRegistry prometheusRegistry) {
     requireNonNull(prometheusRegistry, "prometheusRegistry");
     this.prometheusRegistry = prometheusRegistry;
@@ -56,6 +57,7 @@ public final class PrometheusHttpServerBuilder {
   }
 
   /** Set if the {@code otel_scope_*} attributes are generated. Default is {@code true}. */
+  @SuppressWarnings("UnusedReturnValue")
   public PrometheusHttpServerBuilder setOtelScopeEnabled(boolean otelScopeEnabled) {
     this.otelScopeEnabled = otelScopeEnabled;
     return this;
@@ -83,6 +85,7 @@ public final class PrometheusHttpServerBuilder {
    */
   public PrometheusHttpServer build() {
     return new PrometheusHttpServer(
+        new PrometheusHttpServerBuilder(this), // copy to prevent modification
         host,
         port,
         executor,
@@ -92,4 +95,13 @@ public final class PrometheusHttpServerBuilder {
   }
 
   PrometheusHttpServerBuilder() {}
+
+  PrometheusHttpServerBuilder(PrometheusHttpServerBuilder builder) {
+    this.host = builder.host;
+    this.port = builder.port;
+    this.prometheusRegistry = builder.prometheusRegistry;
+    this.otelScopeEnabled = builder.otelScopeEnabled;
+    this.allowedResourceAttributesFilter = builder.allowedResourceAttributesFilter;
+    this.executor = builder.executor;
+  }
 }


### PR DESCRIPTION
Per the conventions we have in the code, I've added the ability to create create a `PrometheusHttpServerBuilder` out of an existing `PrometheusHttpServer`.
This is particularly useful if you use `AutoConfiguredOpenTelemetrySdkBuilder.addMetricReaderCustomizer()`. In that method, you are given a `MetricReader` instance. In the case of `PrometheusHttpServer` you need to cast it to `PrometheusHttpServer` and then you can use the new `toBuilder()` to modify it.

This is a the completion step for (1) https://github.com/open-telemetry/opentelemetry-java/pull/6179 and (2) https://github.com/open-telemetry/opentelemetry-java/pull/6231