### PR TITLE
Use low precision Clock#now when computing timestamp for exemplars

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-common.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.common.Clock  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) long now(boolean)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/common/SystemClockTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/common/SystemClockTest.java
@@ -18,7 +18,7 @@ class SystemClockTest {
 
   @EnabledOnJre(JRE.JAVA_8)
   @Test
-  void millisPrecision() {
+  void now_millisPrecision() {
     // If we test many times, we can be fairly sure we didn't just get lucky with having a rounded
     // result on a higher than expected precision timestamp.
     for (int i = 0; i < 100; i++) {
@@ -29,12 +29,37 @@ class SystemClockTest {
 
   @DisabledOnJre(JRE.JAVA_8)
   @Test
-  void microsPrecision() {
+  void now_microsPrecision() {
     // If we test many times, we can be fairly sure we get at least one timestamp that isn't
     // coincidentally rounded to millis precision.
     int numHasMicros = 0;
     for (int i = 0; i < 100; i++) {
       long now = SystemClock.getInstance().now();
+      if (now % 1000000 != 0) {
+        numHasMicros++;
+      }
+    }
+    assertThat(numHasMicros).isNotZero();
+  }
+
+  @Test
+  void now_lowPrecision() {
+    // If we test many times, we can be fairly sure we didn't just get lucky with having a rounded
+    // result on a higher than expected precision timestamp.
+    for (int i = 0; i < 100; i++) {
+      long now = SystemClock.getInstance().now(false);
+      assertThat(now % 1000000).isZero();
+    }
+  }
+
+  @DisabledOnJre(JRE.JAVA_8)
+  @Test
+  void now_highPrecision() {
+    // If we test many times, we can be fairly sure we get at least one timestamp that isn't
+    // coincidentally rounded to millis precision.
+    int numHasMicros = 0;
+    for (int i = 0; i < 100; i++) {
+      long now = SystemClock.getInstance().now(true);
       if (now % 1000000 != 0) {
         numHasMicros++;
       }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
@@ -46,10 +46,10 @@ public interface Clock {
    * whether the implementation should attempt to resolve higher precision at the potential expense
    * of performance. For example, in java 9+ its sometimes possible to resolve ns precision higher
    * than the ms precision of {@link System#currentTimeMillis()}, but doing so incurs a performance
-   * penalty which some callers may wish to avoid. In contrast, we don't currently know of resolving
-   * ns precision in java 8, regardless of the value of {@code highPrecision}.
+   * penalty which some callers may wish to avoid. In contrast, we don't currently know if resolving
+   * ns precision is possible in java 8, regardless of the value of {@code highPrecision}.
    *
-   * <p>See {@link #now()} javadoc for details on usage
+   * <p>See {@link #now()} javadoc for details on usage.
    */
   default long now(boolean highPrecision) {
     return now();

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/Clock.java
@@ -34,8 +34,26 @@ public interface Clock {
    * // Spend time...
    * long durationNanos = clock.now() - startNanos;
    * }</pre>
+   *
+   * <p>Calling this is equivalent to calling {@link #now(boolean)} with {@code highPrecision=true}.
    */
   long now();
+
+  /**
+   * Returns the current epoch timestamp in nanos from this clock.
+   *
+   * <p>This overload of {@link #now()} includes a {@code highPrecision} argument which specifies
+   * whether the implementation should attempt to resolve higher precision at the potential expense
+   * of performance. For example, in java 9+ its sometimes possible to resolve ns precision higher
+   * than the ms precision of {@link System#currentTimeMillis()}, but doing so incurs a performance
+   * penalty which some callers may wish to avoid. In contrast, we don't currently know of resolving
+   * ns precision in java 8, regardless of the value of {@code highPrecision}.
+   *
+   * <p>See {@link #now()} javadoc for details on usage
+   */
+  default long now(boolean highPrecision) {
+    return now();
+  }
 
   /**
    * Returns a time measurement with nanosecond precision that can only be used to calculate elapsed

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
@@ -27,7 +27,7 @@ final class SystemClock implements Clock {
 
   @Override
   public long now() {
-    return JavaVersionSpecific.get().currentTimeNanos();
+    return now(true);
   }
 
   @Override

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/SystemClock.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.common;
 
 import io.opentelemetry.sdk.internal.JavaVersionSpecific;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -27,6 +28,14 @@ final class SystemClock implements Clock {
   @Override
   public long now() {
     return JavaVersionSpecific.get().currentTimeNanos();
+  }
+
+  @Override
+  public long now(boolean highPrecision) {
+    if (highPrecision) {
+      return JavaVersionSpecific.get().currentTimeNanos();
+    }
+    return TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
   }
 
   @Override

--- a/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/ExemplarClockBenchmarks.java
+++ b/sdk/metrics/src/jmh/java/io/opentelemetry/sdk/metrics/ExemplarClockBenchmarks.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import io.opentelemetry.sdk.common.Clock;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * {@code io.opentelemetry.sdk.metrics.internal.exemplar.ReservoirCell} relies on {@link Clock} to
+ * obtain the measurement time when storing exemplar values. This benchmark illustrates the
+ * performance impact of using the higher precision {@link Clock#now()} instead of {@link
+ * Clock#now(boolean)} with {@code highPrecision=false}.
+ */
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class ExemplarClockBenchmarks {
+
+  private static final Clock clock = Clock.getDefault();
+
+  @SuppressWarnings("ReturnValueIgnored")
+  @Benchmark
+  public void now_lowPrecision() {
+    clock.now(false);
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  @Benchmark
+  public void now_highPrecision() {
+    clock.now(true);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java
@@ -68,8 +68,8 @@ class ReservoirCell {
 
   private void offerMeasurement(Attributes attributes, Context context) {
     this.attributes = attributes;
-    // Note: It may make sense in the future to attempt to pull this from an active span.
-    this.recordTime = clock.now();
+    // High precision time is not worth the additional performance expense it incurs for exemplars
+    this.recordTime = clock.now(/* highPrecision= */ false);
     Span current = Span.fromContext(context);
     if (current.getSpanContext().isValid()) {
       this.spanContext = current.getSpanContext();


### PR DESCRIPTION
Resolves #6403.

Introduces a new `Clock#now(boolean highPrecision)` overload, which uses a performance optimized millisecond precision when `highPrecision=false`. Updates `ReservoirCell` to obtain measurement times using `Clock#now(false)`, which shaves a good chunk of time off the time to record each exemplar (~50ns on my machine).

This has a greater impact the more frequent measurements are candidates to be stored in ReservoirCell. The savings are especially impactful for the histogram exemplar reservoir, where the algorithm requires us to take the last measurement for each bucket. This means we compute the time for every measurement recorded. 

Here's a benchmark output comparing the high precision and low precision `Clock#now` implementations. Benchmark run using `OpenJDK Runtime Environment Temurin-17.0.3+7`.
```
Benchmark                                                     Mode  Cnt   Score    Error   Units
ExemplarClockBenchmarks.now_highPrecision                     avgt   10  66.006 ±  0.110   ns/op
ExemplarClockBenchmarks.now_highPrecision:gc.alloc.rate       avgt   10   0.001 ±  0.001  MB/sec
ExemplarClockBenchmarks.now_highPrecision:gc.alloc.rate.norm  avgt   10  ≈ 10⁻⁴             B/op
ExemplarClockBenchmarks.now_highPrecision:gc.count            avgt   10     ≈ 0           counts
ExemplarClockBenchmarks.now_lowPrecision                      avgt   10  17.982 ±  0.152   ns/op
ExemplarClockBenchmarks.now_lowPrecision:gc.alloc.rate        avgt   10   0.001 ±  0.001  MB/sec
ExemplarClockBenchmarks.now_lowPrecision:gc.alloc.rate.norm   avgt   10  ≈ 10⁻⁵             B/op
ExemplarClockBenchmarks.now_lowPrecision:gc.count             avgt   10     ≈ 0           counts
```