### PR TITLE
Restrict space-only keys

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -127,7 +127,7 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
    * @return whether the name is valid.
    */
   private static boolean isValidBaggageKey(String name) {
-    return name != null && !name.isEmpty() && StringUtils.isPrintableString(name);
+    return name != null && !name.trim().isEmpty() && StringUtils.isPrintableString(name);
   }
 
   /**

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -448,6 +448,7 @@ class W3CBaggagePropagatorTest {
             .put("\2ab\3cd", "wacky key nonprintable")
             .put(null, "null key")
             .put("nullvalue", null)
+            .put(" ", "key is only space")
             .build();
     W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Map<String, String> carrier = new HashMap<>();


### PR DESCRIPTION
Resolves #2948 

> Someone will need to validate what the specification currently says about baggage keys and create a PR if we're not currently in compliance.

I confirmed it. (Thanks to some commenters.) Written [here](https://www.w3.org/TR/baggage/#key). This page is linked from [opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/baggage/api.md#overview).

> Leading and trailing whitespaces (OWS) are allowed and are not considered to be a part of the key.

So if key consists of space-only, we should treat as null.