### PR TITLE
Rename otel.config.file to otel.experimental.config.file

### DIFF
--- a/sdk-extensions/autoconfigure/README.md
+++ b/sdk-extensions/autoconfigure/README.md
@@ -383,9 +383,9 @@ and [file configuration](https://github.com/open-telemetry/opentelemetry-specifi
 To use, include `io.opentelemetry:opentelemetry-sdk-extension:incubator:<version>` and specify the
 path to the config file as described in the table below.
 
-| System property  | Environment variable | Purpose                                                    |
-|------------------|----------------------|------------------------------------------------------------|
-| otel.config.file | OTEL_CONFIG_FILE     | The path to the SDK configuration file. Defaults to unset. |
+| System property               | Environment variable          | Purpose                                                    |
+|-------------------------------|-------------------------------|------------------------------------------------------------|
+| otel.experimental.config.file | OTEL_EXPERIMENTAL_CONFIG_FILE | The path to the SDK configuration file. Defaults to unset. |
 
 NOTE: When a config file is specified, other environment variables described in this document along
 with SPI [customizations](#customizing-the-opentelemetry-sdk) are ignored. The contents of the file

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -527,7 +527,7 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   @Nullable
   private static AutoConfiguredOpenTelemetrySdk maybeConfigureFromFile(ConfigProperties config) {
-    String configurationFile = config.getString("otel.config.file");
+    String configurationFile = config.getString("otel.experimental.config.file");
     if (configurationFile == null || configurationFile.isEmpty()) {
       return null;
     }

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -527,6 +527,11 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
 
   @Nullable
   private static AutoConfiguredOpenTelemetrySdk maybeConfigureFromFile(ConfigProperties config) {
+    String otelConfigFile = config.getString("otel.config.file");
+    if (otelConfigFile != null && !otelConfigFile.isEmpty()) {
+      logger.warning(
+          "otel.config.file was set, but has been replaced with otel.experimental.config.file");
+    }
     String configurationFile = config.getString("otel.experimental.config.file");
     if (configurationFile == null || configurationFile.isEmpty()) {
       return null;

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -44,7 +44,7 @@ class FileConfigurationTest {
     Files.write(path, yaml.getBytes(StandardCharsets.UTF_8));
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", path.toString()));
+            Collections.singletonMap("otel.experimental.config.file", path.toString()));
 
     assertThatThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build())
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -78,7 +78,7 @@ class FileConfigurationTest {
   void configFile_Valid() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", configFilePath.toString()));
+            Collections.singletonMap("otel.experimental.config.file", configFilePath.toString()));
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdk.builder()
             .setTracerProvider(
@@ -116,7 +116,7 @@ class FileConfigurationTest {
   void configFile_NoShutdownHook() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", configFilePath.toString()));
+            Collections.singletonMap("otel.experimental.config.file", configFilePath.toString()));
     AutoConfiguredOpenTelemetrySdkBuilder builder = spy(AutoConfiguredOpenTelemetrySdk.builder());
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
@@ -131,7 +131,7 @@ class FileConfigurationTest {
     GlobalOpenTelemetry.set(OpenTelemetry.noop());
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", configFilePath.toString()));
+            Collections.singletonMap("otel.experimental.config.file", configFilePath.toString()));
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
         AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build();
@@ -147,7 +147,7 @@ class FileConfigurationTest {
   void configFile_setResultAsGlobalTrue() {
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", configFilePath.toString()));
+            Collections.singletonMap("otel.experimental.config.file", configFilePath.toString()));
 
     AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
         AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).setResultAsGlobal().build();
@@ -177,7 +177,7 @@ class FileConfigurationTest {
     Files.write(path, yaml.getBytes(StandardCharsets.UTF_8));
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
-            Collections.singletonMap("otel.config.file", path.toString()));
+            Collections.singletonMap("otel.experimental.config.file", path.toString()));
 
     assertThatThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder().setConfig(config).build())
         .isInstanceOf(ConfigurationException.class)

--- a/sdk-extensions/incubator/README.md
+++ b/sdk-extensions/incubator/README.md
@@ -20,7 +20,7 @@ try (FileInputStream yamlConfigFileInputStream = new FileInputStream("/path/to/c
 Notes:
 * Environment variable substitution is supported as [defined in the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution)
 * Currently, there is no support for the SPIs defined in [opentelemetry-sdk-extension-autoconfigure-spi](../autoconfigure-spi). Only built in samplers, processors, exporters, etc can be configured.
-* You can use file configuration with [autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#file-configuration) to specify a configuration file via environment variable, e.g. `OTEL_CONFIG_FILE=/path/to/config.yaml`.
+* You can use file configuration with [autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#file-configuration) to specify a configuration file via environment variable, e.g. `OTEL_EXPERIMENTAL_CONFIG_FILE=/path/to/config.yaml`.
 
 ## View File Configuration
 


### PR DESCRIPTION
Reflects naming in spec PR: https://github.com/open-telemetry/opentelemetry-specification/pull/3948

The `experimental` prefix in the name makes it clear to users that the behavior of how file configuration is subject to breaking changes.

This PR removes support for `otel.config.file`. If it is set, we log a warning. 