### PR TITLE
Add missing fields to OTLP metric exporters

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) java.lang.String asString(io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) java.lang.String asString(io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector)

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
+import java.util.StringJoiner;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -124,6 +125,15 @@ public final class OtlpHttpMetricExporter implements MetricExporter {
 
   @Override
   public String toString() {
-    return "OtlpHttpMetricExporter{" + builder.toString(false) + "}";
+    StringJoiner joiner = new StringJoiner(", ", "OtlpHttpMetricExporter{", "}");
+    joiner.add(builder.toString(false));
+    joiner.add(
+        "aggregationTemporalitySelector="
+            + AggregationTemporalitySelector.asString(aggregationTemporalitySelector));
+    joiner.add(
+        "defaultAggregationSelector="
+            + DefaultAggregationSelector.asString(defaultAggregationSelector));
+    joiner.add("memoryMode=" + memoryMode);
+    return joiner.toString();
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.Collection;
+import java.util.StringJoiner;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -128,6 +129,15 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
 
   @Override
   public String toString() {
-    return "OtlpGrpcMetricExporter{" + builder.toString(false) + "}";
+    StringJoiner joiner = new StringJoiner(", ", "OtlpGrpcMetricExporter{", "}");
+    joiner.add(builder.toString(false));
+    joiner.add(
+        "aggregationTemporalitySelector="
+            + AggregationTemporalitySelector.asString(aggregationTemporalitySelector));
+    joiner.add(
+        "defaultAggregationSelector="
+            + DefaultAggregationSelector.asString(defaultAggregationSelector));
+    joiner.add("memoryMode=" + memoryMode);
+    return joiner.toString();
   }
 }

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
@@ -23,7 +23,9 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class OtlpHttpMetricExporterOkHttpSenderTest
@@ -75,6 +77,33 @@ class OtlpHttpMetricExporterOkHttpSenderTest
     assertThatThrownBy(() -> OtlpHttpMetricExporter.builder().setDefaultAggregationSelector(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("defaultAggregationSelector");
+  }
+
+  /** Test configuration specific to metric exporter. */
+  @Test
+  void stringRepresentation() {
+    try (MetricExporter metricExporter = OtlpHttpMetricExporter.builder().build()) {
+      assertThat(metricExporter.toString())
+          .matches(
+              "OtlpHttpMetricExporter\\{"
+                  + "exporterName=otlp, "
+                  + "type=metric, "
+                  + "endpoint=http://localhost:4318/v1/metrics, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "proxyOptions=null, "
+                  + "compressorEncoding=null, "
+                  + "connectTimeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "exportAsJson=false, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
+                  + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
+                  + "memoryMode=IMMUTABLE_DATA"
+                  + "\\}");
+    }
   }
 
   @Override

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -23,8 +23,10 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.Closeable;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class OtlpGrpcMetricExporterTest
@@ -76,6 +78,32 @@ class OtlpGrpcMetricExporterTest
     assertThatThrownBy(() -> OtlpGrpcMetricExporter.builder().setDefaultAggregationSelector(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("defaultAggregationSelector");
+  }
+
+  /** Test configuration specific to metric exporter. */
+  @Test
+  void stringRepresentation() {
+    try (MetricExporter metricExporter = OtlpGrpcMetricExporter.builder().build()) {
+      assertThat(metricExporter.toString())
+          .matches(
+              "OtlpGrpcMetricExporter\\{"
+                  + "exporterName=otlp, "
+                  + "type=metric, "
+                  + "endpoint=http://localhost:4317, "
+                  + "endpointPath=.*, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "connectTimeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "compressorEncoding=null, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
+                  + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
+                  + "memoryMode=IMMUTABLE_DATA"
+                  + "\\}");
+    }
   }
 
   @Test

--- a/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterJdkSenderTest.java
+++ b/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterJdkSenderTest.java
@@ -24,7 +24,9 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class OtlpHttpMetricExporterJdkSenderTest
@@ -76,6 +78,33 @@ class OtlpHttpMetricExporterJdkSenderTest
     assertThatThrownBy(() -> OtlpHttpMetricExporter.builder().setDefaultAggregationSelector(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("defaultAggregationSelector");
+  }
+
+  /** Test configuration specific to metric exporter. */
+  @Test
+  void stringRepresentation() {
+    try (MetricExporter metricExporter = OtlpHttpMetricExporter.builder().build()) {
+      assertThat(metricExporter.toString())
+          .matches(
+              "OtlpHttpMetricExporter\\{"
+                  + "exporterName=otlp, "
+                  + "type=metric, "
+                  + "endpoint=http://localhost:4318/v1/metrics, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "proxyOptions=null, "
+                  + "compressorEncoding=null, "
+                  + "connectTimeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "exportAsJson=false, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
+                  + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
+                  + "memoryMode=IMMUTABLE_DATA"
+                  + "\\}");
+    }
   }
 
   @Override

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -872,7 +872,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + ", "
                   + "compressorEncoding=null, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
-                  + ".*" // Maybe additional grpcChannel field
+                  + ".*" // Maybe additional grpcChannel field, signal specific fields
                   + "\\}");
     } finally {
       telemetryExporter.shutdown();
@@ -914,7 +914,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                   + "compressorEncoding=gzip, "
                   + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
                   + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"
-                  + ".*" // Maybe additional grpcChannel field
+                  + ".*" // Maybe additional grpcChannel field, signal specific fields
                   + "\\}");
     } finally {
       telemetryExporter.shutdown();

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -858,6 +858,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
                   + ", "
                   + "exportAsJson=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}"
+                  + ".*" // Maybe additional signal specific fields
                   + "\\}");
     } finally {
       telemetryExporter.shutdown();
@@ -900,6 +901,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
                   + "exportAsJson=false, "
                   + "headers=Headers\\{.*foo=OBFUSCATED.*\\}, "
                   + "retryPolicy=RetryPolicy\\{maxAttempts=2, initialBackoff=PT0\\.05S, maxBackoff=PT3S, backoffMultiplier=1\\.3\\}"
+                  + ".*" // Maybe additional signal specific fields
                   + "\\}");
     } finally {
       telemetryExporter.shutdown();

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
@@ -28,6 +28,10 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Header
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpMetric;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpMetric.DefaultHistogramAggregation;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Prometheus;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.Closeable;
 import java.io.IOException;
@@ -118,6 +122,10 @@ class MetricExporterFactoryTest {
             .addHeader("key2", "value2")
             .setTimeout(Duration.ofSeconds(15))
             .setCompression("gzip")
+            .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
+            .setDefaultAggregationSelector(
+                DefaultAggregationSelector.getDefault()
+                    .with(InstrumentType.HISTOGRAM, Aggregation.base2ExponentialBucketHistogram()))
             .build();
     cleanup.addCloseable(expectedExporter);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelector.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelector.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.metrics.export;
 
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import java.util.StringJoiner;
 
 /**
  * A functional interface that selects {@link AggregationTemporality} based on {@link
@@ -76,4 +77,16 @@ public interface AggregationTemporalitySelector {
 
   /** Return the aggregation temporality for the {@link InstrumentType}. */
   AggregationTemporality getAggregationTemporality(InstrumentType instrumentType);
+
+  /**
+   * Returns a string representation of this selector, for using in {@link Object#toString()}
+   * implementations.
+   */
+  static String asString(AggregationTemporalitySelector selector) {
+    StringJoiner joiner = new StringJoiner(", ", "AggregationTemporalitySelector{", "}");
+    for (InstrumentType type : InstrumentType.values()) {
+      joiner.add(type.name() + "=" + selector.getAggregationTemporality(type).name());
+    }
+    return joiner.toString();
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/DefaultAggregationSelector.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/DefaultAggregationSelector.java
@@ -9,6 +9,8 @@ import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.internal.aggregator.AggregationUtil;
+import java.util.StringJoiner;
 
 /**
  * A functional interface that selects default {@link Aggregation} based on {@link InstrumentType}.
@@ -58,4 +60,19 @@ public interface DefaultAggregationSelector {
    * <p>The default aggregation is used when an instrument does not match any views.
    */
   Aggregation getDefaultAggregation(InstrumentType instrumentType);
+
+  /**
+   * Returns a string representation of this selector, for using in {@link Object#toString()}
+   * implementations.
+   */
+  static String asString(DefaultAggregationSelector selector) {
+    StringJoiner joiner = new StringJoiner(", ", "DefaultAggregationSelector{", "}");
+    for (InstrumentType type : InstrumentType.values()) {
+      joiner.add(
+          type.name()
+              + "="
+              + AggregationUtil.aggregationName(selector.getDefaultAggregation(type)));
+    }
+    return joiner.toString();
+  }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelectorTest.java
@@ -63,4 +63,32 @@ class AggregationTemporalitySelectorTest {
     assertThat(selector.getAggregationTemporality(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(
+            AggregationTemporalitySelector.asString(
+                AggregationTemporalitySelector.alwaysCumulative()))
+        .isEqualTo(
+            "AggregationTemporalitySelector{"
+                + "COUNTER=CUMULATIVE, "
+                + "UP_DOWN_COUNTER=CUMULATIVE, "
+                + "HISTOGRAM=CUMULATIVE, "
+                + "OBSERVABLE_COUNTER=CUMULATIVE, "
+                + "OBSERVABLE_UP_DOWN_COUNTER=CUMULATIVE, "
+                + "OBSERVABLE_GAUGE=CUMULATIVE"
+                + "}");
+    assertThat(
+            AggregationTemporalitySelector.asString(
+                AggregationTemporalitySelector.deltaPreferred()))
+        .isEqualTo(
+            "AggregationTemporalitySelector{"
+                + "COUNTER=DELTA, "
+                + "UP_DOWN_COUNTER=CUMULATIVE, "
+                + "HISTOGRAM=DELTA, "
+                + "OBSERVABLE_COUNTER=DELTA, "
+                + "OBSERVABLE_UP_DOWN_COUNTER=CUMULATIVE, "
+                + "OBSERVABLE_GAUGE=DELTA"
+                + "}");
+  }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/DefaultAggregationSelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/DefaultAggregationSelectorTest.java
@@ -61,4 +61,31 @@ class DefaultAggregationSelectorTest {
     assertThat(selector2.getDefaultAggregation(InstrumentType.OBSERVABLE_GAUGE))
         .isEqualTo(Aggregation.defaultAggregation());
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(DefaultAggregationSelector.asString(DefaultAggregationSelector.getDefault()))
+        .isEqualTo(
+            "DefaultAggregationSelector{"
+                + "COUNTER=default, "
+                + "UP_DOWN_COUNTER=default, "
+                + "HISTOGRAM=default, "
+                + "OBSERVABLE_COUNTER=default, "
+                + "OBSERVABLE_UP_DOWN_COUNTER=default, "
+                + "OBSERVABLE_GAUGE=default"
+                + "}");
+    assertThat(
+            DefaultAggregationSelector.asString(
+                DefaultAggregationSelector.getDefault()
+                    .with(InstrumentType.HISTOGRAM, Aggregation.base2ExponentialBucketHistogram())))
+        .isEqualTo(
+            "DefaultAggregationSelector{"
+                + "COUNTER=default, "
+                + "UP_DOWN_COUNTER=default, "
+                + "HISTOGRAM=base2_exponential_bucket_histogram, "
+                + "OBSERVABLE_COUNTER=default, "
+                + "OBSERVABLE_UP_DOWN_COUNTER=default, "
+                + "OBSERVABLE_GAUGE=default"
+                + "}");
+  }
 }


### PR DESCRIPTION
Add missing metric-specific fields to the OtlpHttpMetricExporter and OtlpGrpcMetricExporter toString():
- AggregationTemporalitySelector
- DefaultAggregationSelector
- MemoryMode