### PR TITLE
Add memory mode support to OTLP exporters

### DIFF
--- a/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
+++ b/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.exporter.sender.grpc.managedchannel.internal.UpstreamGrpcSender;
 import io.opentelemetry.exporter.sender.okhttp.internal.OkHttpGrpcSender;
@@ -67,7 +68,7 @@ public class OltpExporterBenchmark {
 
   private static ManagedChannel defaultGrpcChannel;
 
-  private static GrpcExporter<TraceRequestMarshaler> upstreamGrpcExporter;
+  private static GrpcExporter<Marshaler> upstreamGrpcExporter;
   private static GrpcExporter<TraceRequestMarshaler> okhttpGrpcSender;
   private static HttpExporter<TraceRequestMarshaler> httpExporter;
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -13,7 +13,7 @@ import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.export.ProxyOptions;
@@ -42,7 +42,7 @@ public final class OtlpHttpMetricExporterBuilder {
       AggregationTemporalitySelector.alwaysCumulative();
   private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.IMMUTABLE_DATA;
 
-  private final HttpExporterBuilder<MetricsRequestMarshaler> delegate;
+  private final HttpExporterBuilder<Marshaler> delegate;
   private AggregationTemporalitySelector aggregationTemporalitySelector =
       DEFAULT_AGGREGATION_TEMPORALITY_SELECTOR;
 
@@ -50,8 +50,7 @@ public final class OtlpHttpMetricExporterBuilder {
       DefaultAggregationSelector.getDefault();
   private MemoryMode memoryMode;
 
-  OtlpHttpMetricExporterBuilder(
-      HttpExporterBuilder<MetricsRequestMarshaler> delegate, MemoryMode memoryMode) {
+  OtlpHttpMetricExporterBuilder(HttpExporterBuilder<Marshaler> delegate, MemoryMode memoryMode) {
     this.delegate = delegate;
     this.memoryMode = memoryMode;
     delegate.setMeterProvider(MeterProvider::noop);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporter.java
@@ -7,11 +7,17 @@ package io.opentelemetry.exporter.otlp.http.trace;
 
 import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.traces.LowAllocationTraceRequestMarshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
+import java.util.StringJoiner;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -22,14 +28,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpHttpSpanExporter implements SpanExporter {
 
-  private final HttpExporterBuilder<TraceRequestMarshaler> builder;
-  private final HttpExporter<TraceRequestMarshaler> delegate;
+  private final Deque<LowAllocationTraceRequestMarshaler> marshalerPool = new ArrayDeque<>();
+  private final HttpExporterBuilder<Marshaler> builder;
+  private final HttpExporter<Marshaler> delegate;
+  private final MemoryMode memoryMode;
 
   OtlpHttpSpanExporter(
-      HttpExporterBuilder<TraceRequestMarshaler> builder,
-      HttpExporter<TraceRequestMarshaler> delegate) {
+      HttpExporterBuilder<Marshaler> builder,
+      HttpExporter<Marshaler> delegate,
+      MemoryMode memoryMode) {
     this.builder = builder;
     this.delegate = delegate;
+    this.memoryMode = memoryMode;
   }
 
   /**
@@ -61,7 +71,7 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
    * @since 1.29.0
    */
   public OtlpHttpSpanExporterBuilder toBuilder() {
-    return new OtlpHttpSpanExporterBuilder(builder.copy());
+    return new OtlpHttpSpanExporterBuilder(builder.copy(), memoryMode);
   }
 
   /**
@@ -72,8 +82,24 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
    */
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
-    TraceRequestMarshaler exportRequest = TraceRequestMarshaler.create(spans);
-    return delegate.export(exportRequest, spans.size());
+    if (memoryMode == MemoryMode.REUSABLE_DATA) {
+      LowAllocationTraceRequestMarshaler marshaler = marshalerPool.poll();
+      if (marshaler == null) {
+        marshaler = new LowAllocationTraceRequestMarshaler();
+      }
+      LowAllocationTraceRequestMarshaler exportMarshaler = marshaler;
+      exportMarshaler.initialize(spans);
+      return delegate
+          .export(exportMarshaler, spans.size())
+          .whenComplete(
+              () -> {
+                exportMarshaler.reset();
+                marshalerPool.add(exportMarshaler);
+              });
+    }
+    // MemoryMode == MemoryMode.IMMUTABLE_DATA
+    TraceRequestMarshaler request = TraceRequestMarshaler.create(spans);
+    return delegate.export(request, spans.size());
   }
 
   /**
@@ -94,6 +120,9 @@ public final class OtlpHttpSpanExporter implements SpanExporter {
 
   @Override
   public String toString() {
-    return "OtlpHttpSpanExporter{" + builder.toString(false) + "}";
+    StringJoiner joiner = new StringJoiner(", ", "OtlpHttpSpanExporter{", "}");
+    joiner.add(builder.toString(false));
+    joiner.add("memoryMode=" + memoryMode);
+    return joiner.toString();
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -14,8 +14,9 @@ import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
-import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.time.Duration;
@@ -33,16 +34,19 @@ import javax.net.ssl.X509TrustManager;
 public final class OtlpHttpSpanExporterBuilder {
 
   private static final String DEFAULT_ENDPOINT = "http://localhost:4318/v1/traces";
+  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.IMMUTABLE_DATA;
 
-  private final HttpExporterBuilder<TraceRequestMarshaler> delegate;
+  private final HttpExporterBuilder<Marshaler> delegate;
+  private MemoryMode memoryMode;
 
-  OtlpHttpSpanExporterBuilder(HttpExporterBuilder<TraceRequestMarshaler> delegate) {
+  OtlpHttpSpanExporterBuilder(HttpExporterBuilder<Marshaler> delegate, MemoryMode memoryMode) {
     this.delegate = delegate;
+    this.memoryMode = memoryMode;
     OtlpUserAgent.addUserAgentHeader(delegate::addConstantHeaders);
   }
 
   OtlpHttpSpanExporterBuilder() {
-    this(new HttpExporterBuilder<>("otlp", "span", DEFAULT_ENDPOINT));
+    this(new HttpExporterBuilder<>("otlp", "span", DEFAULT_ENDPOINT), DEFAULT_MEMORY_MODE);
   }
 
   /**
@@ -207,12 +211,19 @@ public final class OtlpHttpSpanExporterBuilder {
     return this;
   }
 
+  /** Set the {@link MemoryMode}. */
+  OtlpHttpSpanExporterBuilder setMemoryMode(MemoryMode memoryMode) {
+    requireNonNull(memoryMode, "memoryMode");
+    this.memoryMode = memoryMode;
+    return this;
+  }
+
   /**
    * Constructs a new instance of the exporter based on the builder's values.
    *
    * @return a new exporter's instance
    */
   public OtlpHttpSpanExporter build() {
-    return new OtlpHttpSpanExporter(delegate, delegate.build());
+    return new OtlpHttpSpanExporter(delegate, delegate.build(), memoryMode);
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -8,7 +8,9 @@ package io.opentelemetry.exporter.otlp.internal;
 import static io.opentelemetry.sdk.metrics.Aggregation.explicitBucketHistogram;
 
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.common.export.MemoryMode;
@@ -212,12 +214,12 @@ public final class OtlpConfigUtil {
   }
 
   /**
-   * Calls {@code #setMemoryMode} on the {@code Otlp{Protocol}MetricExporterBuilder} with the {@code
-   * memoryMode}.
+   * Calls {@code #setMemoryMode} on the {@code Otlp{Protocol}{Signal}ExporterBuilder} with the
+   * {@code memoryMode}.
    */
-  public static void setMemoryModeOnOtlpMetricExporterBuilder(
-      Object builder, MemoryMode memoryMode) {
+  public static void setMemoryModeOnOtlpExporterBuilder(Object builder, MemoryMode memoryMode) {
     try {
+      // Metrics
       if (builder instanceof OtlpGrpcMetricExporterBuilder) {
         // Calling getDeclaredMethod causes all private methods to be read, which causes a
         // ClassNotFoundException when running with the OkHttHttpProvider as the private
@@ -237,9 +239,27 @@ public final class OtlpConfigUtil {
                 "setMemoryMode", MemoryMode.class);
         method.setAccessible(true);
         method.invoke(builder, memoryMode);
+      } else if (builder instanceof OtlpGrpcSpanExporterBuilder) {
+        // Calling getDeclaredMethod causes all private methods to be read, which causes a
+        // ClassNotFoundException when running with the OkHttHttpProvider as the private
+        // setManagedChanel(io.grpc.ManagedChannel) is reached and io.grpc.ManagedChannel is not on
+        // the classpath. io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanUtil provides a layer
+        // of indirection which avoids scanning the OtlpGrpcSpanExporterBuilder private methods.
+        Class<?> otlpGrpcMetricUtil =
+            Class.forName("io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanUtil");
+        Method method =
+            otlpGrpcMetricUtil.getDeclaredMethod(
+                "setMemoryMode", OtlpGrpcSpanExporterBuilder.class, MemoryMode.class);
+        method.setAccessible(true);
+        method.invoke(null, builder, memoryMode);
+      } else if (builder instanceof OtlpHttpSpanExporterBuilder) {
+        Method method =
+            OtlpHttpSpanExporterBuilder.class.getDeclaredMethod("setMemoryMode", MemoryMode.class);
+        method.setAccessible(true);
+        method.invoke(builder, memoryMode);
       } else {
         throw new IllegalArgumentException(
-            "Can only set memory mode on OtlpHttpMetricExporterBuilder and OtlpGrpcMetricExporterBuilder.");
+            "Cannot set memory mode. Unrecognized OTLP exporter builder");
       }
     } catch (NoSuchMethodException
         | InvocationTargetException

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_GR
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
@@ -53,6 +54,9 @@ public class OtlpLogRecordExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
+      ExporterBuilderUtil.configureExporterMemoryMode(
+          config,
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
 
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
@@ -69,6 +73,9 @@ public class OtlpLogRecordExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
+      ExporterBuilderUtil.configureExporterMemoryMode(
+          config,
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
 
       return builder.build();
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
@@ -51,8 +51,7 @@ public class OtlpMetricExporterProvider implements ConfigurableMetricExporterPro
           config, builder::setDefaultAggregationSelector);
       ExporterBuilderUtil.configureExporterMemoryMode(
           config,
-          memoryMode ->
-              OtlpConfigUtil.setMemoryModeOnOtlpMetricExporterBuilder(builder, memoryMode));
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
 
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
@@ -74,8 +73,7 @@ public class OtlpMetricExporterProvider implements ConfigurableMetricExporterPro
           config, builder::setDefaultAggregationSelector);
       ExporterBuilderUtil.configureExporterMemoryMode(
           config,
-          memoryMode ->
-              OtlpConfigUtil.setMemoryModeOnOtlpMetricExporterBuilder(builder, memoryMode));
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
 
       return builder.build();
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_GR
 import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF;
 
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.exporter.internal.ExporterBuilderUtil;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
@@ -52,7 +53,9 @@ public class OtlpSpanExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
-
+      ExporterBuilderUtil.configureExporterMemoryMode(
+          config,
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
       return builder.build();
     } else if (protocol.equals(PROTOCOL_GRPC)) {
       OtlpGrpcSpanExporterBuilder builder = grpcBuilder();
@@ -68,6 +71,9 @@ public class OtlpSpanExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy);
       builder.setMeterProvider(meterProviderRef::get);
+      ExporterBuilderUtil.configureExporterMemoryMode(
+          config,
+          memoryMode -> OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode));
 
       return builder.build();
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/MarshalerLogsServiceGrpc.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/MarshalerLogsServiceGrpc.java
@@ -14,7 +14,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.stub.ClientCalls;
 import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
-import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 
@@ -23,15 +23,15 @@ final class MarshalerLogsServiceGrpc {
 
   private static final String SERVICE_NAME = "opentelemetry.proto.collector.logs.v1.LogsService";
 
-  private static final MethodDescriptor.Marshaller<LogsRequestMarshaler> REQUEST_MARSHALLER =
-      new MethodDescriptor.Marshaller<LogsRequestMarshaler>() {
+  private static final MethodDescriptor.Marshaller<Marshaler> REQUEST_MARSHALLER =
+      new MethodDescriptor.Marshaller<Marshaler>() {
         @Override
-        public InputStream stream(LogsRequestMarshaler value) {
+        public InputStream stream(Marshaler value) {
           return new MarshalerInputStream(value);
         }
 
         @Override
-        public LogsRequestMarshaler parse(InputStream stream) {
+        public Marshaler parse(InputStream stream) {
           throw new UnsupportedOperationException("Only for serializing");
         }
       };
@@ -49,14 +49,13 @@ final class MarshalerLogsServiceGrpc {
         }
       };
 
-  private static final MethodDescriptor<LogsRequestMarshaler, ExportLogsServiceResponse>
-      getExportMethod =
-          MethodDescriptor.<LogsRequestMarshaler, ExportLogsServiceResponse>newBuilder()
-              .setType(MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
-              .setRequestMarshaller(REQUEST_MARSHALLER)
-              .setResponseMarshaller(RESPONSE_MARSHALER)
-              .build();
+  private static final MethodDescriptor<Marshaler, ExportLogsServiceResponse> getExportMethod =
+      MethodDescriptor.<Marshaler, ExportLogsServiceResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
+          .setRequestMarshaller(REQUEST_MARSHALLER)
+          .setResponseMarshaller(RESPONSE_MARSHALER)
+          .build();
 
   static LogsServiceFutureStub newFutureStub(Channel channel, @Nullable String authorityOverride) {
     return LogsServiceFutureStub.newStub(
@@ -65,8 +64,7 @@ final class MarshalerLogsServiceGrpc {
   }
 
   static final class LogsServiceFutureStub
-      extends MarshalerServiceStub<
-          LogsRequestMarshaler, ExportLogsServiceResponse, LogsServiceFutureStub> {
+      extends MarshalerServiceStub<Marshaler, ExportLogsServiceResponse, LogsServiceFutureStub> {
     private LogsServiceFutureStub(Channel channel, CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -78,7 +76,7 @@ final class MarshalerLogsServiceGrpc {
     }
 
     @Override
-    public ListenableFuture<ExportLogsServiceResponse> export(LogsRequestMarshaler request) {
+    public ListenableFuture<ExportLogsServiceResponse> export(Marshaler request) {
       return ClientCalls.futureUnaryCall(
           getChannel().newCall(getExportMethod, getCallOptions()), request);
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogUtil.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.logs;
+
+import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+
+final class OtlpGrpcLogUtil {
+
+  private OtlpGrpcLogUtil() {}
+
+  /** See {@link OtlpConfigUtil#setMemoryModeOnOtlpExporterBuilder(Object, MemoryMode)}. */
+  static void setMemoryMode(OtlpGrpcLogRecordExporterBuilder builder, MemoryMode memoryMode) {
+    builder.setMemoryMode(memoryMode);
+  }
+}

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/MarshalerMetricsServiceGrpc.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/MarshalerMetricsServiceGrpc.java
@@ -14,7 +14,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.stub.ClientCalls;
 import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 
@@ -24,15 +24,15 @@ final class MarshalerMetricsServiceGrpc {
   private static final String SERVICE_NAME =
       "opentelemetry.proto.collector.metrics.v1.MetricsService";
 
-  private static final MethodDescriptor.Marshaller<MetricsRequestMarshaler> REQUEST_MARSHALLER =
-      new MethodDescriptor.Marshaller<MetricsRequestMarshaler>() {
+  private static final MethodDescriptor.Marshaller<Marshaler> REQUEST_MARSHALLER =
+      new MethodDescriptor.Marshaller<Marshaler>() {
         @Override
-        public InputStream stream(MetricsRequestMarshaler value) {
+        public InputStream stream(Marshaler value) {
           return new MarshalerInputStream(value);
         }
 
         @Override
-        public MetricsRequestMarshaler parse(InputStream stream) {
+        public Marshaler parse(InputStream stream) {
           throw new UnsupportedOperationException("Only for serializing");
         }
       };
@@ -51,14 +51,13 @@ final class MarshalerMetricsServiceGrpc {
             }
           };
 
-  private static final MethodDescriptor<MetricsRequestMarshaler, ExportMetricsServiceResponse>
-      getExportMethod =
-          MethodDescriptor.<MetricsRequestMarshaler, ExportMetricsServiceResponse>newBuilder()
-              .setType(MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
-              .setRequestMarshaller(REQUEST_MARSHALLER)
-              .setResponseMarshaller(RESPONSE_MARSHALER)
-              .build();
+  private static final MethodDescriptor<Marshaler, ExportMetricsServiceResponse> getExportMethod =
+      MethodDescriptor.<Marshaler, ExportMetricsServiceResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
+          .setRequestMarshaller(REQUEST_MARSHALLER)
+          .setResponseMarshaller(RESPONSE_MARSHALER)
+          .build();
 
   static MetricsServiceFutureStub newFutureStub(
       Channel channel, @Nullable String authorityOverride) {
@@ -69,7 +68,7 @@ final class MarshalerMetricsServiceGrpc {
 
   static final class MetricsServiceFutureStub
       extends MarshalerServiceStub<
-          MetricsRequestMarshaler, ExportMetricsServiceResponse, MetricsServiceFutureStub> {
+          Marshaler, ExportMetricsServiceResponse, MetricsServiceFutureStub> {
     private MetricsServiceFutureStub(Channel channel, CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -81,7 +80,7 @@ final class MarshalerMetricsServiceGrpc {
     }
 
     @Override
-    public ListenableFuture<ExportMetricsServiceResponse> export(MetricsRequestMarshaler request) {
+    public ListenableFuture<ExportMetricsServiceResponse> export(Marshaler request) {
       return ClientCalls.futureUnaryCall(
           getChannel().newCall(getExportMethod, getCallOptions()), request);
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporter.java
@@ -7,6 +7,8 @@ package io.opentelemetry.exporter.otlp.metrics;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.metrics.LowAllocationMetricsRequestMarshaler;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
@@ -17,7 +19,9 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.StringJoiner;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -29,8 +33,9 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class OtlpGrpcMetricExporter implements MetricExporter {
 
-  private final GrpcExporterBuilder<MetricsRequestMarshaler> builder;
-  private final GrpcExporter<MetricsRequestMarshaler> delegate;
+  private final Deque<LowAllocationMetricsRequestMarshaler> marshalerPool = new ArrayDeque<>();
+  private final GrpcExporterBuilder<Marshaler> builder;
+  private final GrpcExporter<Marshaler> delegate;
   private final AggregationTemporalitySelector aggregationTemporalitySelector;
   private final DefaultAggregationSelector defaultAggregationSelector;
   private final MemoryMode memoryMode;
@@ -57,8 +62,8 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
   }
 
   OtlpGrpcMetricExporter(
-      GrpcExporterBuilder<MetricsRequestMarshaler> builder,
-      GrpcExporter<MetricsRequestMarshaler> delegate,
+      GrpcExporterBuilder<Marshaler> builder,
+      GrpcExporter<Marshaler> delegate,
       AggregationTemporalitySelector aggregationTemporalitySelector,
       DefaultAggregationSelector defaultAggregationSelector,
       MemoryMode memoryMode) {
@@ -103,8 +108,23 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
    */
   @Override
   public CompletableResultCode export(Collection<MetricData> metrics) {
+    if (memoryMode == MemoryMode.REUSABLE_DATA) {
+      LowAllocationMetricsRequestMarshaler marshaler = marshalerPool.poll();
+      if (marshaler == null) {
+        marshaler = new LowAllocationMetricsRequestMarshaler();
+      }
+      LowAllocationMetricsRequestMarshaler exportMarshaler = marshaler;
+      exportMarshaler.initialize(metrics);
+      return delegate
+          .export(exportMarshaler, metrics.size())
+          .whenComplete(
+              () -> {
+                exportMarshaler.reset();
+                marshalerPool.add(exportMarshaler);
+              });
+    }
+    // MemoryMode == MemoryMode.IMMUTABLE_DATA
     MetricsRequestMarshaler request = MetricsRequestMarshaler.create(metrics);
-
     return delegate.export(request, metrics.size());
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -14,7 +14,7 @@ import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.compression.CompressorProvider;
 import io.opentelemetry.exporter.internal.compression.CompressorUtil;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.otlp.internal.OtlpUserAgent;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
@@ -50,7 +50,7 @@ public final class OtlpGrpcMetricExporterBuilder {
   private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.IMMUTABLE_DATA;
 
   // Visible for testing
-  final GrpcExporterBuilder<MetricsRequestMarshaler> delegate;
+  final GrpcExporterBuilder<Marshaler> delegate;
 
   private AggregationTemporalitySelector aggregationTemporalitySelector =
       DEFAULT_AGGREGATION_TEMPORALITY_SELECTOR;
@@ -59,8 +59,7 @@ public final class OtlpGrpcMetricExporterBuilder {
       DefaultAggregationSelector.getDefault();
   private MemoryMode memoryMode;
 
-  OtlpGrpcMetricExporterBuilder(
-      GrpcExporterBuilder<MetricsRequestMarshaler> delegate, MemoryMode memoryMode) {
+  OtlpGrpcMetricExporterBuilder(GrpcExporterBuilder<Marshaler> delegate, MemoryMode memoryMode) {
     this.delegate = delegate;
     this.memoryMode = memoryMode;
     delegate.setMeterProvider(MeterProvider::noop);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/MarshalerTraceServiceGrpc.java
@@ -10,7 +10,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 import io.grpc.MethodDescriptor;
 import io.opentelemetry.exporter.internal.grpc.MarshalerInputStream;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
-import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 
@@ -19,15 +19,15 @@ final class MarshalerTraceServiceGrpc {
 
   private static final String SERVICE_NAME = "opentelemetry.proto.collector.trace.v1.TraceService";
 
-  private static final MethodDescriptor.Marshaller<TraceRequestMarshaler> REQUEST_MARSHALLER =
-      new MethodDescriptor.Marshaller<TraceRequestMarshaler>() {
+  private static final MethodDescriptor.Marshaller<Marshaler> REQUEST_MARSHALLER =
+      new MethodDescriptor.Marshaller<Marshaler>() {
         @Override
-        public InputStream stream(TraceRequestMarshaler value) {
+        public InputStream stream(Marshaler value) {
           return new MarshalerInputStream(value);
         }
 
         @Override
-        public TraceRequestMarshaler parse(InputStream stream) {
+        public Marshaler parse(InputStream stream) {
           throw new UnsupportedOperationException("Only for serializing");
         }
       };
@@ -45,9 +45,9 @@ final class MarshalerTraceServiceGrpc {
         }
       };
 
-  private static final io.grpc.MethodDescriptor<TraceRequestMarshaler, ExportTraceServiceResponse>
+  private static final io.grpc.MethodDescriptor<Marshaler, ExportTraceServiceResponse>
       getExportMethod =
-          io.grpc.MethodDescriptor.<TraceRequestMarshaler, ExportTraceServiceResponse>newBuilder()
+          io.grpc.MethodDescriptor.<Marshaler, ExportTraceServiceResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Export"))
               .setRequestMarshaller(REQUEST_MARSHALLER)
@@ -62,8 +62,7 @@ final class MarshalerTraceServiceGrpc {
   }
 
   static final class TraceServiceFutureStub
-      extends MarshalerServiceStub<
-          TraceRequestMarshaler, ExportTraceServiceResponse, TraceServiceFutureStub> {
+      extends MarshalerServiceStub<Marshaler, ExportTraceServiceResponse, TraceServiceFutureStub> {
     private TraceServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -76,7 +75,7 @@ final class MarshalerTraceServiceGrpc {
 
     @Override
     public com.google.common.util.concurrent.ListenableFuture<ExportTraceServiceResponse> export(
-        TraceRequestMarshaler request) {
+        Marshaler request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getExportMethod, getCallOptions()), request);
     }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporter.java
@@ -7,19 +7,27 @@ package io.opentelemetry.exporter.otlp.trace;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.grpc.GrpcExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.exporter.internal.otlp.traces.LowAllocationTraceRequestMarshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
+import java.util.StringJoiner;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** Exports spans using OTLP via gRPC, using OpenTelemetry's protobuf model. */
 @ThreadSafe
 public final class OtlpGrpcSpanExporter implements SpanExporter {
 
-  private final GrpcExporterBuilder<TraceRequestMarshaler> builder;
-  private final GrpcExporter<TraceRequestMarshaler> delegate;
+  private final Deque<LowAllocationTraceRequestMarshaler> marshalerPool = new ArrayDeque<>();
+  private final GrpcExporterBuilder<Marshaler> builder;
+  private final GrpcExporter<Marshaler> delegate;
+  private final MemoryMode memoryMode;
 
   /**
    * Returns a new {@link OtlpGrpcSpanExporter} using the default values.
@@ -43,10 +51,12 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
   }
 
   OtlpGrpcSpanExporter(
-      GrpcExporterBuilder<TraceRequestMarshaler> builder,
-      GrpcExporter<TraceRequestMarshaler> delegate) {
+      GrpcExporterBuilder<Marshaler> builder,
+      GrpcExporter<Marshaler> delegate,
+      MemoryMode memoryMode) {
     this.builder = builder;
     this.delegate = delegate;
+    this.memoryMode = memoryMode;
   }
 
   /**
@@ -57,7 +67,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    * @since 1.29.0
    */
   public OtlpGrpcSpanExporterBuilder toBuilder() {
-    return new OtlpGrpcSpanExporterBuilder(builder.copy());
+    return new OtlpGrpcSpanExporterBuilder(builder.copy(), memoryMode);
   }
 
   /**
@@ -68,8 +78,23 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
    */
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
+    if (memoryMode == MemoryMode.REUSABLE_DATA) {
+      LowAllocationTraceRequestMarshaler marshaler = marshalerPool.poll();
+      if (marshaler == null) {
+        marshaler = new LowAllocationTraceRequestMarshaler();
+      }
+      LowAllocationTraceRequestMarshaler exportMarshaler = marshaler;
+      exportMarshaler.initialize(spans);
+      return delegate
+          .export(exportMarshaler, spans.size())
+          .whenComplete(
+              () -> {
+                exportMarshaler.reset();
+                marshalerPool.add(exportMarshaler);
+              });
+    }
+    // MemoryMode == MemoryMode.IMMUTABLE_DATA
     TraceRequestMarshaler request = TraceRequestMarshaler.create(spans);
-
     return delegate.export(request, spans.size());
   }
 
@@ -94,6 +119,9 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
 
   @Override
   public String toString() {
-    return "OtlpGrpcSpanExporter{" + builder.toString(false) + "}";
+    StringJoiner joiner = new StringJoiner(", ", "OtlpGrpcSpanExporter{", "}");
+    joiner.add(builder.toString(false));
+    joiner.add("memoryMode=" + memoryMode);
+    return joiner.toString();
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanUtil.java
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.exporter.otlp.metrics;
+package io.opentelemetry.exporter.otlp.trace;
 
 import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 
-final class OtlpGrpcMetricUtil {
+final class OtlpGrpcSpanUtil {
 
-  private OtlpGrpcMetricUtil() {}
+  private OtlpGrpcSpanUtil() {}
 
   /** See {@link OtlpConfigUtil#setMemoryModeOnOtlpExporterBuilder(Object, MemoryMode)}. */
-  static void setMemoryMode(OtlpGrpcMetricExporterBuilder builder, MemoryMode memoryMode) {
+  static void setMemoryMode(OtlpGrpcSpanExporterBuilder builder, MemoryMode memoryMode) {
     builder.setMemoryMode(memoryMode);
   }
 }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -127,6 +128,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(grpcBuilder, never()).setTrustedCertificates(any());
       verify(grpcBuilder, never()).setClientTls(any(), any());
       assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -176,6 +178,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.logs.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "1s");
     config.put("otel.exporter.otlp.logs.timeout", "15s");
+    config.put("otel.java.experimental.exporter.memory_mode", "reusable_data");
 
     try (LogRecordExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -188,6 +191,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(grpcBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(grpcBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.REUSABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -207,6 +211,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(httpBuilder, never()).setTrustedCertificates(any());
       verify(httpBuilder, never()).setClientTls(any(), any());
       assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }
@@ -259,6 +264,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.logs.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "1s");
     config.put("otel.exporter.otlp.logs.timeout", "15s");
+    config.put("otel.java.experimental.exporter.memory_mode", "reusable_data");
 
     try (LogRecordExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -271,6 +277,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(httpBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.REUSABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -128,6 +129,7 @@ class OtlpSpanExporterProviderTest {
       verify(grpcBuilder, never()).setTrustedCertificates(any());
       verify(grpcBuilder, never()).setClientTls(any(), any());
       assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -177,6 +179,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.traces.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "1s");
     config.put("otel.exporter.otlp.traces.timeout", "15s");
+    config.put("otel.java.experimental.exporter.memory_mode", "reusable_data");
 
     try (SpanExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -189,6 +192,7 @@ class OtlpSpanExporterProviderTest {
       verify(grpcBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(grpcBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.REUSABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -239,6 +243,7 @@ class OtlpSpanExporterProviderTest {
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
       assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }
@@ -262,6 +267,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.traces.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "1s");
     config.put("otel.exporter.otlp.traces.timeout", "15s");
+    config.put("otel.java.experimental.exporter.memory_mode", "reusable_data");
 
     try (SpanExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -274,6 +280,7 @@ class OtlpSpanExporterProviderTest {
       verify(httpBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.REUSABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -212,6 +212,7 @@ class OtlpSpanExporterProviderTest {
       verify(httpBuilder, never()).setTrustedCertificates(any());
       verify(httpBuilder, never()).setClientTls(any(), any());
       assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.exporter.otlp.http.trace;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.otlp.traces.ResourceSpansMarshaler;
 import io.opentelemetry.exporter.otlp.testing.internal.AbstractHttpTelemetryExporterTest;
@@ -14,13 +16,41 @@ import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporter;
 import io.opentelemetry.exporter.otlp.testing.internal.TelemetryExporterBuilder;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
 
 class OtlpHttpSpanExporterOkHttpSenderTest
     extends AbstractHttpTelemetryExporterTest<SpanData, ResourceSpans> {
 
   protected OtlpHttpSpanExporterOkHttpSenderTest() {
     super("span", "/v1/traces", ResourceSpans.getDefaultInstance());
+  }
+
+  /** Test configuration specific to metric exporter. */
+  @Test
+  void stringRepresentation() {
+    try (SpanExporter spanExporter = OtlpHttpSpanExporter.builder().build()) {
+      assertThat(spanExporter.toString())
+          .matches(
+              "OtlpHttpSpanExporter\\{"
+                  + "exporterName=otlp, "
+                  + "type=span, "
+                  + "endpoint=http://localhost:4318/v1/traces, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "proxyOptions=null, "
+                  + "compressorEncoding=null, "
+                  + "connectTimeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "exportAsJson=false, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "memoryMode=IMMUTABLE_DATA"
+                  + "\\}");
+    }
   }
 
   @Override

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/traces/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/traces/OtlpGrpcSpanExporterTest.java
@@ -17,14 +17,40 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.sender.okhttp.internal.OkHttpGrpcSender;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.Closeable;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class OtlpGrpcSpanExporterTest extends AbstractGrpcTelemetryExporterTest<SpanData, ResourceSpans> {
 
   OtlpGrpcSpanExporterTest() {
     super("span", ResourceSpans.getDefaultInstance());
+  }
+
+  /** Test configuration specific to metric exporter. */
+  @Test
+  void stringRepresentation() {
+    try (SpanExporter spanExporter = OtlpGrpcSpanExporter.builder().build()) {
+      assertThat(spanExporter.toString())
+          .matches(
+              "OtlpGrpcSpanExporter\\{"
+                  + "exporterName=otlp, "
+                  + "type=span, "
+                  + "endpoint=http://localhost:4317, "
+                  + "endpointPath=.*, "
+                  + "timeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "connectTimeoutNanos="
+                  + TimeUnit.SECONDS.toNanos(10)
+                  + ", "
+                  + "compressorEncoding=null, "
+                  + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "memoryMode=IMMUTABLE_DATA"
+                  + "\\}");
+    }
   }
 
   @Test

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
@@ -14,9 +14,9 @@ import io.opentelemetry.proto.common.v1.internal.KeyValue;
 import java.io.IOException;
 
 /** A Marshaler of key value pairs. See {@link AnyValueMarshaler}. */
-final class KeyValueStatelessMarshaler implements StatelessMarshaler<KeyAnyValue> {
+public final class KeyValueStatelessMarshaler implements StatelessMarshaler<KeyAnyValue> {
 
-  static final KeyValueStatelessMarshaler INSTANCE = new KeyValueStatelessMarshaler();
+  public static final KeyValueStatelessMarshaler INSTANCE = new KeyValueStatelessMarshaler();
   private static final byte[] EMPTY_BYTES = new byte[0];
 
   private KeyValueStatelessMarshaler() {}

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExemplarStatelessMarshaler.java
@@ -14,7 +14,7 @@ import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
-import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValueStatelessMarshaler;
 import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ExemplarData;
 import io.opentelemetry.sdk.metrics.data.LongExemplarData;
@@ -52,7 +52,7 @@ final class ExemplarStatelessMarshaler implements StatelessMarshaler<ExemplarDat
     output.serializeRepeatedMessageWithContext(
         io.opentelemetry.proto.metrics.v1.internal.Exemplar.FILTERED_ATTRIBUTES,
         exemplar.getFilteredAttributes(),
-        KeyValueStatelessMarshaler.INSTANCE,
+        AttributeKeyValueStatelessMarshaler.INSTANCE,
         context);
   }
 
@@ -85,7 +85,7 @@ final class ExemplarStatelessMarshaler implements StatelessMarshaler<ExemplarDat
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             io.opentelemetry.proto.metrics.v1.internal.Exemplar.FILTERED_ATTRIBUTES,
             exemplar.getFilteredAttributes(),
-            KeyValueStatelessMarshaler.INSTANCE,
+            AttributeKeyValueStatelessMarshaler.INSTANCE,
             context);
 
     return size;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
@@ -10,7 +10,7 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
-import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValueStatelessMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.ExponentialHistogramDataPoint;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
 import java.io.IOException;
@@ -58,7 +58,7 @@ final class ExponentialHistogramDataPointStatelessMarshaler
     output.serializeRepeatedMessageWithContext(
         ExponentialHistogramDataPoint.ATTRIBUTES,
         point.getAttributes(),
-        KeyValueStatelessMarshaler.INSTANCE,
+        AttributeKeyValueStatelessMarshaler.INSTANCE,
         context);
   }
 
@@ -105,7 +105,7 @@ final class ExponentialHistogramDataPointStatelessMarshaler
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             ExponentialHistogramDataPoint.ATTRIBUTES,
             point.getAttributes(),
-            KeyValueStatelessMarshaler.INSTANCE,
+            AttributeKeyValueStatelessMarshaler.INSTANCE,
             context);
 
     return size;

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/HistogramDataPointStatelessMarshaler.java
@@ -10,7 +10,7 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
-import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValueStatelessMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.HistogramDataPoint;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import java.io.IOException;
@@ -45,7 +45,7 @@ final class HistogramDataPointStatelessMarshaler implements StatelessMarshaler<H
     output.serializeRepeatedMessageWithContext(
         HistogramDataPoint.ATTRIBUTES,
         point.getAttributes(),
-        KeyValueStatelessMarshaler.INSTANCE,
+        AttributeKeyValueStatelessMarshaler.INSTANCE,
         context);
   }
 
@@ -77,7 +77,7 @@ final class HistogramDataPointStatelessMarshaler implements StatelessMarshaler<H
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             HistogramDataPoint.ATTRIBUTES,
             point.getAttributes(),
-            KeyValueStatelessMarshaler.INSTANCE,
+            AttributeKeyValueStatelessMarshaler.INSTANCE,
             context);
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/NumberDataPointStatelessMarshaler.java
@@ -13,7 +13,7 @@ import io.opentelemetry.exporter.internal.marshal.ProtoFieldInfo;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
-import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValueStatelessMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.NumberDataPoint;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
@@ -45,7 +45,7 @@ final class NumberDataPointStatelessMarshaler implements StatelessMarshaler<Poin
     output.serializeRepeatedMessageWithContext(
         NumberDataPoint.ATTRIBUTES,
         point.getAttributes(),
-        KeyValueStatelessMarshaler.INSTANCE,
+        AttributeKeyValueStatelessMarshaler.INSTANCE,
         context);
   }
 
@@ -71,7 +71,7 @@ final class NumberDataPointStatelessMarshaler implements StatelessMarshaler<Poin
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             NumberDataPoint.ATTRIBUTES,
             point.getAttributes(),
-            KeyValueStatelessMarshaler.INSTANCE,
+            AttributeKeyValueStatelessMarshaler.INSTANCE,
             context);
     return size;
   }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/SummaryDataPointStatelessMarshaler.java
@@ -10,7 +10,7 @@ import io.opentelemetry.exporter.internal.marshal.MarshalerUtil;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
-import io.opentelemetry.exporter.internal.otlp.KeyValueStatelessMarshaler;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValueStatelessMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.SummaryDataPoint;
 import io.opentelemetry.sdk.metrics.data.SummaryPointData;
 import java.io.IOException;
@@ -37,7 +37,7 @@ final class SummaryDataPointStatelessMarshaler implements StatelessMarshaler<Sum
     output.serializeRepeatedMessageWithContext(
         SummaryDataPoint.ATTRIBUTES,
         point.getAttributes(),
-        KeyValueStatelessMarshaler.INSTANCE,
+        AttributeKeyValueStatelessMarshaler.INSTANCE,
         context);
   }
 
@@ -60,7 +60,7 @@ final class SummaryDataPointStatelessMarshaler implements StatelessMarshaler<Sum
         StatelessMarshalerUtil.sizeRepeatedMessageWithContext(
             SummaryDataPoint.ATTRIBUTES,
             point.getAttributes(),
-            KeyValueStatelessMarshaler.INSTANCE,
+            AttributeKeyValueStatelessMarshaler.INSTANCE,
             context);
     return size;
   }

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -350,7 +350,7 @@ abstract class OtlpExporterIntegrationTest {
   @EnumSource(MemoryMode.class)
   void testOtlpGrpcMetricExport_memoryMode(MemoryMode memoryMode) {
     OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
-    OtlpConfigUtil.setMemoryModeOnOtlpMetricExporterBuilder(builder, memoryMode);
+    OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode);
 
     MetricExporter exporter =
         builder
@@ -403,7 +403,7 @@ abstract class OtlpExporterIntegrationTest {
   @EnumSource(MemoryMode.class)
   void testOtlpHttpMetricExport_memoryMode(MemoryMode memoryMode) {
     OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
-    OtlpConfigUtil.setMemoryModeOnOtlpMetricExporterBuilder(builder, memoryMode);
+    OtlpConfigUtil.setMemoryModeOnOtlpExporterBuilder(builder, memoryMode);
 
     MetricExporter exporter =
         builder


### PR DESCRIPTION
Related to #6429, #6410, #6422. 

Adds support for opting into low allocation memory usage in OTLP exporters via:
```
export OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE=reusable_data
```

cc @laurit 