### PR TITLE
Extended onEnd to allow for explicit calling of next span processor

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/MultiSpanProcessor.java
@@ -23,11 +23,13 @@ final class MultiSpanProcessor implements SpanProcessor {
   private final List<SpanProcessor> spanProcessorsEnd;
 
   /**
-   * Will invoke {@link SpanProcessor#onEnd(ReadableSpan, Consumer)} of all processors from {@link #spanProcessorsEnd}
-   * in order. The output from the first processor is passed to the second, the output form the second to the third ans so on.
-   * The output of the last processor is passed to the {@link Consumer} provided as second argument to this biconsumer.
+   * Will invoke {@link SpanProcessor#onEnd(ReadableSpan, Consumer)} of all processors from {@link
+   * #spanProcessorsEnd} in order. The output from the first processor is passed to the second, the
+   * output from the second to the third and so on. The output of the last processor is passed to
+   * the {@link Consumer} provided as second argument to this biconsumer.
    */
   private BiConsumer<ReadableSpan, Consumer<ReadableSpan>> processorsEndInvoker;
+
   private final List<SpanProcessor> spanProcessorsAll;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
@@ -54,7 +56,6 @@ final class MultiSpanProcessor implements SpanProcessor {
   public boolean isStartRequired() {
     return !spanProcessorsStart.isEmpty();
   }
-
 
   @Override
   public void onEnd(ReadableSpan span, Consumer<ReadableSpan> spanOutput) {
@@ -105,11 +106,12 @@ final class MultiSpanProcessor implements SpanProcessor {
       }
     }
     processorsEndInvoker = (span, drain) -> drain.accept(span);
-    for (int i=spanProcessorsEnd.size() - 1; i>=0; i--) {
+    for (int i = spanProcessorsEnd.size() - 1; i >= 0; i--) {
       BiConsumer<ReadableSpan, Consumer<ReadableSpan>> nextStage = processorsEndInvoker;
       SpanProcessor processor = spanProcessorsEnd.get(i);
-      processorsEndInvoker = (span, finalOutput) ->
-        processor.onEnd(span, outputSpan -> nextStage.accept(outputSpan, finalOutput));
+      processorsEndInvoker =
+          (span, finalOutput) ->
+              processor.onEnd(span, outputSpan -> nextStage.accept(outputSpan, finalOutput));
     }
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -66,6 +67,11 @@ public interface SpanProcessor extends Closeable {
    * @return {@code true} if this {@link SpanProcessor} requires start events.
    */
   boolean isStartRequired();
+
+  default void onEnd(ReadableSpan span, Consumer<ReadableSpan> spanOutput) {
+    onEnd(span);
+    spanOutput.accept(span);
+  }
 
   /**
    * Called when a {@link io.opentelemetry.api.trace.Span} is ended, if the {@link

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/MultiSpanProcessorTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.trace;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,8 +37,10 @@ class MultiSpanProcessorTest {
   void setUp() {
     when(spanProcessor1.isStartRequired()).thenReturn(true);
     when(spanProcessor1.isEndRequired()).thenReturn(true);
+    doCallRealMethod().when(spanProcessor1).onEnd(any(), any());
     when(spanProcessor1.forceFlush()).thenReturn(CompletableResultCode.ofSuccess());
     when(spanProcessor1.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    doCallRealMethod().when(spanProcessor2).onEnd(any(), any());
     when(spanProcessor2.isStartRequired()).thenReturn(true);
     when(spanProcessor2.isEndRequired()).thenReturn(true);
     when(spanProcessor2.forceFlush()).thenReturn(CompletableResultCode.ofSuccess());


### PR DESCRIPTION
Alternative to #6367. This PR adds a new parameter to the `onEnd` callback: A function to explicitly invoke the next `SpanProcessor` with a `ReadableSpan`. This allows `SpanProcessors` to modify the span by wrapping it.
In contrast to #6367, this approach is a bit more flexible would also allow to filter or buffer and delay spans if needed.

This change is backwards compatible. 
