### PR TITLE
Normalize timestamps and file ordering in jars, making the outputs reproducible

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -24,6 +24,13 @@ base {
   }
 }
 
+// normalize timestamps and file ordering in jars, making the outputs reproducible
+// see open-telemetry/opentelemetry-java#4488
+tasks.withType<AbstractArchiveTask>().configureEach {
+  isPreserveFileTimestamps = false
+  isReproducibleFileOrder = true
+}
+
 java {
   toolchain {
     languageVersion.set(JavaLanguageVersion.of(17))


### PR DESCRIPTION
Fixes #4488 

The changes I added to the Java convention plugin will remove the common sources of non-determinism from the project's jar files, namely file creation/modification dates stored in zip catalog metadata.

The net result is that for future releases, a user would be able to checkout a specific tag, rebuild the code locally and produce jars that are bitwise identical (matching checksums) to those releases available on Maven Central.

As for testing: I was able to test this by building the project twice in distinct folders, then spot-checking about ten of the jars (`sdk`, `api`, and `context` libraries plus their `-javadoc` and `-source` jars), and the `opentelemetry-sdk-trace-shaded-deps-1.39.0-SNAPSHOT-all.jar`. All had identical SHA1 checksums, which is the goal.

Please let me know how else we can validate that these changes can pass tests, I'm eager to help.