### PR TITLE
Fix opencensus shim spanBuilderWithRemoteParent behavior

### DIFF
--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanBuilderImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanBuilderImpl.java
@@ -164,7 +164,11 @@ final class OpenTelemetrySpanBuilderImpl extends SpanBuilder {
       otelSpanBuilder.setParent(Context.current().with((OpenTelemetrySpanImpl) ocParent));
     }
     if (ocRemoteParentSpanContext != null) {
-      otelSpanBuilder.addLink(SpanConverter.mapSpanContext(ocRemoteParentSpanContext));
+      io.opentelemetry.api.trace.SpanContext spanContext =
+          SpanConverter.mapSpanContext(ocRemoteParentSpanContext, /* isRemoteParent= */ true);
+      otelSpanBuilder.setParent(
+          Context.current().with(io.opentelemetry.api.trace.Span.wrap(spanContext)));
+      otelSpanBuilder.addLink(spanContext);
     }
     if (otelKind != null) {
       otelSpanBuilder.setSpanKind(otelKind);

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
@@ -57,13 +57,22 @@ final class SpanConverter {
   }
 
   static io.opentelemetry.api.trace.SpanContext mapSpanContext(SpanContext ocSpanContext) {
-    return io.opentelemetry.api.trace.SpanContext.create(
-        ocSpanContext.getTraceId().toLowerBase16(),
-        ocSpanContext.getSpanId().toLowerBase16(),
+    return mapSpanContext(ocSpanContext, /* isRemoteParent= */ false);
+  }
+
+  static io.opentelemetry.api.trace.SpanContext mapSpanContext(
+      SpanContext ocSpanContext, boolean isRemoteParent) {
+    String traceId = ocSpanContext.getTraceId().toLowerBase16();
+    String spanId = ocSpanContext.getSpanId().toLowerBase16();
+    TraceFlags traceFlags =
         ocSpanContext.getTraceOptions().isSampled()
             ? TraceFlags.getSampled()
-            : TraceFlags.getDefault(),
-        mapTracestate(ocSpanContext.getTracestate()));
+            : TraceFlags.getDefault();
+    TraceState traceState = mapTracestate(ocSpanContext.getTracestate());
+    return isRemoteParent
+        ? io.opentelemetry.api.trace.SpanContext.createFromRemoteParent(
+            traceId, spanId, traceFlags, traceState)
+        : io.opentelemetry.api.trace.SpanContext.create(traceId, spanId, traceFlags, traceState);
   }
 
   private static TraceState mapTracestate(Tracestate tracestate) {


### PR DESCRIPTION
Fixes #5475.

The behavior of `spanBuilderWithRemoteParent` seems wrong right now. It adds a span link instead but does not set the span represented by the context argument to be the parent. Not sure why this is, but I can't find anything in the [opencensus compatibility spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opencensus.md) which states that this is intended, so I'm going to assume its just a bug in the implementation.