### PR TITLE
Start prometheus httpserver with daemon thread

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -12,6 +12,7 @@ package io.opentelemetry.exporter.prometheus;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
@@ -75,7 +76,8 @@ public final class PrometheusHttpServer implements MetricReader {
     // we configure prometheus with a single thread executor such that requests are handled
     // sequentially.
     if (memoryMode == MemoryMode.REUSABLE_DATA) {
-      executor = Executors.newSingleThreadExecutor();
+      executor =
+          Executors.newSingleThreadExecutor(new DaemonThreadFactory("prometheus-http-server"));
     }
     try {
       this.httpServer =


### PR DESCRIPTION
Similar to [use daemon thread for scheduling in jmx-metrics BeanFinder](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11337), the Prometheus HTTP server should also be started with daemon thread. Perhaps all threads created by the agent should be daemon in principle?
The pr [#6464](https://github.com/open-telemetry/opentelemetry-java/pull/6464) can solve part of the problem (please refer [Start Prometheus HTTP server on the provided executor](https://github.com/prometheus/client_java/pull/955)), and this pr will solve the rest.
