### PR TITLE
Move away from deprecated gradle enterprise APIs

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -66,7 +66,7 @@ Same settings as above for `main`, except:
 
 * `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
 * `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
-* `GRADLE_ENTERPRISE_ACCESS_KEY` - owned by [@jack-berg](https://github.com/jack-berg)
+* `DEVELOCITY_ACCESS_KEY` - owned by [@jack-berg](https://github.com/jack-berg)
   * Generated at https://ge.opentelemetry.io > My settings > Access keys
   * format of env var is `ge.opentelemetry.io=<access key>`,
     see [docs](https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
   plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.gradle.enterprise") version "3.17"
+    id("com.gradle.develocity") version "3.17"
     id("de.undercouch.download") version "5.6.0"
     id("org.jsonschema2pojo") version "1.2.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
@@ -10,7 +10,7 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise")
+  id("com.gradle.develocity")
 }
 
 dependencyResolutionManagement {
@@ -71,30 +71,29 @@ val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
 val useScansGradleCom = isCI && geAccessKey.isEmpty()
 
 if (useScansGradleCom) {
-  gradleEnterprise {
+  develocity {
     buildScan {
-      termsOfServiceUrl = "https://gradle.com/terms-of-service"
-      termsOfServiceAgree = "yes"
-      isUploadInBackground = !isCI
-      publishAlways()
+      termsOfUseUrl.set("https://gradle.com/terms-of-service")
+      termsOfUseAgree.set("yes")
+      uploadInBackground.set(!isCI)
+      publishing.onlyIf { true }
 
       capture {
-        isTaskInputFiles = true
+        fileFingerprints.set(true)
       }
     }
   }
 } else {
-  gradleEnterprise {
+  develocity {
     server = gradleEnterpriseServer
     buildScan {
-      isUploadInBackground = !isCI
-
-      this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
-      publishIfAuthenticated()
-      publishAlways()
+      uploadInBackground.set(!isCI)
+      publishing.onlyIf {
+        it.isAuthenticated
+      }
 
       capture {
-        isTaskInputFiles = true
+        fileFingerprints.set(true)
       }
 
       gradle.startParameter.projectProperties["testJavaVersion"]?.let { tag(it) }


### PR DESCRIPTION
Notes on migration from gradle enterprise to develocity: https://docs.gradle.com/enterprise/gradle-plugin/legacy/#develocity_migration

Updated secrets to include current value of `GRADLE_ENTERPRISE_ACCESS_KEY` in `DEVELOCITY_ACCESS_KEY`