### PR TITLE
Low allocation OTLP metrics marshaler

### DIFF
--- a/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/MetricsRequestMarshalerBenchmark.java
+++ b/exporters/otlp/common/src/jmh/java/io/opentelemetry/exporter/internal/otlp/MetricsRequestMarshalerBenchmark.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.exporter.internal.otlp.metrics.LowAllocationMetricsRequestMarshaler;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -38,6 +39,9 @@ import org.openjdk.jmh.annotations.Warmup;
 public class MetricsRequestMarshalerBenchmark {
 
   private static final Collection<MetricData> METRICS;
+  private static final LowAllocationMetricsRequestMarshaler MARSHALER =
+      new LowAllocationMetricsRequestMarshaler();
+  private static final TestOutputStream OUTPUT = new TestOutputStream();
 
   static {
     InMemoryMetricReader metricReader = InMemoryMetricReader.create();
@@ -116,10 +120,42 @@ public class MetricsRequestMarshalerBenchmark {
   }
 
   @Benchmark
-  public TestOutputStream marshaler() throws IOException {
+  public int marshalStateful() throws IOException {
     MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(METRICS);
-    TestOutputStream bos = new TestOutputStream();
-    marshaler.writeBinaryTo(bos);
-    return bos;
+    OUTPUT.reset();
+    marshaler.writeBinaryTo(OUTPUT);
+    return OUTPUT.getCount();
+  }
+
+  @Benchmark
+  public int marshalStatefulJson() throws IOException {
+    MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(METRICS);
+    OUTPUT.reset();
+    marshaler.writeJsonTo(OUTPUT);
+    return OUTPUT.getCount();
+  }
+
+  @Benchmark
+  public int marshalStateless() throws IOException {
+    MARSHALER.initialize(METRICS);
+    try {
+      OUTPUT.reset();
+      MARSHALER.writeBinaryTo(OUTPUT);
+      return OUTPUT.getCount();
+    } finally {
+      MARSHALER.reset();
+    }
+  }
+
+  @Benchmark
+  public int marshalStatelessJson() throws IOException {
+    MARSHALER.initialize(METRICS);
+    try {
+      OUTPUT.reset();
+      MARSHALER.writeJsonTo(OUTPUT);
+      return OUTPUT.getCount();
+    } finally {
+      MARSHALER.reset();
+    }
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarMarshaler.java
@@ -37,22 +37,15 @@ final class ExemplarMarshaler extends MarshalerWithSize {
     return marshalers;
   }
 
-  private static ExemplarMarshaler create(ExemplarData exemplar) {
+  // Visible for testing
+  static ExemplarMarshaler create(ExemplarData exemplar) {
     KeyValueMarshaler[] attributeMarshalers =
         KeyValueMarshaler.createForAttributes(exemplar.getFilteredAttributes());
-
-    ProtoFieldInfo valueField;
-    if (exemplar instanceof LongExemplarData) {
-      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT;
-    } else {
-      assert exemplar instanceof DoubleExemplarData;
-      valueField = io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_DOUBLE;
-    }
 
     return new ExemplarMarshaler(
         exemplar.getEpochNanos(),
         exemplar,
-        valueField,
+        toProtoExemplarValueType(exemplar),
         exemplar.getSpanContext(),
         attributeMarshalers);
   }
@@ -120,5 +113,14 @@ final class ExemplarMarshaler extends MarshalerWithSize {
             io.opentelemetry.proto.metrics.v1.internal.Exemplar.FILTERED_ATTRIBUTES,
             filteredAttributeMarshalers);
     return size;
+  }
+
+  static ProtoFieldInfo toProtoExemplarValueType(ExemplarData exemplar) {
+    if (exemplar instanceof LongExemplarData) {
+      return io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT;
+    } else {
+      assert exemplar instanceof DoubleExemplarData;
+      return io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_DOUBLE;
+    }
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarStatelessMarshaler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import static io.opentelemetry.exporter.internal.otlp.metrics.ExemplarMarshaler.toProtoExemplarValueType;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.LongExemplarData;
+import java.io.IOException;
+
+/** See {@link ExemplarMarshaler}. */
+final class ExemplarStatelessMarshaler implements StatelessMarshaler<ExemplarData> {
+  static final ExemplarStatelessMarshaler INSTANCE = new ExemplarStatelessMarshaler();
+
+  private ExemplarStatelessMarshaler() {}
+
+  @Override
+  public void writeTo(Serializer output, ExemplarData exemplar, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(
+        io.opentelemetry.proto.metrics.v1.internal.Exemplar.TIME_UNIX_NANO,
+        exemplar.getEpochNanos());
+    ProtoFieldInfo valueField = toProtoExemplarValueType(exemplar);
+    if (valueField == io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT) {
+      output.serializeFixed64Optional(valueField, ((LongExemplarData) exemplar).getValue());
+    } else {
+      output.serializeDoubleOptional(valueField, ((DoubleExemplarData) exemplar).getValue());
+    }
+    SpanContext spanContext = exemplar.getSpanContext();
+    if (spanContext.isValid()) {
+      output.serializeSpanId(
+          io.opentelemetry.proto.metrics.v1.internal.Exemplar.SPAN_ID,
+          spanContext.getSpanId(),
+          context);
+      output.serializeTraceId(
+          io.opentelemetry.proto.metrics.v1.internal.Exemplar.TRACE_ID,
+          spanContext.getTraceId(),
+          context);
+    }
+    output.serializeRepeatedMessageWithContext(
+        io.opentelemetry.proto.metrics.v1.internal.Exemplar.FILTERED_ATTRIBUTES,
+        exemplar.getFilteredAttributes(),
+        KeyValueStatelessMarshaler.INSTANCE,
+        context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(ExemplarData exemplar, MarshalerContext context) {
+    int size = 0;
+    size +=
+        MarshalerUtil.sizeFixed64(
+            io.opentelemetry.proto.metrics.v1.internal.Exemplar.TIME_UNIX_NANO,
+            exemplar.getEpochNanos());
+    ProtoFieldInfo valueField = toProtoExemplarValueType(exemplar);
+    if (valueField == io.opentelemetry.proto.metrics.v1.internal.Exemplar.AS_INT) {
+      size +=
+          MarshalerUtil.sizeFixed64Optional(valueField, ((LongExemplarData) exemplar).getValue());
+    } else {
+      size +=
+          MarshalerUtil.sizeDoubleOptional(valueField, ((DoubleExemplarData) exemplar).getValue());
+    }
+    SpanContext spanContext = exemplar.getSpanContext();
+    if (spanContext.isValid()) {
+      size +=
+          MarshalerUtil.sizeSpanId(
+              io.opentelemetry.proto.metrics.v1.internal.Exemplar.SPAN_ID, spanContext.getSpanId());
+      size +=
+          MarshalerUtil.sizeTraceId(
+              io.opentelemetry.proto.metrics.v1.internal.Exemplar.TRACE_ID,
+              spanContext.getTraceId());
+    }
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            io.opentelemetry.proto.metrics.v1.internal.Exemplar.FILTERED_ATTRIBUTES,
+            exemplar.getFilteredAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramBucketsMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramBucketsMarshaler.java
@@ -45,7 +45,7 @@ public class ExponentialHistogramBucketsMarshaler extends MarshalerWithSize {
     }
   }
 
-  private static int calculateSize(int offset, List<Long> counts) {
+  static int calculateSize(int offset, List<Long> counts) {
     int size = 0;
     size += MarshalerUtil.sizeSInt32(ExponentialHistogramDataPoint.Buckets.OFFSET, offset);
     if (counts instanceof DynamicPrimitiveLongList) {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramBucketsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramBucketsStatelessMarshaler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.ExponentialHistogramDataPoint;
+import io.opentelemetry.sdk.internal.DynamicPrimitiveLongList;
+import io.opentelemetry.sdk.internal.PrimitiveLongList;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
+import java.io.IOException;
+import java.util.List;
+
+/** See {@link ExponentialHistogramBucketsMarshaler}. */
+final class ExponentialHistogramBucketsStatelessMarshaler
+    implements StatelessMarshaler<ExponentialHistogramBuckets> {
+  static final ExponentialHistogramBucketsStatelessMarshaler INSTANCE =
+      new ExponentialHistogramBucketsStatelessMarshaler();
+
+  private ExponentialHistogramBucketsStatelessMarshaler() {}
+
+  @Override
+  public void writeTo(
+      Serializer output, ExponentialHistogramBuckets buckets, MarshalerContext context)
+      throws IOException {
+    output.serializeSInt32(ExponentialHistogramDataPoint.Buckets.OFFSET, buckets.getOffset());
+    List<Long> counts = buckets.getBucketCounts();
+    if (counts instanceof DynamicPrimitiveLongList) {
+      output.serializeRepeatedUInt64(
+          ExponentialHistogramDataPoint.Buckets.BUCKET_COUNTS, (DynamicPrimitiveLongList) counts);
+    } else {
+      output.serializeRepeatedUInt64(
+          ExponentialHistogramDataPoint.Buckets.BUCKET_COUNTS, PrimitiveLongList.toArray(counts));
+    }
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      ExponentialHistogramBuckets buckets, MarshalerContext context) {
+    return ExponentialHistogramBucketsMarshaler.calculateSize(
+        buckets.getOffset(), buckets.getBucketCounts());
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
@@ -21,6 +21,8 @@ final class ExponentialHistogramDataPointStatelessMarshaler
   static final ExponentialHistogramDataPointStatelessMarshaler INSTANCE =
       new ExponentialHistogramDataPointStatelessMarshaler();
 
+  private ExponentialHistogramDataPointStatelessMarshaler() {}
+
   @Override
   public void writeTo(
       Serializer output, ExponentialHistogramPointData point, MarshalerContext context)

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.ExponentialHistogramDataPoint;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import java.io.IOException;
+
+/** See {@link ExponentialHistogramDataPointMarshaler}. */
+final class ExponentialHistogramDataPointStatelessMarshaler
+    implements StatelessMarshaler<ExponentialHistogramPointData> {
+  static final ExponentialHistogramDataPointStatelessMarshaler INSTANCE =
+      new ExponentialHistogramDataPointStatelessMarshaler();
+
+  @Override
+  public void writeTo(
+      Serializer output, ExponentialHistogramPointData point, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(
+        ExponentialHistogramDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    output.serializeFixed64(ExponentialHistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    output.serializeFixed64(ExponentialHistogramDataPoint.COUNT, point.getCount());
+    output.serializeDouble(ExponentialHistogramDataPoint.SUM, point.getSum());
+    if (point.hasMin()) {
+      output.serializeDoubleOptional(ExponentialHistogramDataPoint.MIN, point.getMin());
+    }
+    if (point.hasMax()) {
+      output.serializeDoubleOptional(ExponentialHistogramDataPoint.MAX, point.getMax());
+    }
+    output.serializeSInt32(ExponentialHistogramDataPoint.SCALE, point.getScale());
+    output.serializeFixed64(ExponentialHistogramDataPoint.ZERO_COUNT, point.getZeroCount());
+    output.serializeMessageWithContext(
+        ExponentialHistogramDataPoint.POSITIVE,
+        point.getPositiveBuckets(),
+        ExponentialHistogramBucketsStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeMessageWithContext(
+        ExponentialHistogramDataPoint.NEGATIVE,
+        point.getNegativeBuckets(),
+        ExponentialHistogramBucketsStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeRepeatedMessageWithContext(
+        ExponentialHistogramDataPoint.EXEMPLARS,
+        point.getExemplars(),
+        ExemplarStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeRepeatedMessageWithContext(
+        ExponentialHistogramDataPoint.ATTRIBUTES,
+        point.getAttributes(),
+        KeyValueStatelessMarshaler.INSTANCE,
+        context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      ExponentialHistogramPointData point, MarshalerContext context) {
+    int size = 0;
+    size +=
+        MarshalerUtil.sizeFixed64(
+            ExponentialHistogramDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    size +=
+        MarshalerUtil.sizeFixed64(
+            ExponentialHistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.COUNT, point.getCount());
+    size += MarshalerUtil.sizeDouble(ExponentialHistogramDataPoint.SUM, point.getSum());
+    if (point.hasMin()) {
+      size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MIN, point.getMin());
+    }
+    if (point.hasMax()) {
+      size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MAX, point.getMax());
+    }
+    size += MarshalerUtil.sizeSInt32(ExponentialHistogramDataPoint.SCALE, point.getScale());
+    size +=
+        MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.ZERO_COUNT, point.getZeroCount());
+    size +=
+        StatelessMarshalerUtil.sizeMessageWithContext(
+            ExponentialHistogramDataPoint.POSITIVE,
+            point.getPositiveBuckets(),
+            ExponentialHistogramBucketsStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeMessageWithContext(
+            ExponentialHistogramDataPoint.NEGATIVE,
+            point.getNegativeBuckets(),
+            ExponentialHistogramBucketsStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            ExponentialHistogramDataPoint.EXEMPLARS,
+            point.getExemplars(),
+            ExemplarStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            ExponentialHistogramDataPoint.ATTRIBUTES,
+            point.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramStatelessMarshaler.java
@@ -22,6 +22,8 @@ final class ExponentialHistogramStatelessMarshaler
   private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
   private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
 
+  private ExponentialHistogramStatelessMarshaler() {}
+
   @Override
   public void writeTo(
       Serializer output, ExponentialHistogramData histogram, MarshalerContext context)

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramStatelessMarshaler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.ExponentialHistogram;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramData;
+import java.io.IOException;
+
+/** See {@link ExponentialHistogramMarshaler}. */
+final class ExponentialHistogramStatelessMarshaler
+    implements StatelessMarshaler<ExponentialHistogramData> {
+  static final ExponentialHistogramStatelessMarshaler INSTANCE =
+      new ExponentialHistogramStatelessMarshaler();
+  private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(
+      Serializer output, ExponentialHistogramData histogram, MarshalerContext context)
+      throws IOException {
+    output.serializeRepeatedMessageWithContext(
+        ExponentialHistogram.DATA_POINTS,
+        histogram.getPoints(),
+        ExponentialHistogramDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_WRITER_KEY);
+    output.serializeEnum(
+        ExponentialHistogram.AGGREGATION_TEMPORALITY,
+        MetricsMarshalerUtil.mapToTemporality(histogram.getAggregationTemporality()));
+  }
+
+  @Override
+  public int getBinarySerializedSize(ExponentialHistogramData histogram, MarshalerContext context) {
+    int size = 0;
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            ExponentialHistogram.DATA_POINTS,
+            histogram.getPoints(),
+            ExponentialHistogramDataPointStatelessMarshaler.INSTANCE,
+            context,
+            DATA_POINT_SIZE_CALCULATOR_KEY);
+    size +=
+        MarshalerUtil.sizeEnum(
+            ExponentialHistogram.AGGREGATION_TEMPORALITY,
+            MetricsMarshalerUtil.mapToTemporality(histogram.getAggregationTemporality()));
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/GaugeStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/GaugeStatelessMarshaler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.Gauge;
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import java.io.IOException;
+
+/** See {@link GaugeMarshaler}. */
+final class GaugeStatelessMarshaler implements StatelessMarshaler<GaugeData<? extends PointData>> {
+  static final GaugeStatelessMarshaler INSTANCE = new GaugeStatelessMarshaler();
+  private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(
+      Serializer output, GaugeData<? extends PointData> gauge, MarshalerContext context)
+      throws IOException {
+    output.serializeRepeatedMessageWithContext(
+        Gauge.DATA_POINTS,
+        gauge.getPoints(),
+        NumberDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_WRITER_KEY);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      GaugeData<? extends PointData> gauge, MarshalerContext context) {
+    int size = 0;
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            Gauge.DATA_POINTS,
+            gauge.getPoints(),
+            NumberDataPointStatelessMarshaler.INSTANCE,
+            context,
+            DATA_POINT_SIZE_CALCULATOR_KEY);
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/GaugeStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/GaugeStatelessMarshaler.java
@@ -20,6 +20,8 @@ final class GaugeStatelessMarshaler implements StatelessMarshaler<GaugeData<? ex
   private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
   private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
 
+  private GaugeStatelessMarshaler() {}
+
   @Override
   public void writeTo(
       Serializer output, GaugeData<? extends PointData> gauge, MarshalerContext context)
@@ -35,14 +37,11 @@ final class GaugeStatelessMarshaler implements StatelessMarshaler<GaugeData<? ex
   @Override
   public int getBinarySerializedSize(
       GaugeData<? extends PointData> gauge, MarshalerContext context) {
-    int size = 0;
-    size +=
-        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
-            Gauge.DATA_POINTS,
-            gauge.getPoints(),
-            NumberDataPointStatelessMarshaler.INSTANCE,
-            context,
-            DATA_POINT_SIZE_CALCULATOR_KEY);
-    return size;
+    return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+        Gauge.DATA_POINTS,
+        gauge.getPoints(),
+        NumberDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_SIZE_CALCULATOR_KEY);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
@@ -20,6 +20,8 @@ final class HistogramDataPointStatelessMarshaler implements StatelessMarshaler<H
   static final HistogramDataPointStatelessMarshaler INSTANCE =
       new HistogramDataPointStatelessMarshaler();
 
+  private HistogramDataPointStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, HistogramPointData point, MarshalerContext context)
       throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.HistogramDataPoint;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import java.io.IOException;
+
+/** See {@link HistogramDataPointMarshaler}. */
+final class HistogramDataPointStatelessMarshaler implements StatelessMarshaler<HistogramPointData> {
+  static final HistogramDataPointStatelessMarshaler INSTANCE =
+      new HistogramDataPointStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, HistogramPointData point, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(HistogramDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    output.serializeFixed64(HistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    output.serializeFixed64(HistogramDataPoint.COUNT, point.getCount());
+    output.serializeDoubleOptional(HistogramDataPoint.SUM, point.getSum());
+    if (point.hasMin()) {
+      output.serializeDoubleOptional(HistogramDataPoint.MIN, point.getMin());
+    }
+    if (point.hasMax()) {
+      output.serializeDoubleOptional(HistogramDataPoint.MAX, point.getMax());
+    }
+    output.serializeRepeatedFixed64(HistogramDataPoint.BUCKET_COUNTS, point.getCounts());
+    output.serializeRepeatedDouble(HistogramDataPoint.EXPLICIT_BOUNDS, point.getBoundaries());
+    output.serializeRepeatedMessageWithContext(
+        HistogramDataPoint.EXEMPLARS,
+        point.getExemplars(),
+        ExemplarStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeRepeatedMessageWithContext(
+        HistogramDataPoint.ATTRIBUTES,
+        point.getAttributes(),
+        KeyValueStatelessMarshaler.INSTANCE,
+        context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(HistogramPointData point, MarshalerContext context) {
+    int size = 0;
+    size +=
+        MarshalerUtil.sizeFixed64(
+            HistogramDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    size += MarshalerUtil.sizeFixed64(HistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    size += MarshalerUtil.sizeFixed64(HistogramDataPoint.COUNT, point.getCount());
+    size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.SUM, point.getSum());
+    if (point.hasMin()) {
+      size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.MIN, point.getMin());
+    }
+    if (point.hasMax()) {
+      size += MarshalerUtil.sizeDoubleOptional(HistogramDataPoint.MAX, point.getMax());
+    }
+    size += MarshalerUtil.sizeRepeatedFixed64(HistogramDataPoint.BUCKET_COUNTS, point.getCounts());
+    size +=
+        MarshalerUtil.sizeRepeatedDouble(HistogramDataPoint.EXPLICIT_BOUNDS, point.getBoundaries());
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            HistogramDataPoint.EXEMPLARS,
+            point.getExemplars(),
+            ExemplarStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            HistogramDataPoint.ATTRIBUTES,
+            point.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramStatelessMarshaler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.Histogram;
+import io.opentelemetry.sdk.metrics.data.HistogramData;
+import java.io.IOException;
+
+/** See {@link HistogramMarshaler}. */
+final class HistogramStatelessMarshaler implements StatelessMarshaler<HistogramData> {
+  static final HistogramStatelessMarshaler INSTANCE = new HistogramStatelessMarshaler();
+  private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(Serializer output, HistogramData histogram, MarshalerContext context)
+      throws IOException {
+    output.serializeRepeatedMessageWithContext(
+        Histogram.DATA_POINTS,
+        histogram.getPoints(),
+        HistogramDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_WRITER_KEY);
+    output.serializeEnum(
+        Histogram.AGGREGATION_TEMPORALITY,
+        MetricsMarshalerUtil.mapToTemporality(histogram.getAggregationTemporality()));
+  }
+
+  @Override
+  public int getBinarySerializedSize(HistogramData histogram, MarshalerContext context) {
+    int size = 0;
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            Histogram.DATA_POINTS,
+            histogram.getPoints(),
+            HistogramDataPointStatelessMarshaler.INSTANCE,
+            context,
+            DATA_POINT_SIZE_CALCULATOR_KEY);
+    size +=
+        MarshalerUtil.sizeEnum(
+            Histogram.AGGREGATION_TEMPORALITY,
+            MetricsMarshalerUtil.mapToTemporality(histogram.getAggregationTemporality()));
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramStatelessMarshaler.java
@@ -20,6 +20,8 @@ final class HistogramStatelessMarshaler implements StatelessMarshaler<HistogramD
   private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
   private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
 
+  private HistogramStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, HistogramData histogram, MarshalerContext context)
       throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
@@ -24,6 +24,8 @@ final class InstrumentationScopeMetricsStatelessMarshaler
   static final InstrumentationScopeMetricsStatelessMarshaler INSTANCE =
       new InstrumentationScopeMetricsStatelessMarshaler();
 
+  private InstrumentationScopeMetricsStatelessMarshaler() {}
+
   @Override
   public void writeTo(
       Serializer output,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.ScopeMetrics;
+import io.opentelemetry.proto.trace.v1.internal.ScopeSpans;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.io.IOException;
+import java.util.List;
+
+/** See {@link InstrumentationScopeMetricsMarshaler}. */
+final class InstrumentationScopeMetricsStatelessMarshaler
+    implements StatelessMarshaler2<InstrumentationScopeInfo, List<MetricData>> {
+  static final InstrumentationScopeMetricsStatelessMarshaler INSTANCE =
+      new InstrumentationScopeMetricsStatelessMarshaler();
+
+  @Override
+  public void writeTo(
+      Serializer output,
+      InstrumentationScopeInfo instrumentationScope,
+      List<MetricData> metrics,
+      MarshalerContext context)
+      throws IOException {
+    InstrumentationScopeMarshaler instrumentationScopeMarshaler =
+        context.getData(InstrumentationScopeMarshaler.class);
+
+    output.serializeMessage(ScopeMetrics.SCOPE, instrumentationScopeMarshaler);
+    output.serializeRepeatedMessageWithContext(
+        ScopeMetrics.METRICS, metrics, MetricStatelessMarshaler.INSTANCE, context);
+    output.serializeStringWithContext(
+        ScopeMetrics.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      InstrumentationScopeInfo instrumentationScope,
+      List<MetricData> metrics,
+      MarshalerContext context) {
+    InstrumentationScopeMarshaler instrumentationScopeMarshaler =
+        InstrumentationScopeMarshaler.create(instrumentationScope);
+    context.addData(instrumentationScopeMarshaler);
+
+    int size = 0;
+    size += MarshalerUtil.sizeMessage(ScopeMetrics.SCOPE, instrumentationScopeMarshaler);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            ScopeMetrics.METRICS, metrics, MetricStatelessMarshaler.INSTANCE, context);
+    size +=
+        StatelessMarshalerUtil.sizeStringWithContext(
+            ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshaler.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <pre>{@code
  * void marshal(LowAllocationMetricsRequestMarshaler requestMarshaler, OutputStream output,
  *     Collection<MetricData> metricDataList) throws IOException {
- *   requestMarshaler.initialize(spanList);
+ *   requestMarshaler.initialize(metricDataList);
  *   try {
  *     requestMarshaler.writeBinaryTo(output);
  *   } finally {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshaler.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.collector.metrics.v1.internal.ExportMetricsServiceRequest;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link Marshaler} to convert SDK {@link MetricData} to OTLP ExportMetricsServiceRequest. See
+ * {@link MetricsRequestMarshaler}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * void marshal(LowAllocationMetricsRequestMarshaler requestMarshaler, OutputStream output,
+ *     Collection<MetricData> metricDataList) throws IOException {
+ *   requestMarshaler.initialize(spanList);
+ *   try {
+ *     requestMarshaler.writeBinaryTo(output);
+ *   } finally {
+ *     requestMarshaler.reset();
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class LowAllocationMetricsRequestMarshaler extends Marshaler {
+  private static final MarshalerContext.Key RESOURCE_METRIC_SIZE_CALCULATOR_KEY =
+      MarshalerContext.key();
+  private static final MarshalerContext.Key RESOURCE_METRIC_WRITER_KEY = MarshalerContext.key();
+
+  private final MarshalerContext context = new MarshalerContext();
+
+  @SuppressWarnings("NullAway")
+  private Map<Resource, Map<InstrumentationScopeInfo, List<MetricData>>> resourceAndScopeMap;
+
+  private int size;
+
+  public void initialize(Collection<MetricData> metricDataList) {
+    resourceAndScopeMap = groupByResourceAndScope(context, metricDataList);
+    size = calculateSize(context, resourceAndScopeMap);
+  }
+
+  public void reset() {
+    context.reset();
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return size;
+  }
+
+  @Override
+  public void writeTo(Serializer output) throws IOException {
+    // serializing can be retried, reset the indexes, so we could call writeTo multiple times
+    context.resetReadIndex();
+    output.serializeRepeatedMessageWithContext(
+        ExportMetricsServiceRequest.RESOURCE_METRICS,
+        resourceAndScopeMap,
+        ResourceMetricsStatelessMarshaler.INSTANCE,
+        context,
+        RESOURCE_METRIC_WRITER_KEY);
+  }
+
+  private static int calculateSize(
+      MarshalerContext context,
+      Map<Resource, Map<InstrumentationScopeInfo, List<MetricData>>> resourceAndScopeMap) {
+    return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+        ExportMetricsServiceRequest.RESOURCE_METRICS,
+        resourceAndScopeMap,
+        ResourceMetricsStatelessMarshaler.INSTANCE,
+        context,
+        RESOURCE_METRIC_SIZE_CALCULATOR_KEY);
+  }
+
+  private static Map<Resource, Map<InstrumentationScopeInfo, List<MetricData>>>
+      groupByResourceAndScope(MarshalerContext context, Collection<MetricData> metricDataList) {
+
+    if (metricDataList.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    return StatelessMarshalerUtil.groupByResourceAndScope(
+        metricDataList,
+        // TODO(anuraaga): Replace with an internal SdkData type of interface that exposes these
+        // two.
+        MetricData::getResource,
+        MetricData::getInstrumentationScopeInfo,
+        context);
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricStatelessMarshaler.java
@@ -14,7 +14,6 @@ import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_SUM;
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.SUMMARY;
 
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
-import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
@@ -28,17 +27,17 @@ import java.util.Map;
 /** See {@link MetricMarshaler}. */
 final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
   static final MetricStatelessMarshaler INSTANCE = new MetricStatelessMarshaler();
-  private static final Map<MetricDataType, DataHandler> DATA_HANDLERS =
+  private static final Map<MetricDataType, StatelessMarshaler<MetricData>> METRIC_MARSHALERS =
       new EnumMap<>(MetricDataType.class);
 
   static {
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         LONG_GAUGE,
-        new DataHandler(Metric.GAUGE) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField,
+                Metric.GAUGE,
                 metricData.getLongGaugeData(),
                 GaugeStatelessMarshaler.INSTANCE,
                 context);
@@ -51,13 +50,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 Metric.GAUGE, metric.getLongGaugeData(), GaugeStatelessMarshaler.INSTANCE, context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         DOUBLE_GAUGE,
-        new DataHandler(Metric.GAUGE) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField,
+                Metric.GAUGE,
                 metricData.getDoubleGaugeData(),
                 GaugeStatelessMarshaler.INSTANCE,
                 context);
@@ -73,13 +72,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         LONG_SUM,
-        new DataHandler(Metric.SUM) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField, metricData.getLongSumData(), SumStatelessMarshaler.INSTANCE, context);
+                Metric.SUM, metricData.getLongSumData(), SumStatelessMarshaler.INSTANCE, context);
           }
 
           @Override
@@ -89,13 +88,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 Metric.SUM, metric.getLongSumData(), SumStatelessMarshaler.INSTANCE, context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         DOUBLE_SUM,
-        new DataHandler(Metric.SUM) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField, metricData.getDoubleSumData(), SumStatelessMarshaler.INSTANCE, context);
+                Metric.SUM, metricData.getDoubleSumData(), SumStatelessMarshaler.INSTANCE, context);
           }
 
           @Override
@@ -105,13 +104,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 Metric.SUM, metric.getDoubleSumData(), SumStatelessMarshaler.INSTANCE, context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         SUMMARY,
-        new DataHandler(Metric.SUMMARY) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField,
+                Metric.SUMMARY,
                 metricData.getSummaryData(),
                 SummaryStatelessMarshaler.INSTANCE,
                 context);
@@ -127,13 +126,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         HISTOGRAM,
-        new DataHandler(Metric.HISTOGRAM) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField,
+                Metric.HISTOGRAM,
                 metricData.getHistogramData(),
                 HistogramStatelessMarshaler.INSTANCE,
                 context);
@@ -149,13 +148,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
                 context);
           }
         });
-    DATA_HANDLERS.put(
+    METRIC_MARSHALERS.put(
         EXPONENTIAL_HISTOGRAM,
-        new DataHandler(Metric.EXPONENTIAL_HISTOGRAM) {
+        new StatelessMarshaler<MetricData>() {
           @Override
-          public int calculateSize(MetricData metricData, MarshalerContext context) {
+          public int getBinarySerializedSize(MetricData metricData, MarshalerContext context) {
             return StatelessMarshalerUtil.sizeMessageWithContext(
-                dataField,
+                Metric.EXPONENTIAL_HISTOGRAM,
                 metricData.getExponentialHistogramData(),
                 ExponentialHistogramStatelessMarshaler.INSTANCE,
                 context);
@@ -173,11 +172,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
         });
   }
 
+  private MetricStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
       throws IOException {
-    DataHandler dataHandler = DATA_HANDLERS.get(metric.getType());
-    if (dataHandler == null) {
+    StatelessMarshaler<MetricData> metricMarshaler = METRIC_MARSHALERS.get(metric.getType());
+    if (metricMarshaler == null) {
       // Someone not using BOM to align versions as we require. Just skip the metric.
       return;
     }
@@ -186,13 +187,13 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
     output.serializeStringWithContext(Metric.DESCRIPTION, metric.getDescription(), context);
     output.serializeStringWithContext(Metric.UNIT, metric.getUnit(), context);
 
-    dataHandler.writeTo(output, metric, context);
+    metricMarshaler.writeTo(output, metric, context);
   }
 
   @Override
   public int getBinarySerializedSize(MetricData metric, MarshalerContext context) {
-    DataHandler dataHandler = DATA_HANDLERS.get(metric.getType());
-    if (dataHandler == null) {
+    StatelessMarshaler<MetricData> metricMarshaler = METRIC_MARSHALERS.get(metric.getType());
+    if (metricMarshaler == null) {
       // Someone not using BOM to align versions as we require. Just skip the metric.
       return 0;
     }
@@ -204,21 +205,8 @@ final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
             Metric.DESCRIPTION, metric.getDescription(), context);
     size += StatelessMarshalerUtil.sizeStringWithContext(Metric.UNIT, metric.getUnit(), context);
 
-    size += dataHandler.calculateSize(metric, context);
+    size += metricMarshaler.getBinarySerializedSize(metric, context);
 
     return size;
-  }
-
-  private abstract static class DataHandler {
-    final ProtoFieldInfo dataField;
-
-    DataHandler(ProtoFieldInfo dataField) {
-      this.dataField = dataField;
-    }
-
-    abstract int calculateSize(MetricData metricData, MarshalerContext context);
-
-    abstract void writeTo(Serializer output, MetricData metricData, MarshalerContext context)
-        throws IOException;
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricStatelessMarshaler.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_GAUGE;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_SUM;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.EXPONENTIAL_HISTOGRAM;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.HISTOGRAM;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_GAUGE;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_SUM;
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.SUMMARY;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.Metric;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+
+/** See {@link MetricMarshaler}. */
+final class MetricStatelessMarshaler implements StatelessMarshaler<MetricData> {
+  static final MetricStatelessMarshaler INSTANCE = new MetricStatelessMarshaler();
+  private static final Map<MetricDataType, DataHandler> DATA_HANDLERS =
+      new EnumMap<>(MetricDataType.class);
+
+  static {
+    DATA_HANDLERS.put(
+        LONG_GAUGE,
+        new DataHandler(Metric.GAUGE) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField,
+                metricData.getLongGaugeData(),
+                GaugeStatelessMarshaler.INSTANCE,
+                context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.GAUGE, metric.getLongGaugeData(), GaugeStatelessMarshaler.INSTANCE, context);
+          }
+        });
+    DATA_HANDLERS.put(
+        DOUBLE_GAUGE,
+        new DataHandler(Metric.GAUGE) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField,
+                metricData.getDoubleGaugeData(),
+                GaugeStatelessMarshaler.INSTANCE,
+                context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.GAUGE,
+                metric.getDoubleGaugeData(),
+                GaugeStatelessMarshaler.INSTANCE,
+                context);
+          }
+        });
+    DATA_HANDLERS.put(
+        LONG_SUM,
+        new DataHandler(Metric.SUM) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField, metricData.getLongSumData(), SumStatelessMarshaler.INSTANCE, context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.SUM, metric.getLongSumData(), SumStatelessMarshaler.INSTANCE, context);
+          }
+        });
+    DATA_HANDLERS.put(
+        DOUBLE_SUM,
+        new DataHandler(Metric.SUM) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField, metricData.getDoubleSumData(), SumStatelessMarshaler.INSTANCE, context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.SUM, metric.getDoubleSumData(), SumStatelessMarshaler.INSTANCE, context);
+          }
+        });
+    DATA_HANDLERS.put(
+        SUMMARY,
+        new DataHandler(Metric.SUMMARY) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField,
+                metricData.getSummaryData(),
+                SummaryStatelessMarshaler.INSTANCE,
+                context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.SUMMARY,
+                metric.getSummaryData(),
+                SummaryStatelessMarshaler.INSTANCE,
+                context);
+          }
+        });
+    DATA_HANDLERS.put(
+        HISTOGRAM,
+        new DataHandler(Metric.HISTOGRAM) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField,
+                metricData.getHistogramData(),
+                HistogramStatelessMarshaler.INSTANCE,
+                context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.HISTOGRAM,
+                metric.getHistogramData(),
+                HistogramStatelessMarshaler.INSTANCE,
+                context);
+          }
+        });
+    DATA_HANDLERS.put(
+        EXPONENTIAL_HISTOGRAM,
+        new DataHandler(Metric.EXPONENTIAL_HISTOGRAM) {
+          @Override
+          public int calculateSize(MetricData metricData, MarshalerContext context) {
+            return StatelessMarshalerUtil.sizeMessageWithContext(
+                dataField,
+                metricData.getExponentialHistogramData(),
+                ExponentialHistogramStatelessMarshaler.INSTANCE,
+                context);
+          }
+
+          @Override
+          public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+              throws IOException {
+            output.serializeMessageWithContext(
+                Metric.EXPONENTIAL_HISTOGRAM,
+                metric.getExponentialHistogramData(),
+                ExponentialHistogramStatelessMarshaler.INSTANCE,
+                context);
+          }
+        });
+  }
+
+  @Override
+  public void writeTo(Serializer output, MetricData metric, MarshalerContext context)
+      throws IOException {
+    DataHandler dataHandler = DATA_HANDLERS.get(metric.getType());
+    if (dataHandler == null) {
+      // Someone not using BOM to align versions as we require. Just skip the metric.
+      return;
+    }
+
+    output.serializeStringWithContext(Metric.NAME, metric.getName(), context);
+    output.serializeStringWithContext(Metric.DESCRIPTION, metric.getDescription(), context);
+    output.serializeStringWithContext(Metric.UNIT, metric.getUnit(), context);
+
+    dataHandler.writeTo(output, metric, context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(MetricData metric, MarshalerContext context) {
+    DataHandler dataHandler = DATA_HANDLERS.get(metric.getType());
+    if (dataHandler == null) {
+      // Someone not using BOM to align versions as we require. Just skip the metric.
+      return 0;
+    }
+
+    int size = 0;
+    size += StatelessMarshalerUtil.sizeStringWithContext(Metric.NAME, metric.getName(), context);
+    size +=
+        StatelessMarshalerUtil.sizeStringWithContext(
+            Metric.DESCRIPTION, metric.getDescription(), context);
+    size += StatelessMarshalerUtil.sizeStringWithContext(Metric.UNIT, metric.getUnit(), context);
+
+    size += dataHandler.calculateSize(metric, context);
+
+    return size;
+  }
+
+  private abstract static class DataHandler {
+    final ProtoFieldInfo dataField;
+
+    DataHandler(ProtoFieldInfo dataField) {
+      this.dataField = dataField;
+    }
+
+    abstract int calculateSize(MetricData metricData, MarshalerContext context);
+
+    abstract void writeTo(Serializer output, MetricData metricData, MarshalerContext context)
+        throws IOException;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointMarshaler.java
@@ -42,19 +42,11 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     KeyValueMarshaler[] attributeMarshalers =
         KeyValueMarshaler.createForAttributes(point.getAttributes());
 
-    ProtoFieldInfo valueField;
-    if (point instanceof LongPointData) {
-      valueField = NumberDataPoint.AS_INT;
-    } else {
-      assert point instanceof DoublePointData;
-      valueField = NumberDataPoint.AS_DOUBLE;
-    }
-
     return new NumberDataPointMarshaler(
         point.getStartEpochNanos(),
         point.getEpochNanos(),
         point,
-        valueField,
+        toProtoPointValueType(point),
         exemplarMarshalers,
         attributeMarshalers);
   }
@@ -106,5 +98,14 @@ final class NumberDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.EXEMPLARS, exemplars);
     size += MarshalerUtil.sizeRepeatedMessage(NumberDataPoint.ATTRIBUTES, attributes);
     return size;
+  }
+
+  static ProtoFieldInfo toProtoPointValueType(PointData pointData) {
+    if (pointData instanceof LongPointData) {
+      return NumberDataPoint.AS_INT;
+    } else {
+      assert pointData instanceof DoublePointData;
+      return NumberDataPoint.AS_DOUBLE;
+    }
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import static io.opentelemetry.exporter.internal.otlp.metrics.NumberDataPointMarshaler.toProtoPointValueType;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.NumberDataPoint;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import java.io.IOException;
+
+/** See {@link NumberDataPointMarshaler}. */
+final class NumberDataPointStatelessMarshaler implements StatelessMarshaler<PointData> {
+  static final NumberDataPointStatelessMarshaler INSTANCE = new NumberDataPointStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, PointData point, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    output.serializeFixed64(NumberDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    ProtoFieldInfo valueField = toProtoPointValueType(point);
+    if (valueField == NumberDataPoint.AS_INT) {
+      output.serializeFixed64Optional(valueField, ((LongPointData) point).getValue());
+    } else {
+      output.serializeDoubleOptional(valueField, ((DoublePointData) point).getValue());
+    }
+    output.serializeRepeatedMessageWithContext(
+        NumberDataPoint.EXEMPLARS,
+        point.getExemplars(),
+        ExemplarStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeRepeatedMessageWithContext(
+        NumberDataPoint.ATTRIBUTES,
+        point.getAttributes(),
+        KeyValueStatelessMarshaler.INSTANCE,
+        context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(PointData point, MarshalerContext context) {
+    int size = 0;
+    size +=
+        MarshalerUtil.sizeFixed64(NumberDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    size += MarshalerUtil.sizeFixed64(NumberDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    ProtoFieldInfo valueField = toProtoPointValueType(point);
+    if (valueField == NumberDataPoint.AS_INT) {
+      size += MarshalerUtil.sizeFixed64Optional(valueField, ((LongPointData) point).getValue());
+    } else {
+      size += MarshalerUtil.sizeDoubleOptional(valueField, ((DoublePointData) point).getValue());
+    }
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            NumberDataPoint.EXEMPLARS,
+            point.getExemplars(),
+            ExemplarStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            NumberDataPoint.ATTRIBUTES,
+            point.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 final class NumberDataPointStatelessMarshaler implements StatelessMarshaler<PointData> {
   static final NumberDataPointStatelessMarshaler INSTANCE = new NumberDataPointStatelessMarshaler();
 
+  private NumberDataPointStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, PointData point, MarshalerContext context)
       throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsStatelessMarshaler.java
@@ -28,8 +28,11 @@ import java.util.Map;
 public final class ResourceMetricsStatelessMarshaler
     implements StatelessMarshaler2<Resource, Map<InstrumentationScopeInfo, List<MetricData>>> {
   static final ResourceMetricsStatelessMarshaler INSTANCE = new ResourceMetricsStatelessMarshaler();
-  private static final MarshalerContext.Key SCOPE_SPAN_WRITER_KEY = MarshalerContext.key();
-  private static final MarshalerContext.Key SCOPE_SPAN_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key SCOPE_METRIC_WRITER_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key SCOPE_METRIC_SIZE_CALCULATOR_KEY =
+      MarshalerContext.key();
+
+  private ResourceMetricsStatelessMarshaler() {}
 
   @Override
   public void writeTo(
@@ -46,7 +49,7 @@ public final class ResourceMetricsStatelessMarshaler
         scopeMap,
         InstrumentationScopeMetricsStatelessMarshaler.INSTANCE,
         context,
-        SCOPE_SPAN_WRITER_KEY);
+        SCOPE_METRIC_WRITER_KEY);
 
     output.serializeStringWithContext(ResourceMetrics.SCHEMA_URL, resource.getSchemaUrl(), context);
   }
@@ -69,7 +72,7 @@ public final class ResourceMetricsStatelessMarshaler
             scopeMap,
             InstrumentationScopeMetricsStatelessMarshaler.INSTANCE,
             context,
-            SCOPE_SPAN_SIZE_CALCULATOR_KEY);
+            SCOPE_METRIC_SIZE_CALCULATOR_KEY);
 
     size +=
         StatelessMarshalerUtil.sizeStringWithContext(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ResourceMetricsStatelessMarshaler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.ResourceMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.ResourceMetrics;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Marshaler of ResourceMetrics. See {@link ResourceMetricsMarshaler}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class ResourceMetricsStatelessMarshaler
+    implements StatelessMarshaler2<Resource, Map<InstrumentationScopeInfo, List<MetricData>>> {
+  static final ResourceMetricsStatelessMarshaler INSTANCE = new ResourceMetricsStatelessMarshaler();
+  private static final MarshalerContext.Key SCOPE_SPAN_WRITER_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key SCOPE_SPAN_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(
+      Serializer output,
+      Resource resource,
+      Map<InstrumentationScopeInfo, List<MetricData>> scopeMap,
+      MarshalerContext context)
+      throws IOException {
+    ResourceMarshaler resourceMarshaler = context.getData(ResourceMarshaler.class);
+    output.serializeMessage(ResourceMetrics.RESOURCE, resourceMarshaler);
+
+    output.serializeRepeatedMessageWithContext(
+        ResourceMetrics.SCOPE_METRICS,
+        scopeMap,
+        InstrumentationScopeMetricsStatelessMarshaler.INSTANCE,
+        context,
+        SCOPE_SPAN_WRITER_KEY);
+
+    output.serializeStringWithContext(ResourceMetrics.SCHEMA_URL, resource.getSchemaUrl(), context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(
+      Resource resource,
+      Map<InstrumentationScopeInfo, List<MetricData>> scopeMap,
+      MarshalerContext context) {
+
+    int size = 0;
+
+    ResourceMarshaler resourceMarshaler = ResourceMarshaler.create(resource);
+    context.addData(resourceMarshaler);
+    size += MarshalerUtil.sizeMessage(ResourceMetrics.RESOURCE, resourceMarshaler);
+
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            ResourceMetrics.SCOPE_METRICS,
+            scopeMap,
+            InstrumentationScopeMetricsStatelessMarshaler.INSTANCE,
+            context,
+            SCOPE_SPAN_SIZE_CALCULATOR_KEY);
+
+    size +=
+        StatelessMarshalerUtil.sizeStringWithContext(
+            ResourceMetrics.SCHEMA_URL, resource.getSchemaUrl(), context);
+
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SumStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SumStatelessMarshaler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.Sum;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import java.io.IOException;
+
+/** See {@link SumMarshaler}. */
+final class SumStatelessMarshaler implements StatelessMarshaler<SumData<? extends PointData>> {
+  static final SumStatelessMarshaler INSTANCE = new SumStatelessMarshaler();
+  private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(Serializer output, SumData<? extends PointData> sum, MarshalerContext context)
+      throws IOException {
+    output.serializeRepeatedMessageWithContext(
+        Sum.DATA_POINTS,
+        sum.getPoints(),
+        NumberDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_WRITER_KEY);
+    output.serializeEnum(
+        Sum.AGGREGATION_TEMPORALITY,
+        MetricsMarshalerUtil.mapToTemporality(sum.getAggregationTemporality()));
+    output.serializeBool(Sum.IS_MONOTONIC, sum.isMonotonic());
+  }
+
+  @Override
+  public int getBinarySerializedSize(SumData<? extends PointData> sum, MarshalerContext context) {
+    int size = 0;
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            Sum.DATA_POINTS,
+            sum.getPoints(),
+            NumberDataPointStatelessMarshaler.INSTANCE,
+            context,
+            DATA_POINT_SIZE_CALCULATOR_KEY);
+    size +=
+        MarshalerUtil.sizeEnum(
+            Sum.AGGREGATION_TEMPORALITY,
+            MetricsMarshalerUtil.mapToTemporality(sum.getAggregationTemporality()));
+    size += MarshalerUtil.sizeBool(Sum.IS_MONOTONIC, sum.isMonotonic());
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.SummaryDataPoint;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import java.io.IOException;
+
+/** See {@link SummaryDataPointMarshaler}. */
+final class SummaryDataPointStatelessMarshaler implements StatelessMarshaler<SummaryPointData> {
+  static final SummaryDataPointStatelessMarshaler INSTANCE =
+      new SummaryDataPointStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, SummaryPointData point, MarshalerContext context)
+      throws IOException {
+    output.serializeFixed64(SummaryDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    output.serializeFixed64(SummaryDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    output.serializeFixed64(SummaryDataPoint.COUNT, point.getCount());
+    output.serializeDoubleOptional(SummaryDataPoint.SUM, point.getSum());
+    output.serializeRepeatedMessageWithContext(
+        SummaryDataPoint.QUANTILE_VALUES,
+        point.getValues(),
+        ValueAtQuantileStatelessMarshaler.INSTANCE,
+        context);
+    output.serializeRepeatedMessageWithContext(
+        SummaryDataPoint.ATTRIBUTES,
+        point.getAttributes(),
+        KeyValueStatelessMarshaler.INSTANCE,
+        context);
+  }
+
+  @Override
+  public int getBinarySerializedSize(SummaryPointData point, MarshalerContext context) {
+    int size = 0;
+    size +=
+        MarshalerUtil.sizeFixed64(
+            SummaryDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
+    size += MarshalerUtil.sizeFixed64(SummaryDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
+    size += MarshalerUtil.sizeFixed64(SummaryDataPoint.COUNT, point.getCount());
+    size += MarshalerUtil.sizeDoubleOptional(SummaryDataPoint.SUM, point.getSum());
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            SummaryDataPoint.QUANTILE_VALUES,
+            point.getValues(),
+            ValueAtQuantileStatelessMarshaler.INSTANCE,
+            context);
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            SummaryDataPoint.ATTRIBUTES,
+            point.getAttributes(),
+            KeyValueStatelessMarshaler.INSTANCE,
+            context);
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
@@ -20,13 +20,15 @@ final class SummaryDataPointStatelessMarshaler implements StatelessMarshaler<Sum
   static final SummaryDataPointStatelessMarshaler INSTANCE =
       new SummaryDataPointStatelessMarshaler();
 
+  private SummaryDataPointStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, SummaryPointData point, MarshalerContext context)
       throws IOException {
     output.serializeFixed64(SummaryDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
     output.serializeFixed64(SummaryDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
     output.serializeFixed64(SummaryDataPoint.COUNT, point.getCount());
-    output.serializeDoubleOptional(SummaryDataPoint.SUM, point.getSum());
+    output.serializeDouble(SummaryDataPoint.SUM, point.getSum());
     output.serializeRepeatedMessageWithContext(
         SummaryDataPoint.QUANTILE_VALUES,
         point.getValues(),
@@ -47,7 +49,7 @@ final class SummaryDataPointStatelessMarshaler implements StatelessMarshaler<Sum
             SummaryDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
     size += MarshalerUtil.sizeFixed64(SummaryDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
     size += MarshalerUtil.sizeFixed64(SummaryDataPoint.COUNT, point.getCount());
-    size += MarshalerUtil.sizeDoubleOptional(SummaryDataPoint.SUM, point.getSum());
+    size += MarshalerUtil.sizeDouble(SummaryDataPoint.SUM, point.getSum());
     size +=
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             SummaryDataPoint.QUANTILE_VALUES,

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryStatelessMarshaler.java
@@ -19,6 +19,8 @@ final class SummaryStatelessMarshaler implements StatelessMarshaler<SummaryData>
   private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
   private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
 
+  private SummaryStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, SummaryData summary, MarshalerContext context)
       throws IOException {
@@ -32,14 +34,11 @@ final class SummaryStatelessMarshaler implements StatelessMarshaler<SummaryData>
 
   @Override
   public int getBinarySerializedSize(SummaryData summary, MarshalerContext context) {
-    int size = 0;
-    size +=
-        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
-            Summary.DATA_POINTS,
-            summary.getPoints(),
-            SummaryDataPointStatelessMarshaler.INSTANCE,
-            context,
-            DATA_POINT_SIZE_CALCULATOR_KEY);
-    return size;
+    return StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+        Summary.DATA_POINTS,
+        summary.getPoints(),
+        SummaryDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_SIZE_CALCULATOR_KEY);
   }
 }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryStatelessMarshaler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
+import io.opentelemetry.proto.metrics.v1.internal.Summary;
+import io.opentelemetry.sdk.metrics.data.SummaryData;
+import java.io.IOException;
+
+/** See {@link SummaryMarshaler}. */
+final class SummaryStatelessMarshaler implements StatelessMarshaler<SummaryData> {
+  static final SummaryStatelessMarshaler INSTANCE = new SummaryStatelessMarshaler();
+  private static final MarshalerContext.Key DATA_POINT_SIZE_CALCULATOR_KEY = MarshalerContext.key();
+  private static final MarshalerContext.Key DATA_POINT_WRITER_KEY = MarshalerContext.key();
+
+  @Override
+  public void writeTo(Serializer output, SummaryData summary, MarshalerContext context)
+      throws IOException {
+    output.serializeRepeatedMessageWithContext(
+        Summary.DATA_POINTS,
+        summary.getPoints(),
+        SummaryDataPointStatelessMarshaler.INSTANCE,
+        context,
+        DATA_POINT_WRITER_KEY);
+  }
+
+  @Override
+  public int getBinarySerializedSize(SummaryData summary, MarshalerContext context) {
+    int size = 0;
+    size +=
+        StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
+            Summary.DATA_POINTS,
+            summary.getPoints(),
+            SummaryDataPointStatelessMarshaler.INSTANCE,
+            context,
+            DATA_POINT_SIZE_CALCULATOR_KEY);
+    return size;
+  }
+}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileMarshaler.java
@@ -42,7 +42,7 @@ final class ValueAtQuantileMarshaler extends MarshalerWithSize {
     output.serializeDouble(SummaryDataPoint.ValueAtQuantile.VALUE, value);
   }
 
-  private static int calculateSize(double quantile, double value) {
+  static int calculateSize(double quantile, double value) {
     int size = 0;
     size += MarshalerUtil.sizeDouble(SummaryDataPoint.ValueAtQuantile.QUANTILE, quantile);
     size += MarshalerUtil.sizeDouble(SummaryDataPoint.ValueAtQuantile.VALUE, value);

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileStatelessMarshaler.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 final class ValueAtQuantileStatelessMarshaler implements StatelessMarshaler<ValueAtQuantile> {
   static final ValueAtQuantileStatelessMarshaler INSTANCE = new ValueAtQuantileStatelessMarshaler();
 
+  private ValueAtQuantileStatelessMarshaler() {}
+
   @Override
   public void writeTo(Serializer output, ValueAtQuantile value, MarshalerContext context)
       throws IOException {

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ValueAtQuantileStatelessMarshaler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
+import io.opentelemetry.proto.metrics.v1.internal.SummaryDataPoint;
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
+import java.io.IOException;
+
+/** See {@link ValueAtQuantileMarshaler}. */
+final class ValueAtQuantileStatelessMarshaler implements StatelessMarshaler<ValueAtQuantile> {
+  static final ValueAtQuantileStatelessMarshaler INSTANCE = new ValueAtQuantileStatelessMarshaler();
+
+  @Override
+  public void writeTo(Serializer output, ValueAtQuantile value, MarshalerContext context)
+      throws IOException {
+    output.serializeDouble(SummaryDataPoint.ValueAtQuantile.QUANTILE, value.getQuantile());
+    output.serializeDouble(SummaryDataPoint.ValueAtQuantile.VALUE, value.getValue());
+  }
+
+  @Override
+  public int getBinarySerializedSize(ValueAtQuantile value, MarshalerContext context) {
+    return ValueAtQuantileMarshaler.calculateSize(value.getQuantile(), value.getValue());
+  }
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/LowAllocationMetricsRequestMarshalerTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.otlp.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
+import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
+import io.opentelemetry.exporter.internal.marshal.Serializer;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentSelector;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.data.ExemplarData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SummaryData;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class LowAllocationMetricsRequestMarshalerTest {
+
+  @ParameterizedTest
+  @ArgumentsSource(MetricsProvider.class)
+  void validateOutput(Collection<MetricData> metrics) throws Exception {
+    byte[] result;
+    {
+      MetricsRequestMarshaler requestMarshaler = MetricsRequestMarshaler.create(metrics);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeBinaryTo(customOutput);
+      result = customOutput.toByteArray();
+    }
+
+    byte[] lowAllocationResult;
+    {
+      LowAllocationMetricsRequestMarshaler requestMarshaler =
+          new LowAllocationMetricsRequestMarshaler();
+      requestMarshaler.initialize(metrics);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeBinaryTo(customOutput);
+      lowAllocationResult = customOutput.toByteArray();
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(MetricsProvider.class)
+  void validateJsonOutput(Collection<MetricData> metrics) throws Exception {
+    String result;
+    {
+      MetricsRequestMarshaler requestMarshaler = MetricsRequestMarshaler.create(metrics);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeJsonTo(customOutput);
+      result = new String(customOutput.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    String lowAllocationResult;
+    {
+      LowAllocationMetricsRequestMarshaler requestMarshaler =
+          new LowAllocationMetricsRequestMarshaler();
+      requestMarshaler.initialize(metrics);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(requestMarshaler.getBinarySerializedSize());
+      requestMarshaler.writeJsonTo(customOutput);
+      lowAllocationResult = new String(customOutput.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ExemplarProvider.class)
+  void validateExemplar(ExemplarData exemplar) throws Exception {
+    byte[] result;
+    {
+      Marshaler marshaler = ExemplarMarshaler.create(exemplar);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(marshaler.getBinarySerializedSize());
+      marshaler.writeBinaryTo(customOutput);
+      result = customOutput.toByteArray();
+    }
+
+    byte[] lowAllocationResult;
+    {
+      MarshalerContext context = new MarshalerContext();
+      class TestMarshaler extends MarshalerWithSize {
+
+        protected TestMarshaler() {
+          super(ExemplarStatelessMarshaler.INSTANCE.getBinarySerializedSize(exemplar, context));
+        }
+
+        @Override
+        protected void writeTo(Serializer output) throws IOException {
+          ExemplarStatelessMarshaler.INSTANCE.writeTo(output, exemplar, context);
+        }
+      }
+      Marshaler marshaler = new TestMarshaler();
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(marshaler.getBinarySerializedSize());
+      marshaler.writeBinaryTo(customOutput);
+      lowAllocationResult = customOutput.toByteArray();
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+
+  @Test
+  void validateSummary() throws Exception {
+    List<ValueAtQuantile> percentileValues =
+        Arrays.asList(ImmutableValueAtQuantile.create(3.0, 4.0));
+    List<SummaryPointData> points =
+        Arrays.asList(
+            ImmutableSummaryPointData.create(
+                12345, 12346, Attributes.empty(), 1, 2.0, percentileValues));
+    SummaryData summary = ImmutableSummaryData.create(points);
+
+    byte[] result;
+    {
+      Marshaler marshaler = SummaryMarshaler.create(summary);
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(marshaler.getBinarySerializedSize());
+      marshaler.writeBinaryTo(customOutput);
+      result = customOutput.toByteArray();
+    }
+
+    byte[] lowAllocationResult;
+    {
+      MarshalerContext context = new MarshalerContext();
+      class TestMarshaler extends MarshalerWithSize {
+
+        protected TestMarshaler() {
+          super(SummaryStatelessMarshaler.INSTANCE.getBinarySerializedSize(summary, context));
+        }
+
+        @Override
+        protected void writeTo(Serializer output) throws IOException {
+          SummaryStatelessMarshaler.INSTANCE.writeTo(output, summary, context);
+        }
+      }
+      Marshaler marshaler = new TestMarshaler();
+      ByteArrayOutputStream customOutput =
+          new ByteArrayOutputStream(marshaler.getBinarySerializedSize());
+      marshaler.writeBinaryTo(customOutput);
+      lowAllocationResult = customOutput.toByteArray();
+    }
+
+    assertThat(lowAllocationResult).isEqualTo(result);
+  }
+
+  private static Collection<MetricData> metrics(Consumer<MeterProvider> metricProducer) {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder()
+            .registerMetricReader(metricReader)
+            .registerView(
+                InstrumentSelector.builder().setName("exponentialhistogram").build(),
+                View.builder()
+                    .setAggregation(Aggregation.base2ExponentialBucketHistogram())
+                    .build())
+            .setResource(
+                Resource.create(
+                    Attributes.builder()
+                        .put(AttributeKey.booleanKey("key_bool"), true)
+                        .put(AttributeKey.stringKey("key_string"), "string")
+                        .put(AttributeKey.longKey("key_int"), 100L)
+                        .put(AttributeKey.doubleKey("key_double"), 100.3)
+                        .put(
+                            AttributeKey.stringArrayKey("key_string_array"),
+                            Arrays.asList("string", "string"))
+                        .put(AttributeKey.longArrayKey("key_long_array"), Arrays.asList(12L, 23L))
+                        .put(
+                            AttributeKey.doubleArrayKey("key_double_array"),
+                            Arrays.asList(12.3, 23.1))
+                        .put(
+                            AttributeKey.booleanArrayKey("key_boolean_array"),
+                            Arrays.asList(true, false))
+                        .build()))
+            .build();
+    metricProducer.accept(meterProvider);
+
+    return metricReader.collectAllMetrics();
+  }
+
+  private static class MetricsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          arguments(
+              named(
+                  "long gauge",
+                  metrics(
+                      meterProvider ->
+                          meterProvider
+                              .get("long gauge")
+                              .gaugeBuilder("gauge")
+                              .setDescription("gauge description")
+                              .setUnit("unit")
+                              .ofLongs()
+                              .buildWithCallback(
+                                  measurement ->
+                                      measurement.record(
+                                          5,
+                                          Attributes.of(
+                                              AttributeKey.stringKey("key"), "value")))))),
+          arguments(
+              named(
+                  "long counter",
+                  metrics(
+                      meterProvider -> {
+                        LongCounter longCounter =
+                            meterProvider
+                                .get("long counter")
+                                .counterBuilder("counter")
+                                .setDescription("counter description")
+                                .setUnit("unit")
+                                .build();
+                        longCounter.add(1);
+                        longCounter.add(2, Attributes.of(AttributeKey.longKey("lives"), 9L));
+                        longCounter.add(3);
+                      }))),
+          arguments(
+              named(
+                  "long updowncounter",
+                  metrics(
+                      meterProvider -> {
+                        LongUpDownCounter longUpDownCounter =
+                            meterProvider
+                                .get("long updowncounter")
+                                .upDownCounterBuilder("updowncounter")
+                                .setDescription("updowncounter description")
+                                .setUnit("unit")
+                                .build();
+                        longUpDownCounter.add(1);
+                        longUpDownCounter.add(
+                            -1, Attributes.of(AttributeKey.booleanKey("on"), true));
+                        longUpDownCounter.add(1);
+                      }))),
+          arguments(
+              named(
+                  "double gauge",
+                  metrics(
+                      meterProvider ->
+                          meterProvider
+                              .get("double gauge")
+                              .gaugeBuilder("doublegauge")
+                              .setDescription("doublegauge")
+                              .setUnit("unit")
+                              .buildWithCallback(measurement -> measurement.record(5.0))))),
+          arguments(
+              named(
+                  "double counter",
+                  metrics(
+                      meterProvider -> {
+                        DoubleCounter doubleCounter =
+                            meterProvider
+                                .get("double counter")
+                                .counterBuilder("doublecounter")
+                                .ofDoubles()
+                                .build();
+                        doubleCounter.add(1.0);
+                        doubleCounter.add(2.0);
+                      }))),
+          arguments(
+              named(
+                  "double updowncounter",
+                  metrics(
+                      meterProvider -> {
+                        DoubleUpDownCounter doubleUpDownCounter =
+                            meterProvider
+                                .get("double updowncounter")
+                                .upDownCounterBuilder("doubleupdown")
+                                .ofDoubles()
+                                .build();
+                        doubleUpDownCounter.add(1.0);
+                        doubleUpDownCounter.add(-1.0);
+                      }))),
+          arguments(
+              named(
+                  "double histogram",
+                  metrics(
+                      meterProvider -> {
+                        DoubleHistogram histogram =
+                            meterProvider
+                                .get("double histogram")
+                                .histogramBuilder("histogram")
+                                .build();
+                        histogram.record(1.0);
+                        histogram.record(2.0);
+                        histogram.record(3.0);
+                        histogram.record(4.0);
+                        histogram.record(5.0);
+                      }))),
+          arguments(
+              named(
+                  "long histogram",
+                  metrics(
+                      meterProvider -> {
+                        LongHistogram histogram =
+                            meterProvider
+                                .get("long histogram")
+                                .histogramBuilder("histogram")
+                                .ofLongs()
+                                .build();
+                        histogram.record(1);
+                        histogram.record(2);
+                        histogram.record(3);
+                        histogram.record(4);
+                        histogram.record(5);
+                      }))),
+          arguments(
+              named(
+                  "double exponential histogram",
+                  metrics(
+                      meterProvider -> {
+                        DoubleHistogram histogram =
+                            meterProvider
+                                .get("double exponential histogram")
+                                .histogramBuilder("exponentialhistogram")
+                                .build();
+                        histogram.record(1.0);
+                        histogram.record(2.0);
+                        histogram.record(3.0);
+                        histogram.record(4.0);
+                        histogram.record(5.0);
+                      }))),
+          arguments(
+              named(
+                  "long exponential histogram",
+                  metrics(
+                      meterProvider -> {
+                        DoubleHistogram histogram =
+                            meterProvider
+                                .get("long exponential histogram")
+                                .histogramBuilder("exponentialhistogram")
+                                .build();
+                        histogram.record(1);
+                        histogram.record(2);
+                        histogram.record(3);
+                        histogram.record(4);
+                        histogram.record(5);
+                      }))));
+    }
+  }
+
+  private static class ExemplarProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      SpanContext spanContext =
+          SpanContext.create(
+              "7b2e170db4df2d593ddb4ddf2ddf2d59",
+              "170d3ddb4d23e81f",
+              TraceFlags.getSampled(),
+              TraceState.getDefault());
+
+      return Stream.of(
+          arguments(
+              named(
+                  "double exemplar",
+                  ImmutableDoubleExemplarData.create(Attributes.empty(), 12345, spanContext, 5.0))),
+          arguments(
+              named(
+                  "long exemplar",
+                  ImmutableLongExemplarData.create(Attributes.empty(), 12345, spanContext, 5))));
+    }
+  }
+}

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/traces/TraceRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/traces/TraceRequestMarshalerTest.java
@@ -536,7 +536,7 @@ class TraceRequestMarshalerTest {
   }
 
   private enum MarshalerSource {
-    MARSHALER {
+    STATEFUL_MARSHALER {
       @Override
       Marshaler create(SpanData spanData) {
         return SpanMarshaler.create(spanData);
@@ -557,7 +557,7 @@ class TraceRequestMarshalerTest {
         return SpanLinkMarshaler.create(linkData);
       }
     },
-    LOW_ALLOCATION_MARSHALER {
+    STATELESS_MARSHALER {
       @Override
       Marshaler create(SpanData spanData) {
         return createMarshaler(SpanStatelessMarshaler.INSTANCE, spanData);


### PR DESCRIPTION
Continuation of https://github.com/open-telemetry/opentelemetry-java/pull/6410
```
Benchmark                                                                 Mode  Cnt     Score    Error   Units
MetricsRequestMarshalerBenchmark.marshalStateful                          avgt   10     1.013 ±  0.021   us/op
MetricsRequestMarshalerBenchmark.marshalStateful:gc.alloc.rate            avgt   10  3080.843 ± 62.442  MB/sec
MetricsRequestMarshalerBenchmark.marshalStateful:gc.alloc.rate.norm       avgt   10  3272.006 ±  0.001    B/op
MetricsRequestMarshalerBenchmark.marshalStateful:gc.count                 avgt   10    92.000           counts
MetricsRequestMarshalerBenchmark.marshalStateful:gc.time                  avgt   10    32.000               ms
MetricsRequestMarshalerBenchmark.marshalStatefulJson                      avgt   10     5.096 ±  0.079   us/op
MetricsRequestMarshalerBenchmark.marshalStatefulJson:gc.alloc.rate        avgt   10  1489.729 ± 23.126  MB/sec
MetricsRequestMarshalerBenchmark.marshalStatefulJson:gc.alloc.rate.norm   avgt   10  7960.030 ±  0.001    B/op
MetricsRequestMarshalerBenchmark.marshalStatefulJson:gc.count             avgt   10    45.000           counts
MetricsRequestMarshalerBenchmark.marshalStatefulJson:gc.time              avgt   10    17.000               ms
MetricsRequestMarshalerBenchmark.marshalStateless                         avgt   10     1.206 ±  0.016   us/op
MetricsRequestMarshalerBenchmark.marshalStateless:gc.alloc.rate           avgt   10    18.991 ±  0.248  MB/sec
MetricsRequestMarshalerBenchmark.marshalStateless:gc.alloc.rate.norm      avgt   10    24.007 ±  0.001    B/op
MetricsRequestMarshalerBenchmark.marshalStateless:gc.count                avgt   10       ≈ 0           counts
MetricsRequestMarshalerBenchmark.marshalStatelessJson                     avgt   10     4.292 ±  0.041   us/op
MetricsRequestMarshalerBenchmark.marshalStatelessJson:gc.alloc.rate       avgt   10   847.853 ±  8.212  MB/sec
MetricsRequestMarshalerBenchmark.marshalStatelessJson:gc.alloc.rate.norm  avgt   10  3816.025 ±  0.001    B/op
MetricsRequestMarshalerBenchmark.marshalStatelessJson:gc.count            avgt   10    25.000           counts
MetricsRequestMarshalerBenchmark.marshalStatelessJson:gc.time             avgt   10    11.000               ms
```