### PR TITLE
Low allocation OTLP trace marshaler

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -89,10 +89,15 @@ public final class OtelEncodingUtils {
   /** Returns the {@code byte[]} decoded from the given hex {@link CharSequence}. */
   public static byte[] bytesFromBase16(CharSequence value, int length) {
     byte[] result = new byte[length / 2];
-    for (int i = 0; i < length; i += 2) {
-      result[i / 2] = byteFromBase16(value.charAt(i), value.charAt(i + 1));
-    }
+    bytesFromBase16(value, length, result);
     return result;
+  }
+
+  /** Fills {@code bytes} with bytes decoded from the given hex {@link CharSequence}. */
+  public static void bytesFromBase16(CharSequence value, int length, byte[] bytes) {
+    for (int i = 0; i < length; i += 2) {
+      bytes[i / 2] = byteFromBase16(value.charAt(i), value.charAt(i + 1));
+    }
   }
 
   /** Fills {@code dest} with the hex encoding of {@code bytes}. */

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
@@ -174,7 +174,7 @@ final class JsonSerializer extends Serializer {
   }
 
   @Override
-  public <T> void serializeRepeatedMessage(
+  public <T> void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       List<? extends T> messages,
       StatelessMarshaler<T> marshaler,

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
@@ -109,6 +109,14 @@ final class JsonSerializer extends Serializer {
   }
 
   @Override
+  public void writeString(
+      ProtoFieldInfo field, String string, int utf8Length, MarshalerContext context)
+      throws IOException {
+    generator.writeFieldName(field.getJsonName());
+    generator.writeString(string);
+  }
+
+  @Override
   public void writeBytes(ProtoFieldInfo field, byte[] value) throws IOException {
     generator.writeBinaryField(field.getJsonName(), value);
   }
@@ -163,6 +171,44 @@ final class JsonSerializer extends Serializer {
       writeMessageValue(marshaler);
     }
     generator.writeEndArray();
+  }
+
+  @Override
+  public <T> void serializeRepeatedMessage(
+      ProtoFieldInfo field,
+      List<? extends T> messages,
+      StatelessMarshaler<T> marshaler,
+      MarshalerContext context)
+      throws IOException {
+    generator.writeArrayFieldStart(field.getJsonName());
+    for (int i = 0; i < messages.size(); i++) {
+      T message = messages.get(i);
+      generator.writeStartObject();
+      marshaler.writeTo(this, message, context);
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+  }
+
+  @Override
+  protected void writeStartRepeated(ProtoFieldInfo field) throws IOException {
+    generator.writeArrayFieldStart(field.getJsonName());
+  }
+
+  @Override
+  protected void writeEndRepeated() throws IOException {
+    generator.writeEndArray();
+  }
+
+  @Override
+  protected void writeStartRepeatedElement(ProtoFieldInfo field, int protoMessageSize)
+      throws IOException {
+    generator.writeStartObject();
+  }
+
+  @Override
+  protected void writeEndRepeatedElement() throws IOException {
+    generator.writeEndObject();
   }
 
   // Not a field.

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerContext.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerContext.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+/**
+ * Class for keeping marshaling state. The state consists of integers, that we call sizes, and
+ * objects, that we call data. Both integers and objects can be read from the state in the order
+ * they were added (first in, first out). Additionally, this class provides various pools and caches
+ * for objects that can be reused between marshalling attempts.
+ */
+public final class MarshalerContext {
+  private final boolean marshalStringNoAllocation;
+
+  private int[] sizes = new int[16];
+  private int sizeReadIndex;
+  private int sizeWriteIndex;
+  private Object[] data = new Object[16];
+  private int dataReadIndex;
+  private int dataWriteIndex;
+
+  @SuppressWarnings("BooleanParameter")
+  public MarshalerContext() {
+    this(true);
+  }
+
+  public MarshalerContext(boolean marshalStringNoAllocation) {
+    this.marshalStringNoAllocation = marshalStringNoAllocation;
+  }
+
+  public boolean marshalStringNoAllocation() {
+    return marshalStringNoAllocation;
+  }
+
+  public void addSize(int size) {
+    growSizeIfNeeded();
+    sizes[sizeWriteIndex++] = size;
+  }
+
+  public int addSize() {
+    growSizeIfNeeded();
+    return sizeWriteIndex++;
+  }
+
+  private void growSizeIfNeeded() {
+    if (sizeWriteIndex == sizes.length) {
+      int[] newSizes = new int[sizes.length * 2];
+      System.arraycopy(sizes, 0, newSizes, 0, sizes.length);
+      sizes = newSizes;
+    }
+  }
+
+  public void setSize(int index, int size) {
+    sizes[index] = size;
+  }
+
+  public int getSize() {
+    return sizes[sizeReadIndex++];
+  }
+
+  public void addData(@Nullable Object o) {
+    growDataIfNeeded();
+    data[dataWriteIndex++] = o;
+  }
+
+  private void growDataIfNeeded() {
+    if (dataWriteIndex == data.length) {
+      Object[] newData = new Object[data.length * 2];
+      System.arraycopy(data, 0, newData, 0, data.length);
+      data = newData;
+    }
+  }
+
+  public <T> T getData(Class<T> type) {
+    return type.cast(data[dataReadIndex++]);
+  }
+
+  private final IdPool traceIdPool = new IdPool(TraceId.getLength() / 2);
+
+  /** Returns a buffer that can be used to hold a trace id. */
+  public byte[] getTraceIdBuffer() {
+    return traceIdPool.get();
+  }
+
+  private final IdPool spanIdPool = new IdPool(SpanId.getLength() / 2);
+
+  /** Returns a buffer that can be used to hold a span id. */
+  public byte[] getSpanIdBuffer() {
+    return spanIdPool.get();
+  }
+
+  private static class IdPool {
+    private final List<byte[]> pool = new ArrayList<>();
+    int index;
+    final int idSize;
+
+    IdPool(int idSize) {
+      this.idSize = idSize;
+    }
+
+    byte[] get() {
+      if (index < pool.size()) {
+        return pool.get(index++);
+      }
+      byte[] result = new byte[idSize];
+      pool.add(result);
+      index++;
+
+      return result;
+    }
+
+    void reset() {
+      index = 0;
+    }
+  }
+
+  private final Pool<Map<?, ?>> mapPool = new Pool<>(IdentityHashMap::new, Map::clear);
+
+  /** Returns a pooled identity map. */
+  @SuppressWarnings("unchecked")
+  public <K, V> Map<K, V> getIdentityMap() {
+    return (Map<K, V>) mapPool.get();
+  }
+
+  private final Pool<List<?>> listPool = new Pool<>(ArrayList::new, List::clear);
+
+  /** Returns a pooled list. */
+  @SuppressWarnings("unchecked")
+  public <T> List<T> getList() {
+    return (List<T>) listPool.get();
+  }
+
+  private static class Pool<T> {
+    private final List<T> pool = new ArrayList<>();
+    private int index;
+    private final Supplier<T> factory;
+    private final Consumer<T> clean;
+
+    Pool(Supplier<T> factory, Consumer<T> clean) {
+      this.factory = factory;
+      this.clean = clean;
+    }
+
+    T get() {
+      if (index < pool.size()) {
+        return pool.get(index++);
+      }
+      T result = factory.get();
+      pool.add(result);
+      index++;
+
+      return result;
+    }
+
+    void reset() {
+      for (int i = 0; i < index; i++) {
+        clean.accept(pool.get(i));
+      }
+      index = 0;
+    }
+  }
+
+  /** Reset context so that serialization could be re-run. */
+  public void resetReadIndex() {
+    sizeReadIndex = 0;
+    dataReadIndex = 0;
+  }
+
+  /** Reset context so that it could be reused. */
+  public void reset() {
+    sizeReadIndex = 0;
+    sizeWriteIndex = 0;
+    for (int i = 0; i < dataWriteIndex; i++) {
+      data[i] = null;
+    }
+    dataReadIndex = 0;
+    dataWriteIndex = 0;
+
+    traceIdPool.reset();
+    spanIdPool.reset();
+
+    mapPool.reset();
+    listPool.reset();
+  }
+
+  private static final AtomicInteger KEY_INDEX = new AtomicInteger();
+
+  public static class Key {
+    final int index = KEY_INDEX.getAndIncrement();
+  }
+
+  public static Key key() {
+    return new Key();
+  }
+
+  private Object[] instances = new Object[16];
+
+  @SuppressWarnings("unchecked")
+  public <T> T getInstance(Key key, Supplier<T> supplier) {
+    if (key.index >= instances.length) {
+      Object[] newData = new Object[instances.length * 2];
+      System.arraycopy(instances, 0, newData, 0, instances.length);
+      instances = newData;
+    }
+
+    T result = (T) instances[key.index];
+    if (result == null) {
+      result = supplier.get();
+      instances[key.index] = result;
+    }
+    return result;
+  }
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.exporter.internal.marshal;
 
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -21,8 +19,6 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -37,8 +33,6 @@ public final class MarshalerUtil {
       CodedOutputStream.computeLengthDelimitedFieldSize(TraceId.getLength() / 2);
   private static final int SPAN_ID_VALUE_SIZE =
       CodedOutputStream.computeLengthDelimitedFieldSize(SpanId.getLength() / 2);
-  private static final MarshalerContext.Key GROUPER_KEY = MarshalerContext.key();
-  private static final MarshalerContext.Key ATTRIBUTES_SIZE_CALCULATOR_KEY = MarshalerContext.key();
 
   private static final boolean JSON_AVAILABLE;
 
@@ -74,63 +68,6 @@ public final class MarshalerUtil {
       marshalerList.add(createMarshaler.apply(data));
     }
     return result;
-  }
-
-  /** Groups SDK items by resource and instrumentation scope. */
-  public static <T> Map<Resource, Map<InstrumentationScopeInfo, List<T>>> groupByResourceAndScope(
-      Collection<T> dataList,
-      Function<T, Resource> getResource,
-      Function<T, InstrumentationScopeInfo> getInstrumentationScope,
-      MarshalerContext context) {
-    Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result = context.getIdentityMap();
-
-    Grouper<T> grouper = context.getInstance(GROUPER_KEY, Grouper::new);
-    grouper.initialize(result, getResource, getInstrumentationScope, context);
-    dataList.forEach(grouper);
-
-    return result;
-  }
-
-  private static class Grouper<T> implements Consumer<T> {
-    @SuppressWarnings("NullAway")
-    private Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result;
-
-    @SuppressWarnings("NullAway")
-    private Function<T, Resource> getResource;
-
-    @SuppressWarnings("NullAway")
-    private Function<T, InstrumentationScopeInfo> getInstrumentationScope;
-
-    @SuppressWarnings("NullAway")
-    private MarshalerContext context;
-
-    void initialize(
-        Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result,
-        Function<T, Resource> getResource,
-        Function<T, InstrumentationScopeInfo> getInstrumentationScope,
-        MarshalerContext context) {
-      this.result = result;
-      this.getResource = getResource;
-      this.getInstrumentationScope = getInstrumentationScope;
-      this.context = context;
-    }
-
-    @Override
-    public void accept(T data) {
-      Resource resource = getResource.apply(data);
-      Map<InstrumentationScopeInfo, List<T>> scopeInfoListMap = result.get(resource);
-      if (scopeInfoListMap == null) {
-        scopeInfoListMap = context.getIdentityMap();
-        result.put(resource, scopeInfoListMap);
-      }
-      InstrumentationScopeInfo instrumentationScopeInfo = getInstrumentationScope.apply(data);
-      List<T> elementList = scopeInfoListMap.get(instrumentationScopeInfo);
-      if (elementList == null) {
-        elementList = context.getList();
-        scopeInfoListMap.put(instrumentationScopeInfo, elementList);
-      }
-      elementList.add(data);
-    }
   }
 
   /** Preserialize into JSON format. */
@@ -248,171 +185,10 @@ public final class MarshalerUtil {
     return size;
   }
 
-  /** Returns the size of a repeated message field. */
-  public static <T> int sizeRepeatedMessage(
-      ProtoFieldInfo field,
-      List<? extends T> messages,
-      StatelessMarshaler<T> marshaler,
-      MarshalerContext context) {
-    if (messages.isEmpty()) {
-      return 0;
-    }
-
-    int size = 0;
-    int fieldTagSize = field.getTagSize();
-    for (int i = 0; i < messages.size(); i++) {
-      T message = messages.get(i);
-      int sizeIndex = context.addSize();
-      int fieldSize = marshaler.getBinarySerializedSize(message, context);
-      context.setSize(sizeIndex, fieldSize);
-      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-    }
-    return size;
-  }
-
-  /** Returns the size of a repeated message field. */
-  @SuppressWarnings("unchecked")
-  public static <T> int sizeRepeatedMessage(
-      ProtoFieldInfo field,
-      Collection<? extends T> messages,
-      StatelessMarshaler<T> marshaler,
-      MarshalerContext context,
-      MarshalerContext.Key key) {
-    if (messages instanceof List) {
-      return sizeRepeatedMessage(field, (List<T>) messages, marshaler, context);
-    }
-
-    if (messages.isEmpty()) {
-      return 0;
-    }
-
-    RepeatedElementSizeCalculator<T> sizeCalculator =
-        context.getInstance(key, RepeatedElementSizeCalculator::new);
-    sizeCalculator.initialize(field, marshaler, context);
-    messages.forEach(sizeCalculator);
-
-    return sizeCalculator.size;
-  }
-
-  /** Returns the size of a repeated message field. */
-  public static <K, V> int sizeRepeatedMessage(
-      ProtoFieldInfo field,
-      Map<K, V> messages,
-      StatelessMarshaler2<K, V> marshaler,
-      MarshalerContext context,
-      MarshalerContext.Key key) {
-    if (messages.isEmpty()) {
-      return 0;
-    }
-
-    RepeatedElementPairSizeCalculator<K, V> sizeCalculator =
-        context.getInstance(key, RepeatedElementPairSizeCalculator::new);
-    sizeCalculator.initialize(field, marshaler, context);
-    messages.forEach(sizeCalculator);
-
-    return sizeCalculator.size;
-  }
-
-  /** Returns the size of a repeated message field. */
-  public static int sizeRepeatedMessage(
-      ProtoFieldInfo field,
-      Attributes attributes,
-      StatelessMarshaler2<AttributeKey<?>, Object> marshaler,
-      MarshalerContext context) {
-    if (attributes.isEmpty()) {
-      return 0;
-    }
-
-    RepeatedElementPairSizeCalculator<AttributeKey<?>, Object> sizeCalculator =
-        context.getInstance(ATTRIBUTES_SIZE_CALCULATOR_KEY, RepeatedElementPairSizeCalculator::new);
-    sizeCalculator.initialize(field, marshaler, context);
-    attributes.forEach(sizeCalculator);
-
-    return sizeCalculator.size;
-  }
-
-  private static class RepeatedElementSizeCalculator<T> implements Consumer<T> {
-    private int size;
-    private int fieldTagSize;
-
-    @SuppressWarnings("NullAway")
-    private StatelessMarshaler<T> marshaler;
-
-    @SuppressWarnings("NullAway")
-    private MarshalerContext context;
-
-    void initialize(
-        ProtoFieldInfo field, StatelessMarshaler<T> marshaler, MarshalerContext context) {
-      this.size = 0;
-      this.fieldTagSize = field.getTagSize();
-      this.marshaler = marshaler;
-      this.context = context;
-    }
-
-    @Override
-    public void accept(T element) {
-      int sizeIndex = context.addSize();
-      int fieldSize = marshaler.getBinarySerializedSize(element, context);
-      context.setSize(sizeIndex, fieldSize);
-      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-    }
-  }
-
-  private static class RepeatedElementPairSizeCalculator<K, V> implements BiConsumer<K, V> {
-    private int size;
-    private int fieldTagSize;
-
-    @SuppressWarnings("NullAway")
-    private StatelessMarshaler2<K, V> marshaler;
-
-    @SuppressWarnings("NullAway")
-    private MarshalerContext context;
-
-    void initialize(
-        ProtoFieldInfo field, StatelessMarshaler2<K, V> marshaler, MarshalerContext context) {
-      this.size = 0;
-      this.fieldTagSize = field.getTagSize();
-      this.marshaler = marshaler;
-      this.context = context;
-    }
-
-    @Override
-    public void accept(K key, V value) {
-      int sizeIndex = context.addSize();
-      int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
-      context.setSize(sizeIndex, fieldSize);
-      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-    }
-  }
-
   /** Returns the size of a message field. */
   public static int sizeMessage(ProtoFieldInfo field, Marshaler message) {
     int fieldSize = message.getBinarySerializedSize();
     return field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-  }
-
-  /** Returns the size of a message field. */
-  public static <T> int sizeMessage(
-      ProtoFieldInfo field, T element, StatelessMarshaler<T> marshaler, MarshalerContext context) {
-    int sizeIndex = context.addSize();
-    int fieldSize = marshaler.getBinarySerializedSize(element, context);
-    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-    context.setSize(sizeIndex, fieldSize);
-    return size;
-  }
-
-  /** Returns the size of a message field. */
-  public static <K, V> int sizeMessage(
-      ProtoFieldInfo field,
-      K key,
-      V value,
-      StatelessMarshaler2<K, V> marshaler,
-      MarshalerContext context) {
-    int sizeIndex = context.addSize();
-    int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
-    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
-    context.setSize(sizeIndex, fieldSize);
-    return size;
   }
 
   /** Returns the size of a bool field. */
@@ -502,14 +278,6 @@ public final class MarshalerUtil {
     return field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(message);
   }
 
-  /** Returns the size of a bytes field. */
-  public static int sizeBytes(ProtoFieldInfo field, int length) {
-    if (length == 0) {
-      return 0;
-    }
-    return field.getTagSize() + CodedOutputStream.computeLengthDelimitedFieldSize(length);
-  }
-
   /** Returns the size of a enum field. */
   // Assumes OTLP always defines the first item in an enum with number 0, which it does and will.
   public static int sizeEnum(ProtoFieldInfo field, ProtoEnumInfo enumValue) {
@@ -536,163 +304,12 @@ public final class MarshalerUtil {
     return field.getTagSize() + SPAN_ID_VALUE_SIZE;
   }
 
-  /** Returns the size of a string field. */
-  public static int sizeString(
-      ProtoFieldInfo field, @Nullable String value, MarshalerContext context) {
-    if (value == null || value.isEmpty()) {
-      return sizeBytes(field, 0);
-    }
-    if (context.marshalStringNoAllocation()) {
-      int utf8Size = getUtf8Size(value, context);
-      context.addSize(utf8Size);
-      return sizeBytes(field, utf8Size);
-    } else {
-      byte[] valueUtf8 = toBytes(value);
-      context.addData(valueUtf8);
-      return sizeBytes(field, valueUtf8.length);
-    }
-  }
-
   /** Converts the string to utf8 bytes for encoding. */
   public static byte[] toBytes(@Nullable String value) {
     if (value == null || value.isEmpty()) {
       return EMPTY_BYTES;
     }
     return value.getBytes(StandardCharsets.UTF_8);
-  }
-
-  /** Returns the size of utf8 encoded string in bytes. */
-  @SuppressWarnings("UnusedVariable")
-  private static int getUtf8Size(String string, MarshalerContext context) {
-    return getUtf8Size(string);
-  }
-
-  // Visible for testing
-  static int getUtf8Size(String string) {
-    return encodedUtf8Length(string);
-  }
-
-  // adapted from
-  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L217
-  private static int encodedUtf8Length(String string) {
-    // Warning to maintainers: this implementation is highly optimized.
-    int utf16Length = string.length();
-    int utf8Length = utf16Length;
-    int i = 0;
-
-    // This loop optimizes for pure ASCII.
-    while (i < utf16Length && string.charAt(i) < 0x80) {
-      i++;
-    }
-
-    // This loop optimizes for chars less than 0x800.
-    for (; i < utf16Length; i++) {
-      char c = string.charAt(i);
-      if (c < 0x800) {
-        utf8Length += ((0x7f - c) >>> 31); // branch free!
-      } else {
-        utf8Length += encodedUtf8LengthGeneral(string, i);
-        break;
-      }
-    }
-
-    if (utf8Length < utf16Length) {
-      // Necessary and sufficient condition for overflow because of maximum 3x expansion
-      throw new IllegalArgumentException(
-          "UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
-    }
-
-    return utf8Length;
-  }
-
-  // adapted from
-  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L247
-  private static int encodedUtf8LengthGeneral(String string, int start) {
-    int utf16Length = string.length();
-    int utf8Length = 0;
-    for (int i = start; i < utf16Length; i++) {
-      char c = string.charAt(i);
-      if (c < 0x800) {
-        utf8Length += (0x7f - c) >>> 31; // branch free!
-      } else {
-        utf8Length += 2;
-        if (Character.isSurrogate(c)) {
-          // Check that we have a well-formed surrogate pair.
-          if (Character.codePointAt(string, i) != c) {
-            i++;
-          } else {
-            // invalid sequence
-            // At this point we have accumulated 3 byes of length (2 in this method and 1 in caller)
-            // for current character, reduce the length to 1 bytes as we are going to encode the
-            // invalid character as ?
-            utf8Length -= 2;
-          }
-        }
-      }
-    }
-
-    return utf8Length;
-  }
-
-  /** Write utf8 encoded string to output stream. */
-  @SuppressWarnings("UnusedVariable") // context argument is added for future use
-  static void writeUtf8(
-      CodedOutputStream output, String string, int utf8Length, MarshalerContext context)
-      throws IOException {
-    writeUtf8(output, string, utf8Length);
-  }
-
-  // Visible for testing
-  @SuppressWarnings("UnusedVariable") // utf8Length argument is added for future use
-  static void writeUtf8(CodedOutputStream output, String string, int utf8Length)
-      throws IOException {
-    encodeUtf8(output, string);
-  }
-
-  // encode utf8 the same way as length is computed in encodedUtf8Length
-  // adapted from
-  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L1016
-  private static void encodeUtf8(CodedOutputStream output, String in) throws IOException {
-    int utf16Length = in.length();
-    int i = 0;
-    // Designed to take advantage of
-    // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
-    for (char c; i < utf16Length && (c = in.charAt(i)) < 0x80; i++) {
-      output.write((byte) c);
-    }
-    if (i == utf16Length) {
-      return;
-    }
-
-    for (char c; i < utf16Length; i++) {
-      c = in.charAt(i);
-      if (c < 0x80) {
-        // 1 byte, 7 bits
-        output.write((byte) c);
-      } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
-        output.write((byte) ((0xF << 6) | (c >>> 6)));
-        output.write((byte) (0x80 | (0x3F & c)));
-      } else if (!Character.isSurrogate(c)) {
-        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
-        output.write((byte) ((0xF << 5) | (c >>> 12)));
-        output.write((byte) (0x80 | (0x3F & (c >>> 6))));
-        output.write((byte) (0x80 | (0x3F & c)));
-      } else {
-        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
-        // four UTF-8 bytes
-        int codePoint = Character.codePointAt(in, i);
-        if (codePoint != c) {
-          output.write((byte) ((0xF << 4) | (codePoint >>> 18)));
-          output.write((byte) (0x80 | (0x3F & (codePoint >>> 12))));
-          output.write((byte) (0x80 | (0x3F & (codePoint >>> 6))));
-          output.write((byte) (0x80 | (0x3F & codePoint)));
-          i++;
-        } else {
-          // invalid sequence
-          output.write((byte) '?');
-        }
-      }
-    }
   }
 
   private MarshalerUtil() {}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.internal.marshal;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -19,6 +21,8 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -33,6 +37,8 @@ public final class MarshalerUtil {
       CodedOutputStream.computeLengthDelimitedFieldSize(TraceId.getLength() / 2);
   private static final int SPAN_ID_VALUE_SIZE =
       CodedOutputStream.computeLengthDelimitedFieldSize(SpanId.getLength() / 2);
+  private static final MarshalerContext.Key GROUPER_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key ATTRIBUTES_SIZE_CALCULATOR_KEY = MarshalerContext.key();
 
   private static final boolean JSON_AVAILABLE;
 
@@ -68,6 +74,63 @@ public final class MarshalerUtil {
       marshalerList.add(createMarshaler.apply(data));
     }
     return result;
+  }
+
+  /** Groups SDK items by resource and instrumentation scope. */
+  public static <T> Map<Resource, Map<InstrumentationScopeInfo, List<T>>> groupByResourceAndScope(
+      Collection<T> dataList,
+      Function<T, Resource> getResource,
+      Function<T, InstrumentationScopeInfo> getInstrumentationScope,
+      MarshalerContext context) {
+    Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result = context.getIdentityMap();
+
+    Grouper<T> grouper = context.getInstance(GROUPER_KEY, Grouper::new);
+    grouper.initialize(result, getResource, getInstrumentationScope, context);
+    dataList.forEach(grouper);
+
+    return result;
+  }
+
+  private static class Grouper<T> implements Consumer<T> {
+    @SuppressWarnings("NullAway")
+    private Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result;
+
+    @SuppressWarnings("NullAway")
+    private Function<T, Resource> getResource;
+
+    @SuppressWarnings("NullAway")
+    private Function<T, InstrumentationScopeInfo> getInstrumentationScope;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result,
+        Function<T, Resource> getResource,
+        Function<T, InstrumentationScopeInfo> getInstrumentationScope,
+        MarshalerContext context) {
+      this.result = result;
+      this.getResource = getResource;
+      this.getInstrumentationScope = getInstrumentationScope;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(T data) {
+      Resource resource = getResource.apply(data);
+      Map<InstrumentationScopeInfo, List<T>> scopeInfoListMap = result.get(resource);
+      if (scopeInfoListMap == null) {
+        scopeInfoListMap = context.getIdentityMap();
+        result.put(resource, scopeInfoListMap);
+      }
+      InstrumentationScopeInfo instrumentationScopeInfo = getInstrumentationScope.apply(data);
+      List<T> elementList = scopeInfoListMap.get(instrumentationScopeInfo);
+      if (elementList == null) {
+        elementList = context.getList();
+        scopeInfoListMap.put(instrumentationScopeInfo, elementList);
+      }
+      elementList.add(data);
+    }
   }
 
   /** Preserialize into JSON format. */
@@ -185,10 +248,171 @@ public final class MarshalerUtil {
     return size;
   }
 
+  /** Returns the size of a repeated message field. */
+  public static <T> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      List<? extends T> messages,
+      StatelessMarshaler<T> marshaler,
+      MarshalerContext context) {
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    int size = 0;
+    int fieldTagSize = field.getTagSize();
+    for (int i = 0; i < messages.size(); i++) {
+      T message = messages.get(i);
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(message, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+    return size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  @SuppressWarnings("unchecked")
+  public static <T> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Collection<? extends T> messages,
+      StatelessMarshaler<T> marshaler,
+      MarshalerContext context,
+      MarshalerContext.Key key) {
+    if (messages instanceof List) {
+      return sizeRepeatedMessage(field, (List<T>) messages, marshaler, context);
+    }
+
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementSizeCalculator<T> sizeCalculator =
+        context.getInstance(key, RepeatedElementSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    messages.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  public static <K, V> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Map<K, V> messages,
+      StatelessMarshaler2<K, V> marshaler,
+      MarshalerContext context,
+      MarshalerContext.Key key) {
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementPairSizeCalculator<K, V> sizeCalculator =
+        context.getInstance(key, RepeatedElementPairSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    messages.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  public static int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Attributes attributes,
+      StatelessMarshaler2<AttributeKey<?>, Object> marshaler,
+      MarshalerContext context) {
+    if (attributes.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementPairSizeCalculator<AttributeKey<?>, Object> sizeCalculator =
+        context.getInstance(ATTRIBUTES_SIZE_CALCULATOR_KEY, RepeatedElementPairSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    attributes.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  private static class RepeatedElementSizeCalculator<T> implements Consumer<T> {
+    private int size;
+    private int fieldTagSize;
+
+    @SuppressWarnings("NullAway")
+    private StatelessMarshaler<T> marshaler;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        ProtoFieldInfo field, StatelessMarshaler<T> marshaler, MarshalerContext context) {
+      this.size = 0;
+      this.fieldTagSize = field.getTagSize();
+      this.marshaler = marshaler;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(T element) {
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(element, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+  }
+
+  private static class RepeatedElementPairSizeCalculator<K, V> implements BiConsumer<K, V> {
+    private int size;
+    private int fieldTagSize;
+
+    @SuppressWarnings("NullAway")
+    private StatelessMarshaler2<K, V> marshaler;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        ProtoFieldInfo field, StatelessMarshaler2<K, V> marshaler, MarshalerContext context) {
+      this.size = 0;
+      this.fieldTagSize = field.getTagSize();
+      this.marshaler = marshaler;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(K key, V value) {
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+  }
+
   /** Returns the size of a message field. */
   public static int sizeMessage(ProtoFieldInfo field, Marshaler message) {
     int fieldSize = message.getBinarySerializedSize();
     return field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+  }
+
+  /** Returns the size of a message field. */
+  public static <T> int sizeMessage(
+      ProtoFieldInfo field, T element, StatelessMarshaler<T> marshaler, MarshalerContext context) {
+    int sizeIndex = context.addSize();
+    int fieldSize = marshaler.getBinarySerializedSize(element, context);
+    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    context.setSize(sizeIndex, fieldSize);
+    return size;
+  }
+
+  /** Returns the size of a message field. */
+  public static <K, V> int sizeMessage(
+      ProtoFieldInfo field,
+      K key,
+      V value,
+      StatelessMarshaler2<K, V> marshaler,
+      MarshalerContext context) {
+    int sizeIndex = context.addSize();
+    int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
+    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    context.setSize(sizeIndex, fieldSize);
+    return size;
   }
 
   /** Returns the size of a bool field. */
@@ -278,6 +502,14 @@ public final class MarshalerUtil {
     return field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(message);
   }
 
+  /** Returns the size of a bytes field. */
+  public static int sizeBytes(ProtoFieldInfo field, int length) {
+    if (length == 0) {
+      return 0;
+    }
+    return field.getTagSize() + CodedOutputStream.computeLengthDelimitedFieldSize(length);
+  }
+
   /** Returns the size of a enum field. */
   // Assumes OTLP always defines the first item in an enum with number 0, which it does and will.
   public static int sizeEnum(ProtoFieldInfo field, ProtoEnumInfo enumValue) {
@@ -304,12 +536,163 @@ public final class MarshalerUtil {
     return field.getTagSize() + SPAN_ID_VALUE_SIZE;
   }
 
+  /** Returns the size of a string field. */
+  public static int sizeString(
+      ProtoFieldInfo field, @Nullable String value, MarshalerContext context) {
+    if (value == null || value.isEmpty()) {
+      return sizeBytes(field, 0);
+    }
+    if (context.marshalStringNoAllocation()) {
+      int utf8Size = getUtf8Size(value, context);
+      context.addSize(utf8Size);
+      return sizeBytes(field, utf8Size);
+    } else {
+      byte[] valueUtf8 = toBytes(value);
+      context.addData(valueUtf8);
+      return sizeBytes(field, valueUtf8.length);
+    }
+  }
+
   /** Converts the string to utf8 bytes for encoding. */
   public static byte[] toBytes(@Nullable String value) {
     if (value == null || value.isEmpty()) {
       return EMPTY_BYTES;
     }
     return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /** Returns the size of utf8 encoded string in bytes. */
+  @SuppressWarnings("UnusedVariable")
+  private static int getUtf8Size(String string, MarshalerContext context) {
+    return getUtf8Size(string);
+  }
+
+  // Visible for testing
+  static int getUtf8Size(String string) {
+    return encodedUtf8Length(string);
+  }
+
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L217
+  private static int encodedUtf8Length(String string) {
+    // Warning to maintainers: this implementation is highly optimized.
+    int utf16Length = string.length();
+    int utf8Length = utf16Length;
+    int i = 0;
+
+    // This loop optimizes for pure ASCII.
+    while (i < utf16Length && string.charAt(i) < 0x80) {
+      i++;
+    }
+
+    // This loop optimizes for chars less than 0x800.
+    for (; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += ((0x7f - c) >>> 31); // branch free!
+      } else {
+        utf8Length += encodedUtf8LengthGeneral(string, i);
+        break;
+      }
+    }
+
+    if (utf8Length < utf16Length) {
+      // Necessary and sufficient condition for overflow because of maximum 3x expansion
+      throw new IllegalArgumentException(
+          "UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+    }
+
+    return utf8Length;
+  }
+
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L247
+  private static int encodedUtf8LengthGeneral(String string, int start) {
+    int utf16Length = string.length();
+    int utf8Length = 0;
+    for (int i = start; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += (0x7f - c) >>> 31; // branch free!
+      } else {
+        utf8Length += 2;
+        if (Character.isSurrogate(c)) {
+          // Check that we have a well-formed surrogate pair.
+          if (Character.codePointAt(string, i) != c) {
+            i++;
+          } else {
+            // invalid sequence
+            // At this point we have accumulated 3 byes of length (2 in this method and 1 in caller)
+            // for current character, reduce the length to 1 bytes as we are going to encode the
+            // invalid character as ?
+            utf8Length -= 2;
+          }
+        }
+      }
+    }
+
+    return utf8Length;
+  }
+
+  /** Write utf8 encoded string to output stream. */
+  @SuppressWarnings("UnusedVariable") // context argument is added for future use
+  static void writeUtf8(
+      CodedOutputStream output, String string, int utf8Length, MarshalerContext context)
+      throws IOException {
+    writeUtf8(output, string, utf8Length);
+  }
+
+  // Visible for testing
+  @SuppressWarnings("UnusedVariable") // utf8Length argument is added for future use
+  static void writeUtf8(CodedOutputStream output, String string, int utf8Length)
+      throws IOException {
+    encodeUtf8(output, string);
+  }
+
+  // encode utf8 the same way as length is computed in encodedUtf8Length
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L1016
+  private static void encodeUtf8(CodedOutputStream output, String in) throws IOException {
+    int utf16Length = in.length();
+    int i = 0;
+    // Designed to take advantage of
+    // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+    for (char c; i < utf16Length && (c = in.charAt(i)) < 0x80; i++) {
+      output.write((byte) c);
+    }
+    if (i == utf16Length) {
+      return;
+    }
+
+    for (char c; i < utf16Length; i++) {
+      c = in.charAt(i);
+      if (c < 0x80) {
+        // 1 byte, 7 bits
+        output.write((byte) c);
+      } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
+        output.write((byte) ((0xF << 6) | (c >>> 6)));
+        output.write((byte) (0x80 | (0x3F & c)));
+      } else if (!Character.isSurrogate(c)) {
+        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+        output.write((byte) ((0xF << 5) | (c >>> 12)));
+        output.write((byte) (0x80 | (0x3F & (c >>> 6))));
+        output.write((byte) (0x80 | (0x3F & c)));
+      } else {
+        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
+        // four UTF-8 bytes
+        int codePoint = Character.codePointAt(in, i);
+        if (codePoint != c) {
+          output.write((byte) ((0xF << 4) | (codePoint >>> 18)));
+          output.write((byte) (0x80 | (0x3F & (codePoint >>> 12))));
+          output.write((byte) (0x80 | (0x3F & (codePoint >>> 6))));
+          output.write((byte) (0x80 | (0x3F & codePoint)));
+          i++;
+        } else {
+          // invalid sequence
+          output.write((byte) '?');
+        }
+      }
+    }
   }
 
   private MarshalerUtil() {}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
@@ -214,7 +214,7 @@ final class ProtoSerializer extends Serializer implements AutoCloseable {
   }
 
   @Override
-  public <T> void serializeRepeatedMessage(
+  public <T> void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       List<? extends T> messages,
       StatelessMarshaler<T> marshaler,

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
@@ -153,7 +153,7 @@ final class ProtoSerializer extends Serializer implements AutoCloseable {
     output.writeUInt32NoTag(field.getTag());
     output.writeUInt32NoTag(utf8Length);
 
-    MarshalerUtil.writeUtf8(output, string, utf8Length, context);
+    StatelessMarshalerUtil.writeUtf8(output, string, utf8Length, context);
   }
 
   @Override

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
@@ -210,9 +210,11 @@ public abstract class Serializer implements AutoCloseable {
 
   /**
    * Serializes a protobuf {@code string} field. {@code string} is the value to be serialized and
-   * {@code utf8Length} is the length of the string after it is encoded in UTF8.
+   * {@code utf8Length} is the length of the string after it is encoded in UTF8. This method reads
+   * elements from context, use together with {@link
+   * StatelessMarshalerUtil#sizeStringWithContext(ProtoFieldInfo, String, MarshalerContext)}.
    */
-  public void serializeString(
+  public void serializeStringWithContext(
       ProtoFieldInfo field, @Nullable String string, MarshalerContext context) throws IOException {
     if (string == null || string.isEmpty()) {
       return;
@@ -254,7 +256,12 @@ public abstract class Serializer implements AutoCloseable {
     writeEndMessage();
   }
 
-  public <T> void serializeMessage(
+  /**
+   * Serializes a protobuf embedded {@code message}. This method adds elements to context, use
+   * together with {@link StatelessMarshalerUtil#sizeMessageWithContext(ProtoFieldInfo, Object,
+   * StatelessMarshaler, MarshalerContext)}.
+   */
+  public <T> void serializeMessageWithContext(
       ProtoFieldInfo field, T message, StatelessMarshaler<T> marshaler, MarshalerContext context)
       throws IOException {
     writeStartMessage(field, context.getSize());
@@ -262,7 +269,12 @@ public abstract class Serializer implements AutoCloseable {
     writeEndMessage();
   }
 
-  public <K, V> void serializeMessage(
+  /**
+   * Serializes a protobuf embedded {@code message}. This method adds elements to context, use
+   * together with {@link StatelessMarshalerUtil#sizeMessageWithContext(ProtoFieldInfo, Object,
+   * Object, StatelessMarshaler2, MarshalerContext)}.
+   */
+  public <K, V> void serializeMessageWithContext(
       ProtoFieldInfo field,
       K key,
       V value,
@@ -377,16 +389,25 @@ public abstract class Serializer implements AutoCloseable {
   public abstract void serializeRepeatedMessage(
       ProtoFieldInfo field, List<? extends Marshaler> repeatedMessage) throws IOException;
 
-  /** Serializes {@code repeated message} field. */
-  public abstract <T> void serializeRepeatedMessage(
+  /**
+   * Serializes {@code repeated message} field. This method reads elements from context, use
+   * together with {@link StatelessMarshalerUtil#sizeRepeatedMessageWithContext(ProtoFieldInfo,
+   * List, StatelessMarshaler, MarshalerContext)}.
+   */
+  public abstract <T> void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       List<? extends T> messages,
       StatelessMarshaler<T> marshaler,
       MarshalerContext context)
       throws IOException;
 
+  /**
+   * Serializes {@code repeated message} field. This method reads elements from context, use
+   * together with {@link StatelessMarshalerUtil#sizeRepeatedMessageWithContext(ProtoFieldInfo,
+   * Collection, StatelessMarshaler, MarshalerContext, MarshalerContext.Key)}.
+   */
   @SuppressWarnings("unchecked")
-  public <T> void serializeRepeatedMessage(
+  public <T> void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Collection<? extends T> messages,
       StatelessMarshaler<T> marshaler,
@@ -394,7 +415,7 @@ public abstract class Serializer implements AutoCloseable {
       MarshalerContext.Key key)
       throws IOException {
     if (messages instanceof List) {
-      serializeRepeatedMessage(field, (List<T>) messages, marshaler, context);
+      serializeRepeatedMessageWithContext(field, (List<T>) messages, marshaler, context);
       return;
     }
 
@@ -409,7 +430,12 @@ public abstract class Serializer implements AutoCloseable {
     writeEndRepeated();
   }
 
-  public <K, V> void serializeRepeatedMessage(
+  /**
+   * Serializes {@code repeated message} field. This method reads elements from context, use
+   * together with {@link StatelessMarshalerUtil#sizeRepeatedMessageWithContext(ProtoFieldInfo, Map,
+   * StatelessMarshaler2, MarshalerContext, MarshalerContext.Key)}.
+   */
+  public <K, V> void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Map<K, V> messages,
       StatelessMarshaler2<K, V> marshaler,
@@ -428,7 +454,12 @@ public abstract class Serializer implements AutoCloseable {
     writeEndRepeated();
   }
 
-  public void serializeRepeatedMessage(
+  /**
+   * Serializes {@code repeated message} field. This method reads elements from context, use
+   * together with {@link StatelessMarshalerUtil#sizeRepeatedMessageWithContext(ProtoFieldInfo,
+   * Attributes, StatelessMarshaler2, MarshalerContext)}.
+   */
+  public void serializeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Attributes attributes,
       StatelessMarshaler2<AttributeKey<?>, Object> marshaler,

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler.java
@@ -7,9 +7,22 @@ package io.opentelemetry.exporter.internal.marshal;
 
 import java.io.IOException;
 
+/**
+ * Marshaler from an SDK structure to protobuf wire format. It is intended that the instances of
+ * this interface don't keep marshaling state and can be singletons. Any state needed for marshaling
+ * should be stored in {@link MarshalerContext}. Marshaler should be used so that first {@link
+ * #getBinarySerializedSize} is called and after that {@link #writeTo} is called. Calling {@link
+ * #getBinarySerializedSize} may add values to {@link MarshalerContext} that are later used in
+ * {@link #writeTo}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public interface StatelessMarshaler<T> {
 
+  /** Returns the number of bytes marshaling given value will write in proto binary format. */
   int getBinarySerializedSize(T value, MarshalerContext context);
 
+  /** Marshal given value using the provided {@link Serializer}. */
   void writeTo(Serializer output, T value, MarshalerContext context) throws IOException;
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import java.io.IOException;
+
+public interface StatelessMarshaler<T> {
+
+  int getBinarySerializedSize(T value, MarshalerContext context);
+
+  void writeTo(Serializer output, T value, MarshalerContext context) throws IOException;
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler2.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler2.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import java.io.IOException;
+
+public interface StatelessMarshaler2<K, V> {
+
+  int getBinarySerializedSize(K key, V value, MarshalerContext context);
+
+  void writeTo(Serializer output, K key, V value, MarshalerContext context) throws IOException;
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler2.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshaler2.java
@@ -7,9 +7,22 @@ package io.opentelemetry.exporter.internal.marshal;
 
 import java.io.IOException;
 
+/**
+ * Marshaler from an SDK structure to protobuf wire format. It is intended that the instances of
+ * this interface don't keep marshaling state and can be singletons. Any state needed for marshaling
+ * should be stored in {@link MarshalerContext}. Marshaler should be used so that first {@link
+ * #getBinarySerializedSize} is called and after that {@link #writeTo} is called. Calling {@link
+ * #getBinarySerializedSize} may add values to {@link MarshalerContext} that are later used in
+ * {@link #writeTo}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 public interface StatelessMarshaler2<K, V> {
 
+  /** Returns the number of bytes this Marshaler will write. */
   int getBinarySerializedSize(K key, V value, MarshalerContext context);
 
+  /** Marshal given key and value using the provided {@link Serializer}. */
   void writeTo(Serializer output, K key, V value, MarshalerContext context) throws IOException;
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtil.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * Marshaler utilities.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class StatelessMarshalerUtil {
+  private static final MarshalerContext.Key GROUPER_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key ATTRIBUTES_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+
+  /** Groups SDK items by resource and instrumentation scope. */
+  public static <T> Map<Resource, Map<InstrumentationScopeInfo, List<T>>> groupByResourceAndScope(
+      Collection<T> dataList,
+      Function<T, Resource> getResource,
+      Function<T, InstrumentationScopeInfo> getInstrumentationScope,
+      MarshalerContext context) {
+    Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result = context.getIdentityMap();
+
+    Grouper<T> grouper = context.getInstance(GROUPER_KEY, Grouper::new);
+    grouper.initialize(result, getResource, getInstrumentationScope, context);
+    dataList.forEach(grouper);
+
+    return result;
+  }
+
+  private static class Grouper<T> implements Consumer<T> {
+    @SuppressWarnings("NullAway")
+    private Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result;
+
+    @SuppressWarnings("NullAway")
+    private Function<T, Resource> getResource;
+
+    @SuppressWarnings("NullAway")
+    private Function<T, InstrumentationScopeInfo> getInstrumentationScope;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        Map<Resource, Map<InstrumentationScopeInfo, List<T>>> result,
+        Function<T, Resource> getResource,
+        Function<T, InstrumentationScopeInfo> getInstrumentationScope,
+        MarshalerContext context) {
+      this.result = result;
+      this.getResource = getResource;
+      this.getInstrumentationScope = getInstrumentationScope;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(T data) {
+      Resource resource = getResource.apply(data);
+      Map<InstrumentationScopeInfo, List<T>> scopeInfoListMap = result.get(resource);
+      if (scopeInfoListMap == null) {
+        scopeInfoListMap = context.getIdentityMap();
+        result.put(resource, scopeInfoListMap);
+      }
+      InstrumentationScopeInfo instrumentationScopeInfo = getInstrumentationScope.apply(data);
+      List<T> elementList = scopeInfoListMap.get(instrumentationScopeInfo);
+      if (elementList == null) {
+        elementList = context.getList();
+        scopeInfoListMap.put(instrumentationScopeInfo, elementList);
+      }
+      elementList.add(data);
+    }
+  }
+
+  /** Returns the size of a string field. */
+  public static int sizeString(
+      ProtoFieldInfo field, @Nullable String value, MarshalerContext context) {
+    if (value == null || value.isEmpty()) {
+      return sizeBytes(field, 0);
+    }
+    if (context.marshalStringNoAllocation()) {
+      int utf8Size = getUtf8Size(value, context);
+      context.addSize(utf8Size);
+      return sizeBytes(field, utf8Size);
+    } else {
+      byte[] valueUtf8 = MarshalerUtil.toBytes(value);
+      context.addData(valueUtf8);
+      return sizeBytes(field, valueUtf8.length);
+    }
+  }
+
+  /** Returns the size of a bytes field. */
+  public static int sizeBytes(ProtoFieldInfo field, int length) {
+    if (length == 0) {
+      return 0;
+    }
+    return field.getTagSize() + CodedOutputStream.computeLengthDelimitedFieldSize(length);
+  }
+
+  /** Returns the size of a repeated message field. */
+  public static <T> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      List<? extends T> messages,
+      StatelessMarshaler<T> marshaler,
+      MarshalerContext context) {
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    int size = 0;
+    int fieldTagSize = field.getTagSize();
+    for (int i = 0; i < messages.size(); i++) {
+      T message = messages.get(i);
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(message, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+    return size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  @SuppressWarnings("unchecked")
+  public static <T> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Collection<? extends T> messages,
+      StatelessMarshaler<T> marshaler,
+      MarshalerContext context,
+      MarshalerContext.Key key) {
+    if (messages instanceof List) {
+      return sizeRepeatedMessage(field, (List<T>) messages, marshaler, context);
+    }
+
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementSizeCalculator<T> sizeCalculator =
+        context.getInstance(key, RepeatedElementSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    messages.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  public static <K, V> int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Map<K, V> messages,
+      StatelessMarshaler2<K, V> marshaler,
+      MarshalerContext context,
+      MarshalerContext.Key key) {
+    if (messages.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementPairSizeCalculator<K, V> sizeCalculator =
+        context.getInstance(key, RepeatedElementPairSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    messages.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  /** Returns the size of a repeated message field. */
+  public static int sizeRepeatedMessage(
+      ProtoFieldInfo field,
+      Attributes attributes,
+      StatelessMarshaler2<AttributeKey<?>, Object> marshaler,
+      MarshalerContext context) {
+    if (attributes.isEmpty()) {
+      return 0;
+    }
+
+    RepeatedElementPairSizeCalculator<AttributeKey<?>, Object> sizeCalculator =
+        context.getInstance(ATTRIBUTES_SIZE_CALCULATOR_KEY, RepeatedElementPairSizeCalculator::new);
+    sizeCalculator.initialize(field, marshaler, context);
+    attributes.forEach(sizeCalculator);
+
+    return sizeCalculator.size;
+  }
+
+  private static class RepeatedElementSizeCalculator<T> implements Consumer<T> {
+    private int size;
+    private int fieldTagSize;
+
+    @SuppressWarnings("NullAway")
+    private StatelessMarshaler<T> marshaler;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        ProtoFieldInfo field, StatelessMarshaler<T> marshaler, MarshalerContext context) {
+      this.size = 0;
+      this.fieldTagSize = field.getTagSize();
+      this.marshaler = marshaler;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(T element) {
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(element, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+  }
+
+  private static class RepeatedElementPairSizeCalculator<K, V> implements BiConsumer<K, V> {
+    private int size;
+    private int fieldTagSize;
+
+    @SuppressWarnings("NullAway")
+    private StatelessMarshaler2<K, V> marshaler;
+
+    @SuppressWarnings("NullAway")
+    private MarshalerContext context;
+
+    void initialize(
+        ProtoFieldInfo field, StatelessMarshaler2<K, V> marshaler, MarshalerContext context) {
+      this.size = 0;
+      this.fieldTagSize = field.getTagSize();
+      this.marshaler = marshaler;
+      this.context = context;
+    }
+
+    @Override
+    public void accept(K key, V value) {
+      int sizeIndex = context.addSize();
+      int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
+      context.setSize(sizeIndex, fieldSize);
+      size += fieldTagSize + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    }
+  }
+
+  /** Returns the size of a message field. */
+  public static <T> int sizeMessage(
+      ProtoFieldInfo field, T element, StatelessMarshaler<T> marshaler, MarshalerContext context) {
+    int sizeIndex = context.addSize();
+    int fieldSize = marshaler.getBinarySerializedSize(element, context);
+    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    context.setSize(sizeIndex, fieldSize);
+    return size;
+  }
+
+  /** Returns the size of a message field. */
+  public static <K, V> int sizeMessage(
+      ProtoFieldInfo field,
+      K key,
+      V value,
+      StatelessMarshaler2<K, V> marshaler,
+      MarshalerContext context) {
+    int sizeIndex = context.addSize();
+    int fieldSize = marshaler.getBinarySerializedSize(key, value, context);
+    int size = field.getTagSize() + CodedOutputStream.computeUInt32SizeNoTag(fieldSize) + fieldSize;
+    context.setSize(sizeIndex, fieldSize);
+    return size;
+  }
+
+  /** Returns the size of utf8 encoded string in bytes. */
+  @SuppressWarnings("UnusedVariable")
+  private static int getUtf8Size(String string, MarshalerContext context) {
+    return getUtf8Size(string);
+  }
+
+  // Visible for testing
+  static int getUtf8Size(String string) {
+    return encodedUtf8Length(string);
+  }
+
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L217
+  private static int encodedUtf8Length(String string) {
+    // Warning to maintainers: this implementation is highly optimized.
+    int utf16Length = string.length();
+    int utf8Length = utf16Length;
+    int i = 0;
+
+    // This loop optimizes for pure ASCII.
+    while (i < utf16Length && string.charAt(i) < 0x80) {
+      i++;
+    }
+
+    // This loop optimizes for chars less than 0x800.
+    for (; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += ((0x7f - c) >>> 31); // branch free!
+      } else {
+        utf8Length += encodedUtf8LengthGeneral(string, i);
+        break;
+      }
+    }
+
+    if (utf8Length < utf16Length) {
+      // Necessary and sufficient condition for overflow because of maximum 3x expansion
+      throw new IllegalArgumentException(
+          "UTF-8 length does not fit in int: " + (utf8Length + (1L << 32)));
+    }
+
+    return utf8Length;
+  }
+
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L247
+  private static int encodedUtf8LengthGeneral(String string, int start) {
+    int utf16Length = string.length();
+    int utf8Length = 0;
+    for (int i = start; i < utf16Length; i++) {
+      char c = string.charAt(i);
+      if (c < 0x800) {
+        utf8Length += (0x7f - c) >>> 31; // branch free!
+      } else {
+        utf8Length += 2;
+        if (Character.isSurrogate(c)) {
+          // Check that we have a well-formed surrogate pair.
+          if (Character.codePointAt(string, i) != c) {
+            i++;
+          } else {
+            // invalid sequence
+            // At this point we have accumulated 3 byes of length (2 in this method and 1 in caller)
+            // for current character, reduce the length to 1 bytes as we are going to encode the
+            // invalid character as ?
+            utf8Length -= 2;
+          }
+        }
+      }
+    }
+
+    return utf8Length;
+  }
+
+  /** Write utf8 encoded string to output stream. */
+  @SuppressWarnings("UnusedVariable") // context argument is added for future use
+  static void writeUtf8(
+      CodedOutputStream output, String string, int utf8Length, MarshalerContext context)
+      throws IOException {
+    writeUtf8(output, string, utf8Length);
+  }
+
+  // Visible for testing
+  @SuppressWarnings("UnusedVariable") // utf8Length argument is added for future use
+  static void writeUtf8(CodedOutputStream output, String string, int utf8Length)
+      throws IOException {
+    encodeUtf8(output, string);
+  }
+
+  // encode utf8 the same way as length is computed in encodedUtf8Length
+  // adapted from
+  // https://github.com/protocolbuffers/protobuf/blob/b618f6750aed641a23d5f26fbbaf654668846d24/java/core/src/main/java/com/google/protobuf/Utf8.java#L1016
+  private static void encodeUtf8(CodedOutputStream output, String in) throws IOException {
+    int utf16Length = in.length();
+    int i = 0;
+    // Designed to take advantage of
+    // https://wiki.openjdk.java.net/display/HotSpotInternals/RangeCheckElimination
+    for (char c; i < utf16Length && (c = in.charAt(i)) < 0x80; i++) {
+      output.write((byte) c);
+    }
+    if (i == utf16Length) {
+      return;
+    }
+
+    for (char c; i < utf16Length; i++) {
+      c = in.charAt(i);
+      if (c < 0x80) {
+        // 1 byte, 7 bits
+        output.write((byte) c);
+      } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
+        output.write((byte) ((0xF << 6) | (c >>> 6)));
+        output.write((byte) (0x80 | (0x3F & c)));
+      } else if (!Character.isSurrogate(c)) {
+        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+        output.write((byte) ((0xF << 5) | (c >>> 12)));
+        output.write((byte) (0x80 | (0x3F & (c >>> 6))));
+        output.write((byte) (0x80 | (0x3F & c)));
+      } else {
+        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
+        // four UTF-8 bytes
+        int codePoint = Character.codePointAt(in, i);
+        if (codePoint != c) {
+          output.write((byte) ((0xF << 4) | (codePoint >>> 18)));
+          output.write((byte) (0x80 | (0x3F & (codePoint >>> 12))));
+          output.write((byte) (0x80 | (0x3F & (codePoint >>> 6))));
+          output.write((byte) (0x80 | (0x3F & codePoint)));
+          i++;
+        } else {
+          // invalid sequence
+          output.write((byte) '?');
+        }
+      }
+    }
+  }
+
+  private StatelessMarshalerUtil() {}
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtil.java
@@ -85,8 +85,11 @@ public final class StatelessMarshalerUtil {
     }
   }
 
-  /** Returns the size of a string field. */
-  public static int sizeString(
+  /**
+   * Returns the size of a string field. This method adds elements to context, use together with
+   * {@link Serializer#serializeStringWithContext(ProtoFieldInfo, String, MarshalerContext)}.
+   */
+  public static int sizeStringWithContext(
       ProtoFieldInfo field, @Nullable String value, MarshalerContext context) {
     if (value == null || value.isEmpty()) {
       return sizeBytes(field, 0);
@@ -103,15 +106,19 @@ public final class StatelessMarshalerUtil {
   }
 
   /** Returns the size of a bytes field. */
-  public static int sizeBytes(ProtoFieldInfo field, int length) {
+  private static int sizeBytes(ProtoFieldInfo field, int length) {
     if (length == 0) {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeLengthDelimitedFieldSize(length);
   }
 
-  /** Returns the size of a repeated message field. */
-  public static <T> int sizeRepeatedMessage(
+  /**
+   * Returns the size of a repeated message field. This method adds elements to context, use
+   * together with {@link Serializer#serializeRepeatedMessageWithContext(ProtoFieldInfo, List,
+   * StatelessMarshaler, MarshalerContext)}.
+   */
+  public static <T> int sizeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       List<? extends T> messages,
       StatelessMarshaler<T> marshaler,
@@ -132,16 +139,20 @@ public final class StatelessMarshalerUtil {
     return size;
   }
 
-  /** Returns the size of a repeated message field. */
+  /**
+   * Returns the size of a repeated message field. This method adds elements to context, use
+   * together with {@link Serializer#serializeRepeatedMessageWithContext(ProtoFieldInfo, Collection,
+   * StatelessMarshaler, MarshalerContext, MarshalerContext.Key)}.
+   */
   @SuppressWarnings("unchecked")
-  public static <T> int sizeRepeatedMessage(
+  public static <T> int sizeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Collection<? extends T> messages,
       StatelessMarshaler<T> marshaler,
       MarshalerContext context,
       MarshalerContext.Key key) {
     if (messages instanceof List) {
-      return sizeRepeatedMessage(field, (List<T>) messages, marshaler, context);
+      return sizeRepeatedMessageWithContext(field, (List<T>) messages, marshaler, context);
     }
 
     if (messages.isEmpty()) {
@@ -156,8 +167,12 @@ public final class StatelessMarshalerUtil {
     return sizeCalculator.size;
   }
 
-  /** Returns the size of a repeated message field. */
-  public static <K, V> int sizeRepeatedMessage(
+  /**
+   * Returns the size of a repeated message field. This method adds elements to context, use
+   * together with {@link Serializer#serializeRepeatedMessageWithContext(ProtoFieldInfo, Map,
+   * StatelessMarshaler2, MarshalerContext, MarshalerContext.Key)}.
+   */
+  public static <K, V> int sizeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Map<K, V> messages,
       StatelessMarshaler2<K, V> marshaler,
@@ -175,8 +190,12 @@ public final class StatelessMarshalerUtil {
     return sizeCalculator.size;
   }
 
-  /** Returns the size of a repeated message field. */
-  public static int sizeRepeatedMessage(
+  /**
+   * Returns the size of a repeated message field. This method adds elements to context, use
+   * together with {@link Serializer#serializeRepeatedMessageWithContext(ProtoFieldInfo, Attributes,
+   * StatelessMarshaler2, MarshalerContext)}.
+   */
+  public static int sizeRepeatedMessageWithContext(
       ProtoFieldInfo field,
       Attributes attributes,
       StatelessMarshaler2<AttributeKey<?>, Object> marshaler,
@@ -247,8 +266,12 @@ public final class StatelessMarshalerUtil {
     }
   }
 
-  /** Returns the size of a message field. */
-  public static <T> int sizeMessage(
+  /**
+   * Returns the size of a message field. This method adds elements to context, use together with
+   * {@link Serializer#serializeMessageWithContext(ProtoFieldInfo, Object, StatelessMarshaler,
+   * MarshalerContext)}.
+   */
+  public static <T> int sizeMessageWithContext(
       ProtoFieldInfo field, T element, StatelessMarshaler<T> marshaler, MarshalerContext context) {
     int sizeIndex = context.addSize();
     int fieldSize = marshaler.getBinarySerializedSize(element, context);
@@ -257,8 +280,12 @@ public final class StatelessMarshalerUtil {
     return size;
   }
 
-  /** Returns the size of a message field. */
-  public static <K, V> int sizeMessage(
+  /**
+   * Returns the size of a message field. This method adds elements to context, use together with
+   * {@link Serializer#serializeMessageWithContext(ProtoFieldInfo, Object, Object,
+   * StatelessMarshaler2, MarshalerContext)}.
+   */
+  public static <K, V> int sizeMessageWithContext(
       ProtoFieldInfo field,
       K key,
       V value,

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.marshal;
+
+import static io.opentelemetry.exporter.internal.marshal.MarshalerUtil.getUtf8Size;
+import static io.opentelemetry.exporter.internal.marshal.MarshalerUtil.writeUtf8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class MarshalerUtilTest {
+
+  @Test
+  @SuppressWarnings("AvoidEscapedUnicodeCharacters")
+  void encodeUtf8() {
+    assertThat(getUtf8Size("")).isEqualTo(0);
+    assertThat(testUtf8("", 0)).isEqualTo("");
+
+    assertThat(getUtf8Size("a")).isEqualTo(1);
+    assertThat(testUtf8("a", 1)).isEqualTo("a");
+
+    assertThat(getUtf8Size("©")).isEqualTo(2);
+    assertThat(testUtf8("©", 2)).isEqualTo("©");
+
+    assertThat(getUtf8Size("∆")).isEqualTo(3);
+    assertThat(testUtf8("∆", 3)).isEqualTo("∆");
+
+    assertThat(getUtf8Size("😀")).isEqualTo(4);
+    assertThat(testUtf8("😀", 4)).isEqualTo("😀");
+
+    // test that invalid characters are replaced with ?
+    assertThat(getUtf8Size("\uD83D😀\uDE00")).isEqualTo(6);
+    assertThat(testUtf8("\uD83D😀\uDE00", 6)).isEqualTo("?😀?");
+
+    // the same invalid sequence as encoded by the jdk
+    byte[] bytes = "\uD83D😀\uDE00".getBytes(StandardCharsets.UTF_8);
+    assertThat(bytes.length).isEqualTo(6);
+    assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo("?😀?");
+  }
+
+  @RepeatedTest(1000)
+  void testUtf8SizeLatin1() {
+    Random random = new Random();
+    byte[] bytes = new byte[15001];
+    random.nextBytes(bytes);
+    String string = new String(bytes, StandardCharsets.ISO_8859_1);
+    int utf8Size = string.getBytes(StandardCharsets.UTF_8).length;
+    assertThat(getUtf8Size(string)).isEqualTo(utf8Size);
+  }
+
+  private static String testUtf8(String string, int utf8Length) {
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      CodedOutputStream codedOutputStream = CodedOutputStream.newInstance(outputStream);
+      writeUtf8(codedOutputStream, string, utf8Length);
+      codedOutputStream.flush();
+      return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(exception);
+    }
+  }
+}

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtilTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.exporter.internal.marshal;
 
-import static io.opentelemetry.exporter.internal.marshal.MarshalerUtil.getUtf8Size;
-import static io.opentelemetry.exporter.internal.marshal.MarshalerUtil.writeUtf8;
+import static io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil.getUtf8Size;
+import static io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil.writeUtf8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/StatelessMarshalerUtilTest.java
@@ -15,7 +15,7 @@ import java.util.Random;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-class MarshalerUtilTest {
+class StatelessMarshalerUtilTest {
 
   @Test
   @SuppressWarnings("AvoidEscapedUnicodeCharacters")

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/RequestMarshalBenchmarks.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/RequestMarshalBenchmarks.java
@@ -31,14 +31,14 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public int createCustomMarshal(RequestMarshalState state) {
+  public int createStatefulMarshaler(RequestMarshalState state) {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
     return requestMarshaler.getBinarySerializedSize();
   }
 
   @Benchmark
   @Threads(1)
-  public int marshalCustom(RequestMarshalState state) throws IOException {
+  public int marshalStatefulBinary(RequestMarshalState state) throws IOException {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
     OUTPUT.reset(requestMarshaler.getBinarySerializedSize());
     requestMarshaler.writeBinaryTo(OUTPUT);
@@ -47,7 +47,7 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public int marshalJson(RequestMarshalState state) throws IOException {
+  public int marshalStatefulJson(RequestMarshalState state) throws IOException {
     TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(state.spanDataList);
     OUTPUT.reset();
     requestMarshaler.writeJsonTo(OUTPUT);
@@ -56,7 +56,7 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public int createCustomMarshalLowAllocation(RequestMarshalState state) {
+  public int createStatelessMarshaler(RequestMarshalState state) {
     LowAllocationTraceRequestMarshaler requestMarshaler = MARSHALER;
     requestMarshaler.initialize(state.spanDataList);
     try {
@@ -68,7 +68,7 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public int marshalCustomLowAllocation(RequestMarshalState state) throws IOException {
+  public int marshalStatelessBinary(RequestMarshalState state) throws IOException {
     LowAllocationTraceRequestMarshaler requestMarshaler = MARSHALER;
     requestMarshaler.initialize(state.spanDataList);
     try {
@@ -82,7 +82,7 @@ public class RequestMarshalBenchmarks {
 
   @Benchmark
   @Threads(1)
-  public int marshalJsonLowAllocation(RequestMarshalState state) throws IOException {
+  public int marshalStatelessJson(RequestMarshalState state) throws IOException {
     LowAllocationTraceRequestMarshaler requestMarshaler = MARSHALER;
     requestMarshaler.initialize(state.spanDataList);
     try {

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/StringMarshalBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/StringMarshalBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class StringMarshalBenchmark {
+  private static final TestMarshaler MARSHALER = new TestMarshaler();
+  private static final TestOutputStream OUTPUT = new TestOutputStream();
+
+  @Benchmark
+  @Threads(1)
+  public int marshalAsciiString(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    Marshaler marshaler = StringAnyValueMarshaler.create(state.asciiString);
+    marshaler.writeBinaryTo(OUTPUT);
+    return OUTPUT.getCount();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public int marshalLatin1String(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    Marshaler marshaler = StringAnyValueMarshaler.create(state.latin1String);
+    marshaler.writeBinaryTo(OUTPUT);
+    return OUTPUT.getCount();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public int marshalUnicodeString(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    Marshaler marshaler = StringAnyValueMarshaler.create(state.unicodeString);
+    marshaler.writeBinaryTo(OUTPUT);
+    return OUTPUT.getCount();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public int marshalAsciiStringLowAllocation(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    try {
+      MARSHALER.initialize(state.asciiString);
+      MARSHALER.writeBinaryTo(OUTPUT);
+      return OUTPUT.getCount();
+    } finally {
+      MARSHALER.reset();
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public int marshalLatin1StringLowAllocation(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    try {
+      MARSHALER.initialize(state.latin1String);
+      MARSHALER.writeBinaryTo(OUTPUT);
+      return OUTPUT.getCount();
+    } finally {
+      MARSHALER.reset();
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public int marshalUnicodeStringLowAllocation(StringMarshalState state) throws IOException {
+    OUTPUT.reset();
+    try {
+      MARSHALER.initialize(state.unicodeString);
+      MARSHALER.writeBinaryTo(OUTPUT);
+      return OUTPUT.getCount();
+    } finally {
+      MARSHALER.reset();
+    }
+  }
+
+  private static class TestMarshaler extends Marshaler {
+    private final MarshalerContext context = new MarshalerContext();
+    private int size;
+    private String value;
+
+    public void initialize(String string) {
+      value = string;
+      size = StringAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(string, context);
+    }
+
+    public void reset() {
+      context.reset();
+    }
+
+    @Override
+    public int getBinarySerializedSize() {
+      return size;
+    }
+
+    @Override
+    public void writeTo(Serializer output) throws IOException {
+      StringAnyValueStatelessMarshaler.INSTANCE.writeTo(output, value, context);
+    }
+  }
+}

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/StringMarshalState.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/StringMarshalState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class StringMarshalState {
+
+  @Param({"16", "512"})
+  int stringSize;
+
+  String asciiString;
+  String latin1String;
+  String unicodeString;
+
+  @Setup
+  public void setup() {
+    asciiString = makeString('a', stringSize);
+    latin1String = makeString('ä', stringSize);
+    unicodeString = makeString('∆', stringSize);
+  }
+
+  private static String makeString(char c, int size) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < size; i++) {
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+}

--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/TestOutputStream.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/TestOutputStream.java
@@ -8,7 +8,7 @@ package io.opentelemetry.exporter.internal.otlp;
 import java.io.OutputStream;
 
 class TestOutputStream extends OutputStream {
-  private final int size;
+  private int size;
   private int count;
 
   TestOutputStream() {
@@ -25,5 +25,18 @@ class TestOutputStream extends OutputStream {
     if (size > 0 && count > size) {
       throw new IllegalStateException("max size exceeded");
     }
+  }
+
+  void reset(int size) {
+    this.size = size;
+    this.count = 0;
+  }
+
+  void reset() {
+    reset(-1);
+  }
+
+  int getCount() {
+    return count;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
@@ -7,13 +7,15 @@ package io.opentelemetry.exporter.internal.otlp;
 
 import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
-import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.proto.common.v1.internal.ArrayValue;
 import java.io.IOException;
 import java.util.List;
 
+/** See {@link ArrayAnyValueMarshaler}. */
+// TODO: add support for List<io.opentelemetry.api.incubator.logs.AnyValue<?>>
 final class ArrayAnyValueStatelessMarshaler<T>
     implements StatelessMarshaler2<AttributeType, List<T>> {
   static final ArrayAnyValueStatelessMarshaler<Object> INSTANCE =
@@ -59,22 +61,22 @@ final class ArrayAnyValueStatelessMarshaler<T>
   public int getBinarySerializedSize(AttributeType type, List<T> list, MarshalerContext context) {
     switch (type) {
       case STRING_ARRAY:
-        return MarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessage(
             ArrayValue.VALUES,
             (List<String>) list,
             StringAnyValueStatelessMarshaler.INSTANCE,
             context);
       case LONG_ARRAY:
-        return MarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessage(
             ArrayValue.VALUES, (List<Long>) list, IntAnyValueStatelessMarshaler.INSTANCE, context);
       case BOOLEAN_ARRAY:
-        return MarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessage(
             ArrayValue.VALUES,
             (List<Boolean>) list,
             BoolAnyValueStatelessMarshaler.INSTANCE,
             context);
       case DOUBLE_ARRAY:
-        return MarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessage(
             ArrayValue.VALUES,
             (List<Double>) list,
             DoubleAnyValueStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.proto.common.v1.internal.ArrayValue;
+import java.io.IOException;
+import java.util.List;
+
+final class ArrayAnyValueStatelessMarshaler<T>
+    implements StatelessMarshaler2<AttributeType, List<T>> {
+  static final ArrayAnyValueStatelessMarshaler<Object> INSTANCE =
+      new ArrayAnyValueStatelessMarshaler<>();
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void writeTo(Serializer output, AttributeType type, List<T> list, MarshalerContext context)
+      throws IOException {
+    switch (type) {
+      case STRING_ARRAY:
+        output.serializeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<String>) list,
+            StringAnyValueStatelessMarshaler.INSTANCE,
+            context);
+        return;
+      case LONG_ARRAY:
+        output.serializeRepeatedMessage(
+            ArrayValue.VALUES, (List<Long>) list, IntAnyValueStatelessMarshaler.INSTANCE, context);
+        return;
+      case BOOLEAN_ARRAY:
+        output.serializeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<Boolean>) list,
+            BoolAnyValueStatelessMarshaler.INSTANCE,
+            context);
+        return;
+      case DOUBLE_ARRAY:
+        output.serializeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<Double>) list,
+            DoubleAnyValueStatelessMarshaler.INSTANCE,
+            context);
+        return;
+      default:
+        throw new IllegalArgumentException("Unsupported attribute type.");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public int getBinarySerializedSize(AttributeType type, List<T> list, MarshalerContext context) {
+    switch (type) {
+      case STRING_ARRAY:
+        return MarshalerUtil.sizeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<String>) list,
+            StringAnyValueStatelessMarshaler.INSTANCE,
+            context);
+      case LONG_ARRAY:
+        return MarshalerUtil.sizeRepeatedMessage(
+            ArrayValue.VALUES, (List<Long>) list, IntAnyValueStatelessMarshaler.INSTANCE, context);
+      case BOOLEAN_ARRAY:
+        return MarshalerUtil.sizeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<Boolean>) list,
+            BoolAnyValueStatelessMarshaler.INSTANCE,
+            context);
+      case DOUBLE_ARRAY:
+        return MarshalerUtil.sizeRepeatedMessage(
+            ArrayValue.VALUES,
+            (List<Double>) list,
+            DoubleAnyValueStatelessMarshaler.INSTANCE,
+            context);
+      default:
+        throw new IllegalArgumentException("Unsupported attribute type.");
+    }
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
@@ -27,25 +27,25 @@ final class ArrayAnyValueStatelessMarshaler<T>
       throws IOException {
     switch (type) {
       case STRING_ARRAY:
-        output.serializeRepeatedMessage(
+        output.serializeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<String>) list,
             StringAnyValueStatelessMarshaler.INSTANCE,
             context);
         return;
       case LONG_ARRAY:
-        output.serializeRepeatedMessage(
+        output.serializeRepeatedMessageWithContext(
             ArrayValue.VALUES, (List<Long>) list, IntAnyValueStatelessMarshaler.INSTANCE, context);
         return;
       case BOOLEAN_ARRAY:
-        output.serializeRepeatedMessage(
+        output.serializeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<Boolean>) list,
             BoolAnyValueStatelessMarshaler.INSTANCE,
             context);
         return;
       case DOUBLE_ARRAY:
-        output.serializeRepeatedMessage(
+        output.serializeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<Double>) list,
             DoubleAnyValueStatelessMarshaler.INSTANCE,
@@ -61,22 +61,22 @@ final class ArrayAnyValueStatelessMarshaler<T>
   public int getBinarySerializedSize(AttributeType type, List<T> list, MarshalerContext context) {
     switch (type) {
       case STRING_ARRAY:
-        return StatelessMarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<String>) list,
             StringAnyValueStatelessMarshaler.INSTANCE,
             context);
       case LONG_ARRAY:
-        return StatelessMarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ArrayValue.VALUES, (List<Long>) list, IntAnyValueStatelessMarshaler.INSTANCE, context);
       case BOOLEAN_ARRAY:
-        return StatelessMarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<Boolean>) list,
             BoolAnyValueStatelessMarshaler.INSTANCE,
             context);
       case DOUBLE_ARRAY:
-        return StatelessMarshalerUtil.sizeRepeatedMessage(
+        return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ArrayValue.VALUES,
             (List<Double>) list,
             DoubleAnyValueStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BoolAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BoolAnyValueStatelessMarshaler.java
@@ -12,6 +12,7 @@ import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;
 import java.io.IOException;
 
+/** See {@link BoolAnyValueMarshaler}. */
 final class BoolAnyValueStatelessMarshaler implements StatelessMarshaler<Boolean> {
   static final BoolAnyValueStatelessMarshaler INSTANCE = new BoolAnyValueStatelessMarshaler();
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BoolAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BoolAnyValueStatelessMarshaler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.marshal.CodedOutputStream;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.common.v1.internal.AnyValue;
+import java.io.IOException;
+
+final class BoolAnyValueStatelessMarshaler implements StatelessMarshaler<Boolean> {
+  static final BoolAnyValueStatelessMarshaler INSTANCE = new BoolAnyValueStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, Boolean value, MarshalerContext context)
+      throws IOException {
+    output.writeBool(AnyValue.BOOL_VALUE, value);
+  }
+
+  @Override
+  public int getBinarySerializedSize(Boolean value, MarshalerContext context) {
+    return AnyValue.BOOL_VALUE.getTagSize() + CodedOutputStream.computeBoolSizeNoTag(value);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/DoubleAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/DoubleAnyValueStatelessMarshaler.java
@@ -12,6 +12,7 @@ import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;
 import java.io.IOException;
 
+/** See {@link DoubleAnyValueMarshaler}. */
 final class DoubleAnyValueStatelessMarshaler implements StatelessMarshaler<Double> {
   static final DoubleAnyValueStatelessMarshaler INSTANCE = new DoubleAnyValueStatelessMarshaler();
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/DoubleAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/DoubleAnyValueStatelessMarshaler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.marshal.CodedOutputStream;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.common.v1.internal.AnyValue;
+import java.io.IOException;
+
+final class DoubleAnyValueStatelessMarshaler implements StatelessMarshaler<Double> {
+  static final DoubleAnyValueStatelessMarshaler INSTANCE = new DoubleAnyValueStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, Double value, MarshalerContext context)
+      throws IOException {
+    output.writeDouble(AnyValue.DOUBLE_VALUE, value);
+  }
+
+  @Override
+  public int getBinarySerializedSize(Double value, MarshalerContext context) {
+    return AnyValue.DOUBLE_VALUE.getTagSize() + CodedOutputStream.computeDoubleSizeNoTag(value);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IntAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IntAnyValueStatelessMarshaler.java
@@ -12,6 +12,7 @@ import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;
 import java.io.IOException;
 
+/** See {@link IntAnyValueMarshaler}. */
 final class IntAnyValueStatelessMarshaler implements StatelessMarshaler<Long> {
   static final IntAnyValueStatelessMarshaler INSTANCE = new IntAnyValueStatelessMarshaler();
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IntAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IntAnyValueStatelessMarshaler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.marshal.CodedOutputStream;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.common.v1.internal.AnyValue;
+import java.io.IOException;
+
+final class IntAnyValueStatelessMarshaler implements StatelessMarshaler<Long> {
+  static final IntAnyValueStatelessMarshaler INSTANCE = new IntAnyValueStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, Long value, MarshalerContext context) throws IOException {
+    output.writeInt64(AnyValue.INT_VALUE, value);
+  }
+
+  @Override
+  public int getBinarySerializedSize(Long value, MarshalerContext context) {
+    return AnyValue.INT_VALUE.getTagSize() + CodedOutputStream.computeInt64SizeNoTag(value);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
@@ -12,13 +12,14 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;
 import io.opentelemetry.proto.common.v1.internal.KeyValue;
 import java.io.IOException;
 import java.util.List;
 
 /**
- * A Marshaler of key value pairs.
+ * A Marshaler of key value pairs. See {@link KeyValueMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -53,11 +54,11 @@ public final class KeyValueStatelessMarshaler
         byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
         size += MarshalerUtil.sizeBytes(KeyValue.KEY, keyUtf8);
       } else {
-        return MarshalerUtil.sizeString(KeyValue.KEY, attributeKey.getKey(), context);
+        return StatelessMarshalerUtil.sizeString(KeyValue.KEY, attributeKey.getKey(), context);
       }
     }
     size +=
-        MarshalerUtil.sizeMessage(
+        StatelessMarshalerUtil.sizeMessage(
             KeyValue.VALUE, attributeKey, value, ValueStatelessMarshaler.INSTANCE, context);
 
     return size;
@@ -89,7 +90,7 @@ public final class KeyValueStatelessMarshaler
         case LONG_ARRAY:
         case BOOLEAN_ARRAY:
         case DOUBLE_ARRAY:
-          return MarshalerUtil.sizeMessage(
+          return StatelessMarshalerUtil.sizeMessage(
               AnyValue.ARRAY_VALUE,
               attributeType,
               (List<Object>) value,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
@@ -39,9 +39,9 @@ public final class KeyValueStatelessMarshaler
       byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
       output.serializeString(KeyValue.KEY, keyUtf8);
     } else {
-      output.serializeString(KeyValue.KEY, attributeKey.getKey(), context);
+      output.serializeStringWithContext(KeyValue.KEY, attributeKey.getKey(), context);
     }
-    output.serializeMessage(
+    output.serializeMessageWithContext(
         KeyValue.VALUE, attributeKey, value, ValueStatelessMarshaler.INSTANCE, context);
   }
 
@@ -54,11 +54,12 @@ public final class KeyValueStatelessMarshaler
         byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
         size += MarshalerUtil.sizeBytes(KeyValue.KEY, keyUtf8);
       } else {
-        return StatelessMarshalerUtil.sizeString(KeyValue.KEY, attributeKey.getKey(), context);
+        return StatelessMarshalerUtil.sizeStringWithContext(
+            KeyValue.KEY, attributeKey.getKey(), context);
       }
     }
     size +=
-        StatelessMarshalerUtil.sizeMessage(
+        StatelessMarshalerUtil.sizeMessageWithContext(
             KeyValue.VALUE, attributeKey, value, ValueStatelessMarshaler.INSTANCE, context);
 
     return size;
@@ -90,7 +91,7 @@ public final class KeyValueStatelessMarshaler
         case LONG_ARRAY:
         case BOOLEAN_ARRAY:
         case DOUBLE_ARRAY:
-          return StatelessMarshalerUtil.sizeMessage(
+          return StatelessMarshalerUtil.sizeMessageWithContext(
               AnyValue.ARRAY_VALUE,
               attributeType,
               (List<Object>) value,
@@ -125,7 +126,7 @@ public final class KeyValueStatelessMarshaler
         case LONG_ARRAY:
         case BOOLEAN_ARRAY:
         case DOUBLE_ARRAY:
-          output.serializeMessage(
+          output.serializeMessageWithContext(
               AnyValue.ARRAY_VALUE,
               attributeType,
               (List<Object>) value,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.proto.common.v1.internal.AnyValue;
+import io.opentelemetry.proto.common.v1.internal.KeyValue;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A Marshaler of key value pairs.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class KeyValueStatelessMarshaler
+    implements StatelessMarshaler2<AttributeKey<?>, Object> {
+  public static final KeyValueStatelessMarshaler INSTANCE = new KeyValueStatelessMarshaler();
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  @Override
+  public void writeTo(
+      Serializer output, AttributeKey<?> attributeKey, Object value, MarshalerContext context)
+      throws IOException {
+    if (attributeKey.getKey().isEmpty()) {
+      output.serializeString(KeyValue.KEY, EMPTY_BYTES);
+    } else if (attributeKey instanceof InternalAttributeKeyImpl) {
+      byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
+      output.serializeString(KeyValue.KEY, keyUtf8);
+    } else {
+      output.serializeString(KeyValue.KEY, attributeKey.getKey(), context);
+    }
+    output.serializeMessage(
+        KeyValue.VALUE, attributeKey, value, ValueStatelessMarshaler.INSTANCE, context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      AttributeKey<?> attributeKey, Object value, MarshalerContext context) {
+    int size = 0;
+    if (!attributeKey.getKey().isEmpty()) {
+      if (attributeKey instanceof InternalAttributeKeyImpl) {
+        byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
+        size += MarshalerUtil.sizeBytes(KeyValue.KEY, keyUtf8);
+      } else {
+        return MarshalerUtil.sizeString(KeyValue.KEY, attributeKey.getKey(), context);
+      }
+    }
+    size +=
+        MarshalerUtil.sizeMessage(
+            KeyValue.VALUE, attributeKey, value, ValueStatelessMarshaler.INSTANCE, context);
+
+    return size;
+  }
+
+  private static class ValueStatelessMarshaler
+      implements StatelessMarshaler2<AttributeKey<?>, Object> {
+    static final ValueStatelessMarshaler INSTANCE = new ValueStatelessMarshaler();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public int getBinarySerializedSize(
+        AttributeKey<?> attributeKey, Object value, MarshalerContext context) {
+      AttributeType attributeType = attributeKey.getType();
+      switch (attributeType) {
+        case STRING:
+          return StringAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(
+              (String) value, context);
+        case LONG:
+          return IntAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(
+              (Long) value, context);
+        case BOOLEAN:
+          return BoolAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(
+              (Boolean) value, context);
+        case DOUBLE:
+          return DoubleAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(
+              (Double) value, context);
+        case STRING_ARRAY:
+        case LONG_ARRAY:
+        case BOOLEAN_ARRAY:
+        case DOUBLE_ARRAY:
+          return MarshalerUtil.sizeMessage(
+              AnyValue.ARRAY_VALUE,
+              attributeType,
+              (List<Object>) value,
+              ArrayAnyValueStatelessMarshaler.INSTANCE,
+              context);
+      }
+      // Error prone ensures the switch statement is complete, otherwise only can happen with
+      // unaligned versions which are not supported.
+      throw new IllegalArgumentException("Unsupported attribute type.");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void writeTo(
+        Serializer output, AttributeKey<?> attributeKey, Object value, MarshalerContext context)
+        throws IOException {
+      AttributeType attributeType = attributeKey.getType();
+      switch (attributeType) {
+        case STRING:
+          StringAnyValueStatelessMarshaler.INSTANCE.writeTo(output, (String) value, context);
+          return;
+        case LONG:
+          IntAnyValueStatelessMarshaler.INSTANCE.writeTo(output, (Long) value, context);
+          return;
+        case BOOLEAN:
+          BoolAnyValueStatelessMarshaler.INSTANCE.writeTo(output, (Boolean) value, context);
+          return;
+        case DOUBLE:
+          DoubleAnyValueStatelessMarshaler.INSTANCE.writeTo(output, (Double) value, context);
+          return;
+        case STRING_ARRAY:
+        case LONG_ARRAY:
+        case BOOLEAN_ARRAY:
+        case DOUBLE_ARRAY:
+          output.serializeMessage(
+              AnyValue.ARRAY_VALUE,
+              attributeType,
+              (List<Object>) value,
+              ArrayAnyValueStatelessMarshaler.INSTANCE,
+              context);
+          return;
+      }
+      // Error prone ensures the switch statement is complete, otherwise only can happen with
+      // unaligned versions which are not supported.
+      throw new IllegalArgumentException("Unsupported attribute type.");
+    }
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
@@ -24,11 +24,11 @@ final class StringAnyValueStatelessMarshaler implements StatelessMarshaler<Strin
   @Override
   public void writeTo(Serializer output, String value, MarshalerContext context)
       throws IOException {
-    output.serializeString(AnyValue.STRING_VALUE, value, context);
+    output.serializeStringWithContext(AnyValue.STRING_VALUE, value, context);
   }
 
   @Override
   public int getBinarySerializedSize(String value, MarshalerContext context) {
-    return StatelessMarshalerUtil.sizeString(AnyValue.STRING_VALUE, value, context);
+    return StatelessMarshalerUtil.sizeStringWithContext(AnyValue.STRING_VALUE, value, context);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.exporter.internal.otlp;
 
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
-import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.proto.common.v1.internal.AnyValue;
 import java.io.IOException;
 
 /**
- * A Marshaler of string-valued {@link AnyValue}.
+ * A Marshaler of string-valued {@link AnyValue}. See {@link StringAnyValueMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -29,6 +29,6 @@ final class StringAnyValueStatelessMarshaler implements StatelessMarshaler<Strin
 
   @Override
   public int getBinarySerializedSize(String value, MarshalerContext context) {
-    return MarshalerUtil.sizeString(AnyValue.STRING_VALUE, value, context);
+    return StatelessMarshalerUtil.sizeString(AnyValue.STRING_VALUE, value, context);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/StringAnyValueStatelessMarshaler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.common.v1.internal.AnyValue;
+import java.io.IOException;
+
+/**
+ * A Marshaler of string-valued {@link AnyValue}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+final class StringAnyValueStatelessMarshaler implements StatelessMarshaler<String> {
+  static final StringAnyValueStatelessMarshaler INSTANCE = new StringAnyValueStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, String value, MarshalerContext context)
+      throws IOException {
+    output.serializeString(AnyValue.STRING_VALUE, value, context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(String value, MarshalerContext context) {
+    return MarshalerUtil.sizeString(AnyValue.STRING_VALUE, value, context);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
@@ -34,9 +34,10 @@ final class InstrumentationScopeSpansStatelessMarshaler
         context.getData(InstrumentationScopeMarshaler.class);
 
     output.serializeMessage(ScopeSpans.SCOPE, instrumentationScopeMarshaler);
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         ScopeSpans.SPANS, spans, SpanStatelessMarshaler.INSTANCE, context);
-    output.serializeString(ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+    output.serializeStringWithContext(
+        ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
   }
 
   @Override
@@ -51,10 +52,10 @@ final class InstrumentationScopeSpansStatelessMarshaler
     int size = 0;
     size += MarshalerUtil.sizeMessage(ScopeSpans.SCOPE, instrumentationScopeMarshaler);
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ScopeSpans.SPANS, spans, SpanStatelessMarshaler.INSTANCE, context);
     size +=
-        StatelessMarshalerUtil.sizeString(
+        StatelessMarshalerUtil.sizeStringWithContext(
             ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
 
     return size;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.ScopeSpans;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.util.List;
+
+final class InstrumentationScopeSpansStatelessMarshaler
+    implements StatelessMarshaler2<InstrumentationScopeInfo, List<SpanData>> {
+  static final InstrumentationScopeSpansStatelessMarshaler INSTANCE =
+      new InstrumentationScopeSpansStatelessMarshaler();
+
+  @Override
+  public void writeTo(
+      Serializer output,
+      InstrumentationScopeInfo instrumentationScope,
+      List<SpanData> spans,
+      MarshalerContext context)
+      throws IOException {
+    InstrumentationScopeMarshaler instrumentationScopeMarshaler =
+        context.getData(InstrumentationScopeMarshaler.class);
+
+    output.serializeMessage(ScopeSpans.SCOPE, instrumentationScopeMarshaler);
+    output.serializeRepeatedMessage(
+        ScopeSpans.SPANS, spans, SpanStatelessMarshaler.INSTANCE, context);
+    output.serializeString(ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      InstrumentationScopeInfo instrumentationScope,
+      List<SpanData> spans,
+      MarshalerContext context) {
+    InstrumentationScopeMarshaler instrumentationScopeMarshaler =
+        InstrumentationScopeMarshaler.create(instrumentationScope);
+    context.addData(instrumentationScopeMarshaler);
+
+    int size = 0;
+    size += MarshalerUtil.sizeMessage(ScopeSpans.SCOPE, instrumentationScopeMarshaler);
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            ScopeSpans.SPANS, spans, SpanStatelessMarshaler.INSTANCE, context);
+    size +=
+        MarshalerUtil.sizeString(
+            ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/InstrumentationScopeSpansStatelessMarshaler.java
@@ -9,6 +9,7 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
 import io.opentelemetry.proto.trace.v1.internal.ScopeSpans;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -16,6 +17,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
 import java.util.List;
 
+/** See {@link InstrumentationScopeSpansMarshaler}. */
 final class InstrumentationScopeSpansStatelessMarshaler
     implements StatelessMarshaler2<InstrumentationScopeInfo, List<SpanData>> {
   static final InstrumentationScopeSpansStatelessMarshaler INSTANCE =
@@ -49,10 +51,10 @@ final class InstrumentationScopeSpansStatelessMarshaler
     int size = 0;
     size += MarshalerUtil.sizeMessage(ScopeSpans.SCOPE, instrumentationScopeMarshaler);
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             ScopeSpans.SPANS, spans, SpanStatelessMarshaler.INSTANCE, context);
     size +=
-        MarshalerUtil.sizeString(
+        StatelessMarshalerUtil.sizeString(
             ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
 
     return size;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
@@ -7,8 +7,8 @@ package io.opentelemetry.exporter.internal.otlp.traces;
 
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
-import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.proto.collector.trace.v1.internal.ExportTraceServiceRequest;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
@@ -20,12 +20,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest.
+ * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest. See {@link
+ * TraceRequestMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-@SuppressWarnings({"UnusedNestedClass", "UnusedVariable", "CheckedExceptionNotThrown"})
 public final class LowAllocationTraceRequestMarshaler extends Marshaler {
   private static final MarshalerContext.Key RESOURCE_SPAN_SIZE_CALCULATOR_KEY =
       MarshalerContext.key();
@@ -67,7 +67,7 @@ public final class LowAllocationTraceRequestMarshaler extends Marshaler {
   private static int calculateSize(
       MarshalerContext context,
       Map<Resource, Map<InstrumentationScopeInfo, List<SpanData>>> resourceAndScopeMap) {
-    return MarshalerUtil.sizeRepeatedMessage(
+    return StatelessMarshalerUtil.sizeRepeatedMessage(
         ExportTraceServiceRequest.RESOURCE_SPANS,
         resourceAndScopeMap,
         ResourceSpansStatelessMarshaler.INSTANCE,
@@ -82,7 +82,7 @@ public final class LowAllocationTraceRequestMarshaler extends Marshaler {
       return Collections.emptyMap();
     }
 
-    return MarshalerUtil.groupByResourceAndScope(
+    return StatelessMarshalerUtil.groupByResourceAndScope(
         spanDataList,
         // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
         // two.

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
@@ -56,7 +56,7 @@ public final class LowAllocationTraceRequestMarshaler extends Marshaler {
   public void writeTo(Serializer output) throws IOException {
     // serializing can be retried, reset the indexes, so we could call writeTo multiple times
     context.resetReadIndex();
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         ExportTraceServiceRequest.RESOURCE_SPANS,
         resourceAndScopeMap,
         ResourceSpansStatelessMarshaler.INSTANCE,
@@ -67,7 +67,7 @@ public final class LowAllocationTraceRequestMarshaler extends Marshaler {
   private static int calculateSize(
       MarshalerContext context,
       Map<Resource, Map<InstrumentationScopeInfo, List<SpanData>>> resourceAndScopeMap) {
-    return StatelessMarshalerUtil.sizeRepeatedMessage(
+    return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
         ExportTraceServiceRequest.RESOURCE_SPANS,
         resourceAndScopeMap,
         ResourceSpansStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.proto.collector.trace.v1.internal.ExportTraceServiceRequest;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+@SuppressWarnings({"UnusedNestedClass", "UnusedVariable", "CheckedExceptionNotThrown"})
+public final class LowAllocationTraceRequestMarshaler extends Marshaler {
+  private static final MarshalerContext.Key RESOURCE_SPAN_SIZE_CALCULATOR_KEY =
+      MarshalerContext.key();
+  private static final MarshalerContext.Key RESOURCE_SPAN_WRITER_KEY = MarshalerContext.key();
+
+  private final MarshalerContext context = new MarshalerContext();
+
+  @SuppressWarnings("NullAway")
+  private Map<Resource, Map<InstrumentationScopeInfo, List<SpanData>>> resourceAndScopeMap;
+
+  private int size;
+
+  public void initialize(Collection<SpanData> spanDataList) {
+    resourceAndScopeMap = groupByResourceAndScope(context, spanDataList);
+    size = calculateSize(context, resourceAndScopeMap);
+  }
+
+  public void reset() {
+    context.reset();
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  public void writeTo(Serializer output) throws IOException {
+    // serializing can be retried, reset the indexes, so we could call writeTo multiple times
+    context.resetReadIndex();
+    output.serializeRepeatedMessage(
+        ExportTraceServiceRequest.RESOURCE_SPANS,
+        resourceAndScopeMap,
+        ResourceSpansStatelessMarshaler.INSTANCE,
+        context,
+        RESOURCE_SPAN_WRITER_KEY);
+  }
+
+  private static int calculateSize(
+      MarshalerContext context,
+      Map<Resource, Map<InstrumentationScopeInfo, List<SpanData>>> resourceAndScopeMap) {
+    return MarshalerUtil.sizeRepeatedMessage(
+        ExportTraceServiceRequest.RESOURCE_SPANS,
+        resourceAndScopeMap,
+        ResourceSpansStatelessMarshaler.INSTANCE,
+        context,
+        RESOURCE_SPAN_SIZE_CALCULATOR_KEY);
+  }
+
+  private static Map<Resource, Map<InstrumentationScopeInfo, List<SpanData>>>
+      groupByResourceAndScope(MarshalerContext context, Collection<SpanData> spanDataList) {
+
+    if (spanDataList.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    return MarshalerUtil.groupByResourceAndScope(
+        spanDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        SpanData::getResource,
+        SpanData::getInstrumentationScopeInfo,
+        context);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshaler.java
@@ -23,6 +23,20 @@ import java.util.Map;
  * {@link Marshaler} to convert SDK {@link SpanData} to OTLP ExportTraceServiceRequest. See {@link
  * TraceRequestMarshaler}.
  *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * void marshal(LowAllocationTraceRequestMarshaler requestMarshaler, OutputStream output,
+ *     List<SpanData> spanList) throws IOException {
+ *   requestMarshaler.initialize(spanList);
+ *   try {
+ *     requestMarshaler.writeBinaryTo(output);
+ *   } finally {
+ *     requestMarshaler.reset();
+ *   }
+ * }
+ * }</pre>
+ *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.ResourceSpans;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Marshaler of ResourceSpans.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class ResourceSpansStatelessMarshaler
+    implements StatelessMarshaler2<Resource, Map<InstrumentationScopeInfo, List<SpanData>>> {
+  static final ResourceSpansStatelessMarshaler INSTANCE = new ResourceSpansStatelessMarshaler();
+  private static final MarshalerContext.Key SCOPE_SPAN_WRITER_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key SCOPE_SPAN_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(
+      Serializer output,
+      Resource resource,
+      Map<InstrumentationScopeInfo, List<SpanData>> scopeMap,
+      MarshalerContext context)
+      throws IOException {
+    ResourceMarshaler resourceMarshaler = context.getData(ResourceMarshaler.class);
+    output.serializeMessage(ResourceSpans.RESOURCE, resourceMarshaler);
+
+    output.serializeRepeatedMessage(
+        ResourceSpans.SCOPE_SPANS,
+        scopeMap,
+        InstrumentationScopeSpansStatelessMarshaler.INSTANCE,
+        context,
+        SCOPE_SPAN_WRITER_KEY);
+
+    output.serializeString(ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      Resource resource,
+      Map<InstrumentationScopeInfo, List<SpanData>> scopeMap,
+      MarshalerContext context) {
+
+    int size = 0;
+
+    ResourceMarshaler resourceMarshaler = ResourceMarshaler.create(resource);
+    context.addData(resourceMarshaler);
+    size += MarshalerUtil.sizeMessage(ResourceSpans.RESOURCE, resourceMarshaler);
+
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            ResourceSpans.SCOPE_SPANS,
+            scopeMap,
+            InstrumentationScopeSpansStatelessMarshaler.INSTANCE,
+            context,
+            SCOPE_SPAN_SIZE_CALCULATOR_KEY);
+
+    size += MarshalerUtil.sizeString(ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
@@ -41,14 +41,14 @@ public final class ResourceSpansStatelessMarshaler
     ResourceMarshaler resourceMarshaler = context.getData(ResourceMarshaler.class);
     output.serializeMessage(ResourceSpans.RESOURCE, resourceMarshaler);
 
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         ResourceSpans.SCOPE_SPANS,
         scopeMap,
         InstrumentationScopeSpansStatelessMarshaler.INSTANCE,
         context,
         SCOPE_SPAN_WRITER_KEY);
 
-    output.serializeString(ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
+    output.serializeStringWithContext(ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
   }
 
   @Override
@@ -64,7 +64,7 @@ public final class ResourceSpansStatelessMarshaler
     size += MarshalerUtil.sizeMessage(ResourceSpans.RESOURCE, resourceMarshaler);
 
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ResourceSpans.SCOPE_SPANS,
             scopeMap,
             InstrumentationScopeSpansStatelessMarshaler.INSTANCE,
@@ -72,7 +72,7 @@ public final class ResourceSpansStatelessMarshaler
             SCOPE_SPAN_SIZE_CALCULATOR_KEY);
 
     size +=
-        StatelessMarshalerUtil.sizeString(
+        StatelessMarshalerUtil.sizeStringWithContext(
             ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
 
     return size;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/ResourceSpansStatelessMarshaler.java
@@ -9,6 +9,7 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
 import io.opentelemetry.proto.trace.v1.internal.ResourceSpans;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A Marshaler of ResourceSpans.
+ * A Marshaler of ResourceSpans. See {@link ResourceSpansMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -63,14 +64,16 @@ public final class ResourceSpansStatelessMarshaler
     size += MarshalerUtil.sizeMessage(ResourceSpans.RESOURCE, resourceMarshaler);
 
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             ResourceSpans.SCOPE_SPANS,
             scopeMap,
             InstrumentationScopeSpansStatelessMarshaler.INSTANCE,
             context,
             SCOPE_SPAN_SIZE_CALCULATOR_KEY);
 
-    size += MarshalerUtil.sizeString(ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
+    size +=
+        StatelessMarshalerUtil.sizeString(
+            ResourceSpans.SCHEMA_URL, resource.getSchemaUrl(), context);
 
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
@@ -9,11 +9,13 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
 import io.opentelemetry.proto.trace.v1.internal.Span;
 import io.opentelemetry.sdk.trace.data.EventData;
 import java.io.IOException;
 
+/** See {@link SpanEventMarshaler}. */
 final class SpanEventStatelessMarshaler implements StatelessMarshaler<EventData> {
   static final SpanEventStatelessMarshaler INSTANCE = new SpanEventStatelessMarshaler();
 
@@ -32,9 +34,9 @@ final class SpanEventStatelessMarshaler implements StatelessMarshaler<EventData>
   public int getBinarySerializedSize(EventData event, MarshalerContext context) {
     int size = 0;
     size += MarshalerUtil.sizeFixed64(Span.Event.TIME_UNIX_NANO, event.getEpochNanos());
-    size += MarshalerUtil.sizeString(Span.Event.NAME, event.getName(), context);
+    size += StatelessMarshalerUtil.sizeString(Span.Event.NAME, event.getName(), context);
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             Span.Event.ATTRIBUTES,
             event.getAttributes(),
             KeyValueStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.Span;
+import io.opentelemetry.sdk.trace.data.EventData;
+import java.io.IOException;
+
+final class SpanEventStatelessMarshaler implements StatelessMarshaler<EventData> {
+  static final SpanEventStatelessMarshaler INSTANCE = new SpanEventStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, EventData event, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(Span.Event.TIME_UNIX_NANO, event.getEpochNanos());
+    output.serializeString(Span.Event.NAME, event.getName(), context);
+    output.serializeRepeatedMessage(
+        Span.Event.ATTRIBUTES, event.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
+    int droppedAttributesCount = event.getTotalAttributeCount() - event.getAttributes().size();
+    output.serializeUInt32(Span.Event.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+  }
+
+  @Override
+  public int getBinarySerializedSize(EventData event, MarshalerContext context) {
+    int size = 0;
+    size += MarshalerUtil.sizeFixed64(Span.Event.TIME_UNIX_NANO, event.getEpochNanos());
+    size += MarshalerUtil.sizeString(Span.Event.NAME, event.getName(), context);
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            Span.Event.ATTRIBUTES,
+            event.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+    int droppedAttributesCount = event.getTotalAttributeCount() - event.getAttributes().size();
+    size += MarshalerUtil.sizeUInt32(Span.Event.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanEventStatelessMarshaler.java
@@ -23,8 +23,8 @@ final class SpanEventStatelessMarshaler implements StatelessMarshaler<EventData>
   public void writeTo(Serializer output, EventData event, MarshalerContext context)
       throws IOException {
     output.serializeFixed64(Span.Event.TIME_UNIX_NANO, event.getEpochNanos());
-    output.serializeString(Span.Event.NAME, event.getName(), context);
-    output.serializeRepeatedMessage(
+    output.serializeStringWithContext(Span.Event.NAME, event.getName(), context);
+    output.serializeRepeatedMessageWithContext(
         Span.Event.ATTRIBUTES, event.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
     int droppedAttributesCount = event.getTotalAttributeCount() - event.getAttributes().size();
     output.serializeUInt32(Span.Event.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
@@ -34,9 +34,9 @@ final class SpanEventStatelessMarshaler implements StatelessMarshaler<EventData>
   public int getBinarySerializedSize(EventData event, MarshalerContext context) {
     int size = 0;
     size += MarshalerUtil.sizeFixed64(Span.Event.TIME_UNIX_NANO, event.getEpochNanos());
-    size += StatelessMarshalerUtil.sizeString(Span.Event.NAME, event.getName(), context);
+    size += StatelessMarshalerUtil.sizeStringWithContext(Span.Event.NAME, event.getName(), context);
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             Span.Event.ATTRIBUTES,
             event.getAttributes(),
             KeyValueStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkStatelessMarshaler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import static io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding.encodeTraceState;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.Span;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+final class SpanLinkStatelessMarshaler implements StatelessMarshaler<LinkData> {
+  static final SpanLinkStatelessMarshaler INSTANCE = new SpanLinkStatelessMarshaler();
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  @Override
+  public void writeTo(Serializer output, LinkData link, MarshalerContext context)
+      throws IOException {
+    output.serializeTraceId(Span.Link.TRACE_ID, link.getSpanContext().getTraceId(), context);
+    output.serializeSpanId(Span.Link.SPAN_ID, link.getSpanContext().getSpanId(), context);
+    output.serializeString(Span.Link.TRACE_STATE, context.getData(byte[].class));
+    output.serializeRepeatedMessage(
+        Span.Link.ATTRIBUTES, link.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
+    int droppedAttributesCount = link.getTotalAttributeCount() - link.getAttributes().size();
+    output.serializeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+    output.serializeFixed32(
+        Span.Link.FLAGS,
+        SpanFlags.withParentIsRemoteFlags(
+            link.getSpanContext().getTraceFlags(), link.getSpanContext().isRemote()));
+  }
+
+  @Override
+  public int getBinarySerializedSize(LinkData link, MarshalerContext context) {
+    TraceState traceState = link.getSpanContext().getTraceState();
+    byte[] traceStateUtf8 =
+        traceState.isEmpty()
+            ? EMPTY_BYTES
+            : encodeTraceState(traceState).getBytes(StandardCharsets.UTF_8);
+    context.addData(traceStateUtf8);
+
+    int size = 0;
+    size += MarshalerUtil.sizeTraceId(Span.Link.TRACE_ID, link.getSpanContext().getTraceId());
+    size += MarshalerUtil.sizeSpanId(Span.Link.SPAN_ID, link.getSpanContext().getSpanId());
+    size += MarshalerUtil.sizeBytes(Span.Link.TRACE_STATE, traceStateUtf8);
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            Span.Link.ATTRIBUTES,
+            link.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+    int droppedAttributesCount = link.getTotalAttributeCount() - link.getAttributes().size();
+    size += MarshalerUtil.sizeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+    size +=
+        MarshalerUtil.sizeFixed32(
+            Span.Link.FLAGS,
+            SpanFlags.withParentIsRemoteFlags(
+                link.getSpanContext().getTraceFlags(), link.getSpanContext().isRemote()));
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanLinkStatelessMarshaler.java
@@ -27,7 +27,7 @@ final class SpanLinkStatelessMarshaler implements StatelessMarshaler<LinkData> {
     output.serializeTraceId(Span.Link.TRACE_ID, link.getSpanContext().getTraceId(), context);
     output.serializeSpanId(Span.Link.SPAN_ID, link.getSpanContext().getSpanId(), context);
     output.serializeString(Span.Link.TRACE_STATE, context.getData(byte[].class));
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         Span.Link.ATTRIBUTES, link.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
     int droppedAttributesCount = link.getTotalAttributeCount() - link.getAttributes().size();
     output.serializeUInt32(Span.Link.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
@@ -47,7 +47,7 @@ final class SpanLinkStatelessMarshaler implements StatelessMarshaler<LinkData> {
     size += MarshalerUtil.sizeSpanId(Span.Link.SPAN_ID, link.getSpanContext().getSpanId());
     size += MarshalerUtil.sizeBytes(Span.Link.TRACE_STATE, traceStateUtf8);
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             Span.Link.ATTRIBUTES,
             link.getAttributes(),
             KeyValueStatelessMarshaler.INSTANCE,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import static io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding.encodeTraceState;
+import static io.opentelemetry.exporter.internal.otlp.traces.SpanMarshaler.toProtoSpanKind;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.Span;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
+  static final SpanStatelessMarshaler INSTANCE = new SpanStatelessMarshaler();
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  @Override
+  public void writeTo(Serializer output, SpanData span, MarshalerContext context)
+      throws IOException {
+    output.serializeTraceId(Span.TRACE_ID, span.getTraceId(), context);
+    output.serializeSpanId(Span.SPAN_ID, span.getSpanId(), context);
+
+    byte[] traceStateUtf8 = context.getData(byte[].class);
+    output.serializeString(Span.TRACE_STATE, traceStateUtf8);
+    String parentSpanId =
+        span.getParentSpanContext().isValid() ? span.getParentSpanContext().getSpanId() : null;
+    output.serializeSpanId(Span.PARENT_SPAN_ID, parentSpanId, context);
+
+    output.serializeString(Span.NAME, span.getName(), context);
+    output.serializeEnum(Span.KIND, toProtoSpanKind(span.getKind()));
+
+    output.serializeFixed64(Span.START_TIME_UNIX_NANO, span.getStartEpochNanos());
+    output.serializeFixed64(Span.END_TIME_UNIX_NANO, span.getEndEpochNanos());
+
+    output.serializeRepeatedMessage(
+        Span.ATTRIBUTES, span.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
+    int droppedAttributesCount = span.getTotalAttributeCount() - span.getAttributes().size();
+    output.serializeUInt32(Span.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+
+    output.serializeRepeatedMessage(
+        Span.EVENTS, span.getEvents(), SpanEventStatelessMarshaler.INSTANCE, context);
+    int droppedEventsCount = span.getTotalRecordedEvents() - span.getEvents().size();
+    output.serializeUInt32(Span.DROPPED_EVENTS_COUNT, droppedEventsCount);
+
+    output.serializeRepeatedMessage(
+        Span.LINKS, span.getLinks(), SpanLinkStatelessMarshaler.INSTANCE, context);
+    int droppedLinksCount = span.getTotalRecordedLinks() - span.getLinks().size();
+    output.serializeUInt32(Span.DROPPED_LINKS_COUNT, droppedLinksCount);
+
+    output.serializeMessage(
+        Span.STATUS, span.getStatus(), SpanStatusStatelessMarshaler.INSTANCE, context);
+
+    output.serializeFixed32(
+        Span.FLAGS,
+        SpanFlags.withParentIsRemoteFlags(
+            span.getSpanContext().getTraceFlags(), span.getParentSpanContext().isRemote()));
+  }
+
+  @Override
+  public int getBinarySerializedSize(SpanData span, MarshalerContext context) {
+    int size = 0;
+    size += MarshalerUtil.sizeTraceId(Span.TRACE_ID, span.getTraceId());
+    size += MarshalerUtil.sizeSpanId(Span.SPAN_ID, span.getSpanId());
+
+    TraceState traceState = span.getSpanContext().getTraceState();
+    byte[] traceStateUtf8 =
+        traceState.isEmpty()
+            ? EMPTY_BYTES
+            : encodeTraceState(traceState).getBytes(StandardCharsets.UTF_8);
+    context.addData(traceStateUtf8);
+
+    size += MarshalerUtil.sizeBytes(Span.TRACE_STATE, traceStateUtf8);
+    String parentSpanId =
+        span.getParentSpanContext().isValid() ? span.getParentSpanContext().getSpanId() : null;
+    size += MarshalerUtil.sizeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
+
+    size += MarshalerUtil.sizeString(Span.NAME, span.getName(), context);
+    size += MarshalerUtil.sizeEnum(Span.KIND, toProtoSpanKind(span.getKind()));
+
+    size += MarshalerUtil.sizeFixed64(Span.START_TIME_UNIX_NANO, span.getStartEpochNanos());
+    size += MarshalerUtil.sizeFixed64(Span.END_TIME_UNIX_NANO, span.getEndEpochNanos());
+
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            Span.ATTRIBUTES, span.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
+    int droppedAttributesCount = span.getTotalAttributeCount() - span.getAttributes().size();
+    size += MarshalerUtil.sizeUInt32(Span.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            Span.EVENTS, span.getEvents(), SpanEventStatelessMarshaler.INSTANCE, context);
+    int droppedEventsCount = span.getTotalRecordedEvents() - span.getEvents().size();
+    size += MarshalerUtil.sizeUInt32(Span.DROPPED_EVENTS_COUNT, droppedEventsCount);
+
+    size +=
+        MarshalerUtil.sizeRepeatedMessage(
+            Span.LINKS, span.getLinks(), SpanLinkStatelessMarshaler.INSTANCE, context);
+    int droppedLinksCount = span.getTotalRecordedLinks() - span.getLinks().size();
+    size += MarshalerUtil.sizeUInt32(Span.DROPPED_LINKS_COUNT, droppedLinksCount);
+
+    size +=
+        MarshalerUtil.sizeMessage(
+            Span.STATUS, span.getStatus(), SpanStatusStatelessMarshaler.INSTANCE, context);
+
+    size +=
+        MarshalerUtil.sizeFixed32(
+            Span.FLAGS,
+            SpanFlags.withParentIsRemoteFlags(
+                span.getSpanContext().getTraceFlags(), span.getParentSpanContext().isRemote()));
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
@@ -5,23 +5,22 @@
 
 package io.opentelemetry.exporter.internal.otlp.traces;
 
-import static io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding.encodeTraceState;
+import static io.opentelemetry.exporter.internal.otlp.traces.SpanMarshaler.encodeSpanTraceState;
 import static io.opentelemetry.exporter.internal.otlp.traces.SpanMarshaler.toProtoSpanKind;
 
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
 import io.opentelemetry.proto.trace.v1.internal.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
+/** See {@link SpanMarshaler}. */
 final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
   static final SpanStatelessMarshaler INSTANCE = new SpanStatelessMarshaler();
-  private static final byte[] EMPTY_BYTES = new byte[0];
 
   @Override
   public void writeTo(Serializer output, SpanData span, MarshalerContext context)
@@ -71,11 +70,7 @@ final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
     size += MarshalerUtil.sizeTraceId(Span.TRACE_ID, span.getTraceId());
     size += MarshalerUtil.sizeSpanId(Span.SPAN_ID, span.getSpanId());
 
-    TraceState traceState = span.getSpanContext().getTraceState();
-    byte[] traceStateUtf8 =
-        traceState.isEmpty()
-            ? EMPTY_BYTES
-            : encodeTraceState(traceState).getBytes(StandardCharsets.UTF_8);
+    byte[] traceStateUtf8 = encodeSpanTraceState(span);
     context.addData(traceStateUtf8);
 
     size += MarshalerUtil.sizeBytes(Span.TRACE_STATE, traceStateUtf8);
@@ -83,32 +78,32 @@ final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
         span.getParentSpanContext().isValid() ? span.getParentSpanContext().getSpanId() : null;
     size += MarshalerUtil.sizeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
 
-    size += MarshalerUtil.sizeString(Span.NAME, span.getName(), context);
+    size += StatelessMarshalerUtil.sizeString(Span.NAME, span.getName(), context);
     size += MarshalerUtil.sizeEnum(Span.KIND, toProtoSpanKind(span.getKind()));
 
     size += MarshalerUtil.sizeFixed64(Span.START_TIME_UNIX_NANO, span.getStartEpochNanos());
     size += MarshalerUtil.sizeFixed64(Span.END_TIME_UNIX_NANO, span.getEndEpochNanos());
 
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             Span.ATTRIBUTES, span.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
     int droppedAttributesCount = span.getTotalAttributeCount() - span.getAttributes().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
 
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             Span.EVENTS, span.getEvents(), SpanEventStatelessMarshaler.INSTANCE, context);
     int droppedEventsCount = span.getTotalRecordedEvents() - span.getEvents().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_EVENTS_COUNT, droppedEventsCount);
 
     size +=
-        MarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessage(
             Span.LINKS, span.getLinks(), SpanLinkStatelessMarshaler.INSTANCE, context);
     int droppedLinksCount = span.getTotalRecordedLinks() - span.getLinks().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_LINKS_COUNT, droppedLinksCount);
 
     size +=
-        MarshalerUtil.sizeMessage(
+        StatelessMarshalerUtil.sizeMessage(
             Span.STATUS, span.getStatus(), SpanStatusStatelessMarshaler.INSTANCE, context);
 
     size +=

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatelessMarshaler.java
@@ -34,28 +34,28 @@ final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
         span.getParentSpanContext().isValid() ? span.getParentSpanContext().getSpanId() : null;
     output.serializeSpanId(Span.PARENT_SPAN_ID, parentSpanId, context);
 
-    output.serializeString(Span.NAME, span.getName(), context);
+    output.serializeStringWithContext(Span.NAME, span.getName(), context);
     output.serializeEnum(Span.KIND, toProtoSpanKind(span.getKind()));
 
     output.serializeFixed64(Span.START_TIME_UNIX_NANO, span.getStartEpochNanos());
     output.serializeFixed64(Span.END_TIME_UNIX_NANO, span.getEndEpochNanos());
 
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         Span.ATTRIBUTES, span.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
     int droppedAttributesCount = span.getTotalAttributeCount() - span.getAttributes().size();
     output.serializeUInt32(Span.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
 
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         Span.EVENTS, span.getEvents(), SpanEventStatelessMarshaler.INSTANCE, context);
     int droppedEventsCount = span.getTotalRecordedEvents() - span.getEvents().size();
     output.serializeUInt32(Span.DROPPED_EVENTS_COUNT, droppedEventsCount);
 
-    output.serializeRepeatedMessage(
+    output.serializeRepeatedMessageWithContext(
         Span.LINKS, span.getLinks(), SpanLinkStatelessMarshaler.INSTANCE, context);
     int droppedLinksCount = span.getTotalRecordedLinks() - span.getLinks().size();
     output.serializeUInt32(Span.DROPPED_LINKS_COUNT, droppedLinksCount);
 
-    output.serializeMessage(
+    output.serializeMessageWithContext(
         Span.STATUS, span.getStatus(), SpanStatusStatelessMarshaler.INSTANCE, context);
 
     output.serializeFixed32(
@@ -78,32 +78,32 @@ final class SpanStatelessMarshaler implements StatelessMarshaler<SpanData> {
         span.getParentSpanContext().isValid() ? span.getParentSpanContext().getSpanId() : null;
     size += MarshalerUtil.sizeSpanId(Span.PARENT_SPAN_ID, parentSpanId);
 
-    size += StatelessMarshalerUtil.sizeString(Span.NAME, span.getName(), context);
+    size += StatelessMarshalerUtil.sizeStringWithContext(Span.NAME, span.getName(), context);
     size += MarshalerUtil.sizeEnum(Span.KIND, toProtoSpanKind(span.getKind()));
 
     size += MarshalerUtil.sizeFixed64(Span.START_TIME_UNIX_NANO, span.getStartEpochNanos());
     size += MarshalerUtil.sizeFixed64(Span.END_TIME_UNIX_NANO, span.getEndEpochNanos());
 
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             Span.ATTRIBUTES, span.getAttributes(), KeyValueStatelessMarshaler.INSTANCE, context);
     int droppedAttributesCount = span.getTotalAttributeCount() - span.getAttributes().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
 
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             Span.EVENTS, span.getEvents(), SpanEventStatelessMarshaler.INSTANCE, context);
     int droppedEventsCount = span.getTotalRecordedEvents() - span.getEvents().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_EVENTS_COUNT, droppedEventsCount);
 
     size +=
-        StatelessMarshalerUtil.sizeRepeatedMessage(
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             Span.LINKS, span.getLinks(), SpanLinkStatelessMarshaler.INSTANCE, context);
     int droppedLinksCount = span.getTotalRecordedLinks() - span.getLinks().size();
     size += MarshalerUtil.sizeUInt32(Span.DROPPED_LINKS_COUNT, droppedLinksCount);
 
     size +=
-        StatelessMarshalerUtil.sizeMessage(
+        StatelessMarshalerUtil.sizeMessageWithContext(
             Span.STATUS, span.getStatus(), SpanStatusStatelessMarshaler.INSTANCE, context);
 
     size +=

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusMarshaler.java
@@ -19,12 +19,7 @@ final class SpanStatusMarshaler extends MarshalerWithSize {
   private final byte[] descriptionUtf8;
 
   static SpanStatusMarshaler create(StatusData status) {
-    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
-    if (status.getStatusCode() == StatusCode.OK) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
-    } else if (status.getStatusCode() == StatusCode.ERROR) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
-    }
+    ProtoEnumInfo protoStatusCode = toProtoSpanStatus(status);
     byte[] description = MarshalerUtil.toBytes(status.getDescription());
     return new SpanStatusMarshaler(protoStatusCode, description);
   }
@@ -46,5 +41,15 @@ final class SpanStatusMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeBytes(Status.MESSAGE, descriptionUtf8);
     size += MarshalerUtil.sizeEnum(Status.CODE, protoStatusCode);
     return size;
+  }
+
+  static ProtoEnumInfo toProtoSpanStatus(StatusData status) {
+    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
+    if (status.getStatusCode() == StatusCode.OK) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
+    } else if (status.getStatusCode() == StatusCode.ERROR) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
+    }
+    return protoStatusCode;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusStatelessMarshaler.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.exporter.internal.otlp.traces;
 
-import io.opentelemetry.api.trace.StatusCode;
+import static io.opentelemetry.exporter.internal.otlp.traces.SpanStatusMarshaler.toProtoSpanStatus;
+
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.ProtoEnumInfo;
@@ -15,19 +16,14 @@ import io.opentelemetry.proto.trace.v1.internal.Status;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.IOException;
 
+/** See {@link SpanStatusMarshaler}. */
 final class SpanStatusStatelessMarshaler implements StatelessMarshaler<StatusData> {
   static final SpanStatusStatelessMarshaler INSTANCE = new SpanStatusStatelessMarshaler();
 
   @Override
   public void writeTo(Serializer output, StatusData status, MarshalerContext context)
       throws IOException {
-    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
-    if (status.getStatusCode() == StatusCode.OK) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
-    } else if (status.getStatusCode() == StatusCode.ERROR) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
-    }
-
+    ProtoEnumInfo protoStatusCode = toProtoSpanStatus(status);
     byte[] descriptionUtf8 = context.getData(byte[].class);
 
     output.serializeString(Status.MESSAGE, descriptionUtf8);
@@ -36,12 +32,7 @@ final class SpanStatusStatelessMarshaler implements StatelessMarshaler<StatusDat
 
   @Override
   public int getBinarySerializedSize(StatusData status, MarshalerContext context) {
-    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
-    if (status.getStatusCode() == StatusCode.OK) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
-    } else if (status.getStatusCode() == StatusCode.ERROR) {
-      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
-    }
+    ProtoEnumInfo protoStatusCode = toProtoSpanStatus(status);
     byte[] descriptionUtf8 = MarshalerUtil.toBytes(status.getDescription());
     context.addData(descriptionUtf8);
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/traces/SpanStatusStatelessMarshaler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.ProtoEnumInfo;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.trace.v1.internal.Status;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.io.IOException;
+
+final class SpanStatusStatelessMarshaler implements StatelessMarshaler<StatusData> {
+  static final SpanStatusStatelessMarshaler INSTANCE = new SpanStatusStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, StatusData status, MarshalerContext context)
+      throws IOException {
+    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
+    if (status.getStatusCode() == StatusCode.OK) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
+    } else if (status.getStatusCode() == StatusCode.ERROR) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
+    }
+
+    byte[] descriptionUtf8 = context.getData(byte[].class);
+
+    output.serializeString(Status.MESSAGE, descriptionUtf8);
+    output.serializeEnum(Status.CODE, protoStatusCode);
+  }
+
+  @Override
+  public int getBinarySerializedSize(StatusData status, MarshalerContext context) {
+    ProtoEnumInfo protoStatusCode = Status.StatusCode.STATUS_CODE_UNSET;
+    if (status.getStatusCode() == StatusCode.OK) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_OK;
+    } else if (status.getStatusCode() == StatusCode.ERROR) {
+      protoStatusCode = Status.StatusCode.STATUS_CODE_ERROR;
+    }
+    byte[] descriptionUtf8 = MarshalerUtil.toBytes(status.getDescription());
+    context.addData(descriptionUtf8);
+
+    int size = 0;
+    size += MarshalerUtil.sizeBytes(Status.MESSAGE, descriptionUtf8);
+    size += MarshalerUtil.sizeEnum(Status.CODE, protoStatusCode);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/traces/LowAllocationTraceRequestMarshalerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.traces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LowAllocationTraceRequestMarshalerTest {
+
+  private static final AttributeKey<Boolean> KEY_BOOL = AttributeKey.booleanKey("key_bool");
+  private static final AttributeKey<String> KEY_STRING = AttributeKey.stringKey("key_string");
+  private static final AttributeKey<Long> KEY_INT = AttributeKey.longKey("key_int");
+  private static final AttributeKey<Double> KEY_DOUBLE = AttributeKey.doubleKey("key_double");
+  private static final AttributeKey<List<String>> KEY_STRING_ARRAY =
+      AttributeKey.stringArrayKey("key_string_array");
+  private static final AttributeKey<List<Long>> KEY_LONG_ARRAY =
+      AttributeKey.longArrayKey("key_long_array");
+  private static final AttributeKey<List<Double>> KEY_DOUBLE_ARRAY =
+      AttributeKey.doubleArrayKey("key_double_array");
+  private static final AttributeKey<List<Boolean>> KEY_BOOLEAN_ARRAY =
+      AttributeKey.booleanArrayKey("key_boolean_array");
+  private static final AttributeKey<String> LINK_ATTR_KEY = AttributeKey.stringKey("link_attr_key");
+
+  private static final Resource RESOURCE =
+      Resource.create(
+          Attributes.builder()
+              .put(KEY_BOOL, true)
+              .put(KEY_STRING, "string")
+              .put(KEY_INT, 100L)
+              .put(KEY_DOUBLE, 100.3)
+              .put(KEY_STRING_ARRAY, Arrays.asList("string", "string"))
+              .put(KEY_LONG_ARRAY, Arrays.asList(12L, 23L))
+              .put(KEY_DOUBLE_ARRAY, Arrays.asList(12.3, 23.1))
+              .put(KEY_BOOLEAN_ARRAY, Arrays.asList(true, false))
+              .build());
+
+  private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
+      InstrumentationScopeInfo.create("name");
+  private static final String TRACE_ID = "7b2e170db4df2d593ddb4ddf2ddf2d59";
+  private static final String SPAN_ID = "170d3ddb4d23e81f";
+  private static final SpanContext SPAN_CONTEXT =
+      SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+  private final List<SpanData> spanDataList = createSpanDataList();
+
+  private static List<SpanData> createSpanDataList() {
+    List<SpanData> spanDataList = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      spanDataList.add(createSpanData());
+    }
+    return spanDataList;
+  }
+
+  private static SpanData createSpanData() {
+    return TestSpanData.builder()
+        .setResource(RESOURCE)
+        .setInstrumentationScopeInfo(INSTRUMENTATION_SCOPE_INFO)
+        .setHasEnded(true)
+        .setSpanContext(SPAN_CONTEXT)
+        .setParentSpanContext(SpanContext.getInvalid())
+        .setName("GET /api/endpoint")
+        .setKind(SpanKind.SERVER)
+        .setStartEpochNanos(12345)
+        .setEndEpochNanos(12349)
+        .setAttributes(
+            Attributes.builder()
+                .put(KEY_BOOL, true)
+                .put(KEY_STRING, "string")
+                .put(KEY_INT, 100L)
+                .put(KEY_DOUBLE, 100.3)
+                .build())
+        .setTotalAttributeCount(2)
+        .setEvents(
+            Arrays.asList(
+                EventData.create(12347, "my_event_1", Attributes.empty()),
+                EventData.create(12348, "my_event_2", Attributes.of(KEY_INT, 1234L)),
+                EventData.create(12349, "my_event_3", Attributes.empty())))
+        .setTotalRecordedEvents(4)
+        .setLinks(
+            Arrays.asList(
+                LinkData.create(SPAN_CONTEXT),
+                LinkData.create(SPAN_CONTEXT, Attributes.of(LINK_ATTR_KEY, "value"))))
+        .setTotalRecordedLinks(3)
+        .setStatus(StatusData.ok())
+        .build();
+  }
+
+  @Test
+  void validateOutput() throws Exception {
+    byte[] result;
+    {
+      TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(spanDataList);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeBinaryTo(customOutput);
+      result = customOutput.toByteArray();
+    }
+
+    byte[] lowAllocationResult;
+    {
+      LowAllocationTraceRequestMarshaler requestMarshaler =
+          new LowAllocationTraceRequestMarshaler();
+      requestMarshaler.initialize(spanDataList);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeBinaryTo(customOutput);
+      lowAllocationResult = customOutput.toByteArray();
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+
+  @Test
+  void validateJsonOutput() throws Exception {
+    String result;
+    {
+      TraceRequestMarshaler requestMarshaler = TraceRequestMarshaler.create(spanDataList);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeJsonTo(customOutput);
+      result = new String(customOutput.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    String lowAllocationResult;
+    {
+      LowAllocationTraceRequestMarshaler requestMarshaler =
+          new LowAllocationTraceRequestMarshaler();
+      requestMarshaler.initialize(spanDataList);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeJsonTo(customOutput);
+      lowAllocationResult = new String(customOutput.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+}


### PR DESCRIPTION
Subset of https://github.com/open-telemetry/opentelemetry-java/pull/6328 that contains only trace marshaling.

```
Benchmark                                                                     (numSpans)  Mode  Cnt        Score     Error   Units
RequestMarshalBenchmarks.createCustomMarshal                                          16  avgt   10        6.150 ±   0.715   us/op
RequestMarshalBenchmarks.createCustomMarshal:gc.alloc.rate                            16  avgt   10     2835.838 ± 315.210  MB/sec
RequestMarshalBenchmarks.createCustomMarshal:gc.alloc.rate.norm                       16  avgt   10    18200.003 ±   0.001    B/op
RequestMarshalBenchmarks.createCustomMarshal:gc.count                                 16  avgt   10       78.000            counts
RequestMarshalBenchmarks.createCustomMarshal:gc.time                                  16  avgt   10       77.000                ms
RequestMarshalBenchmarks.createCustomMarshal                                         512  avgt   10      186.124 ±   8.696   us/op
RequestMarshalBenchmarks.createCustomMarshal:gc.alloc.rate                           512  avgt   10     2873.058 ± 126.706  MB/sec
RequestMarshalBenchmarks.createCustomMarshal:gc.alloc.rate.norm                      512  avgt   10   560383.738 ±  17.191    B/op
RequestMarshalBenchmarks.createCustomMarshal:gc.count                                512  avgt   10       71.000            counts
RequestMarshalBenchmarks.createCustomMarshal:gc.time                                 512  avgt   10       82.000                ms
RequestMarshalBenchmarks.createCustomMarshalLowAllocation                             16  avgt   10        3.822 ±   0.112   us/op
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.alloc.rate               16  avgt   10        0.001 ±   0.001  MB/sec
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.alloc.rate.norm          16  avgt   10        0.002 ±   0.001    B/op
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.count                    16  avgt   10          ≈ 0            counts
RequestMarshalBenchmarks.createCustomMarshalLowAllocation                            512  avgt   10      137.433 ±  10.486   us/op
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.alloc.rate              512  avgt   10        0.001 ±   0.001  MB/sec
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.alloc.rate.norm         512  avgt   10        0.074 ±   0.014    B/op
RequestMarshalBenchmarks.createCustomMarshalLowAllocation:gc.count                   512  avgt   10          ≈ 0            counts
RequestMarshalBenchmarks.marshalCustom                                                16  avgt   10       13.325 ±   0.362   us/op
RequestMarshalBenchmarks.marshalCustom:gc.alloc.rate                                  16  avgt   10     1314.425 ±  35.678  MB/sec
RequestMarshalBenchmarks.marshalCustom:gc.alloc.rate.norm                             16  avgt   10    18368.007 ±   0.001    B/op
RequestMarshalBenchmarks.marshalCustom:gc.count                                       16  avgt   10       44.000            counts
RequestMarshalBenchmarks.marshalCustom:gc.time                                        16  avgt   10       47.000                ms
RequestMarshalBenchmarks.marshalCustom                                               512  avgt   10      482.968 ±  11.295   us/op
RequestMarshalBenchmarks.marshalCustom:gc.alloc.rate                                 512  avgt   10     1106.838 ±  25.556  MB/sec
RequestMarshalBenchmarks.marshalCustom:gc.alloc.rate.norm                            512  avgt   10   560544.256 ±   0.008    B/op
RequestMarshalBenchmarks.marshalCustom:gc.count                                      512  avgt   10       37.000            counts
RequestMarshalBenchmarks.marshalCustom:gc.time                                       512  avgt   10       41.000                ms
RequestMarshalBenchmarks.marshalCustomLowAllocation                                   16  avgt   10       14.876 ±   1.089   us/op
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.alloc.rate                     16  avgt   10        5.652 ±   0.394  MB/sec
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.alloc.rate.norm                16  avgt   10       88.008 ±   0.001    B/op
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.count                          16  avgt   10        2.000            counts
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.time                           16  avgt   10        5.000                ms
RequestMarshalBenchmarks.marshalCustomLowAllocation                                  512  avgt   10      525.182 ±  53.841   us/op
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.alloc.rate                    512  avgt   10        0.161 ±   0.016  MB/sec
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.alloc.rate.norm               512  avgt   10       88.270 ±   0.027    B/op
RequestMarshalBenchmarks.marshalCustomLowAllocation:gc.count                         512  avgt   10          ≈ 0            counts
RequestMarshalBenchmarks.marshalJson                                                  16  avgt   10       50.843 ±   1.571   us/op
RequestMarshalBenchmarks.marshalJson:gc.alloc.rate                                    16  avgt   10      615.603 ±  18.741  MB/sec
RequestMarshalBenchmarks.marshalJson:gc.alloc.rate.norm                               16  avgt   10    32816.027 ±   0.003    B/op
RequestMarshalBenchmarks.marshalJson:gc.count                                         16  avgt   10       20.000            counts
RequestMarshalBenchmarks.marshalJson:gc.time                                          16  avgt   10       23.000                ms
RequestMarshalBenchmarks.marshalJson                                                 512  avgt   10     1564.466 ±  24.863   us/op
RequestMarshalBenchmarks.marshalJson:gc.alloc.rate                                   512  avgt   10      661.690 ±  10.372  MB/sec
RequestMarshalBenchmarks.marshalJson:gc.alloc.rate.norm                              512  avgt   10  1085588.150 ±  15.889    B/op
RequestMarshalBenchmarks.marshalJson:gc.count                                        512  avgt   10       23.000            counts
RequestMarshalBenchmarks.marshalJson:gc.time                                         512  avgt   10       27.000                ms
RequestMarshalBenchmarks.marshalJsonLowAllocation                                     16  avgt   10       51.248 ±   0.936   us/op
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.alloc.rate                       16  avgt   10      173.268 ±   3.179  MB/sec
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.alloc.rate.norm                  16  avgt   10     9312.028 ±   0.002    B/op
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.count                            16  avgt   10        5.000            counts
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.time                             16  avgt   10        5.000                ms
RequestMarshalBenchmarks.marshalJsonLowAllocation                                    512  avgt   10     1680.969 ± 147.464   us/op
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.alloc.rate                      512  avgt   10      203.218 ±  17.142  MB/sec
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.alloc.rate.norm                 512  avgt   10   357220.414 ±  16.837    B/op
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.count                           512  avgt   10        7.000            counts
RequestMarshalBenchmarks.marshalJsonLowAllocation:gc.time                            512  avgt   10        8.000                ms
```