### PR TITLE
Add forward slash to InstrumentName log message

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/Meter.java
@@ -65,7 +65,7 @@ public interface Meter {
    * callbacks).
    *
    * @param name the name of the Counter. Instrument names must consist of 255 or fewer characters
-   *     including alphanumeric, _, ., -, and start with a letter.
+   *     including alphanumeric, _, ., -, /, and start with a letter.
    * @return a builder for configuring a Counter instrument. Defaults to recording long values, but
    *     may be changed.
    * @see <a
@@ -81,7 +81,7 @@ public interface Meter {
    * callbacks).
    *
    * @param name the name of the UpDownCounter. Instrument names must consist of 255 or fewer
-   *     characters including alphanumeric, _, ., -, and start with a letter.
+   *     characters including alphanumeric, _, ., -, /, and start with a letter.
    * @return a builder for configuring an UpDownCounter instrument. Defaults to recording long
    *     values, but may be changed.
    * @see <a
@@ -94,7 +94,7 @@ public interface Meter {
    * Constructs a Histogram instrument.
    *
    * @param name the name of the Histogram. Instrument names must consist of 255 or fewer characters
-   *     including alphanumeric, _, ., -, and start with a letter.
+   *     including alphanumeric, _, ., -, /, and start with a letter.
    * @return a builder for configuring a Histogram synchronous instrument. Defaults to recording
    *     double values, but may be changed.
    * @see <a
@@ -107,7 +107,7 @@ public interface Meter {
    * Constructs an Asynchronous Gauge instrument.
    *
    * @param name the name of the Gauge. Instrument names must consist of 255 or fewer characters
-   *     including alphanumeric, _, ., -, and start with a letter.
+   *     including alphanumeric, _, ., -, /, and start with a letter.
    * @return a builder used for configuring a Gauge instrument. Defaults to recording double values,
    *     but may be changed.
    * @see <a

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeter.java
@@ -163,7 +163,7 @@ final class SdkMeter implements Meter {
           Level.WARNING,
           "Instrument name \""
               + name
-              + "\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, and start with a letter.",
+              + "\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, /, and start with a letter.",
           new AssertionError());
     }
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -94,7 +94,7 @@ class SdkMeterTest {
   void checkValidInstrumentName_InvalidNameLogs() {
     assertThat(checkValidInstrumentName("1")).isFalse();
     sdkMeterLogs.assertContains(
-        "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, and start with a letter.");
+        "Instrument name \"1\" is invalid, returning noop instrument. Instrument names must consist of 255 or fewer characters including alphanumeric, _, ., -, /, and start with a letter.");
   }
 
   @Test


### PR DESCRIPTION
This came up in a real-world situation where the instrument name was failing for a different reason, but contained a forward slash, leading us to believe that was the cause. This adds the forward slash as an allowable character to the log message, and is in keeping with [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax).