### PR TITLE
Update the Prometetheus metrics library

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -70,7 +70,7 @@ val DEPENDENCIES = listOf(
   "io.opentelemetry.proto:opentelemetry-proto:1.2.0-alpha",
   "io.opentracing:opentracing-api:0.33.0",
   "io.opentracing:opentracing-noop:0.33.0",
-  "io.prometheus:prometheus-metrics-exporter-httpserver:1.2.1",
+  "io.prometheus:prometheus-metrics-exporter-httpserver:1.3.1",
   "junit:junit:4.13.2",
   "nl.jqno.equalsverifier:equalsverifier:3.16.1",
   "org.awaitility:awaitility:4.2.1",

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
@@ -537,8 +537,7 @@ final class Otel2PrometheusConverter {
     String help = metricData.getDescription();
     Unit unit = PrometheusUnitsHelper.convertUnit(metricData.getUnit());
     if (unit != null && !name.endsWith(unit.toString())) {
-      // Need to re-sanitize metric name since unit may contain illegal characters
-      name = sanitizeMetricName(name + "_" + unit);
+      name = name + "_" + unit;
     }
     // Repeated __ are not allowed according to spec, although this is allowed in prometheus
     while (name.contains("__")) {

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusUnitsHelper.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusUnitsHelper.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.prometheus;
 
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Unit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,11 +87,22 @@ class PrometheusUnitsHelper {
       String part1 = pluralNames.getOrDefault(parts[0], parts[0]).trim();
       String part2 = singularNames.getOrDefault(parts[1], parts[1]).trim();
       if (part1.isEmpty()) {
-        return new Unit("per_" + part2);
+        return unitOrNull("per_" + part2);
       } else {
-        return new Unit(part1 + "_per_" + part2);
+        return unitOrNull(part1 + "_per_" + part2);
       }
     }
-    return new Unit(otelUnit);
+    return unitOrNull(otelUnit);
+  }
+
+  @Nullable
+  private static Unit unitOrNull(String name) {
+    try {
+      return new Unit(PrometheusNaming.sanitizeUnitName(name));
+    } catch (IllegalArgumentException e) {
+      // This happens if the name cannot be converted to a valid Prometheus unit name,
+      // for example if name is "total".
+      return null;
+    }
   }
 }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
@@ -283,9 +283,9 @@ class Otel2PrometheusConverterTest {
         // if metric name ends with unit the unit is omitted - order matters
         Arguments.of(
             createSampleMetricData("metric_total_hertz", "hertz_total", MetricDataType.LONG_SUM),
-            "metric_total_hertz_hertz_total counter",
-            "metric_total_hertz_hertz_total description",
-            "metric_total_hertz_hertz_total"),
+            "metric_total_hertz_total counter",
+            "metric_total_hertz_total description",
+            "metric_total_hertz_total"),
         // metric name cannot start with a number
         Arguments.of(
             createSampleMetricData("2_metric_name", "By", MetricDataType.SUMMARY),


### PR DESCRIPTION
The Prometheus metrics library 1.3.x introduced stricter checks for Prometheus `UNIT` names, and it also added a new helper method `PrometheusNaming.sanitizeUnitName(name)` for creating compliant `UNIT` names.

This PR updates the dependency version of the Prometheus metrics library, and also calls the new sanitize method to make sure we don't create illegal Prometheus UNIT names.