### PR TITLE
Make /metrics the only Prometheus metrics endpoint

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
-import io.prometheus.metrics.exporter.httpserver.MetricsHandler;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -84,7 +83,6 @@ public final class PrometheusHttpServer implements MetricReader {
               .port(port)
               .executorService(executor)
               .registry(prometheusRegistry)
-              .defaultHandler(new MetricsHandler(prometheusRegistry))
               .buildAndStart();
     } catch (IOException e) {
       throw new UncheckedIOException("Could not create Prometheus HTTP server", e);

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.java
@@ -10,6 +10,7 @@
 
 package io.opentelemetry.exporter.prometheus;
 
+import com.sun.net.httpserver.HttpHandler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -62,7 +63,8 @@ public final class PrometheusHttpServer implements MetricReader {
       PrometheusRegistry prometheusRegistry,
       boolean otelScopeEnabled,
       @Nullable Predicate<String> allowedResourceAttributesFilter,
-      MemoryMode memoryMode) {
+      MemoryMode memoryMode,
+      @Nullable HttpHandler defaultHandler) {
     this.builder = builder;
     this.prometheusMetricReader =
         new PrometheusMetricReader(otelScopeEnabled, allowedResourceAttributesFilter);
@@ -83,6 +85,7 @@ public final class PrometheusHttpServer implements MetricReader {
               .port(port)
               .executorService(executor)
               .registry(prometheusRegistry)
+              .defaultHandler(defaultHandler)
               .buildAndStart();
     } catch (IOException e) {
       throw new UncheckedIOException("Could not create Prometheus HTTP server", e);

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.prometheus;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import com.sun.net.httpserver.HttpHandler;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +30,7 @@ public final class PrometheusHttpServerBuilder {
   @Nullable private Predicate<String> allowedResourceAttributesFilter;
   @Nullable private ExecutorService executor;
   private MemoryMode memoryMode = DEFAULT_MEMORY_MODE;
+  @Nullable private HttpHandler defaultHandler;
 
   PrometheusHttpServerBuilder() {}
 
@@ -108,6 +110,23 @@ public final class PrometheusHttpServerBuilder {
   }
 
   /**
+   * Override the default handler for serving the "/", "/**" endpoint.
+   *
+   * <p>This can be used to serve metrics on additional paths besides the default "/metrics". For
+   * example: <code>
+   *   PrometheusHttpServer.builder()
+   *     .setPrometheusRegistry(prometheusRegistry)
+   *     .setDefaultHandler(new MetricsHandler(prometheusRegistry))
+   *     .build()
+   * </code>
+   */
+  public PrometheusHttpServerBuilder setDefaultHandler(HttpHandler defaultHandler) {
+    requireNonNull(defaultHandler, "defaultHandler");
+    this.defaultHandler = defaultHandler;
+    return this;
+  }
+
+  /**
    * Returns a new {@link PrometheusHttpServer} with the configuration of this builder which can be
    * registered with a {@link io.opentelemetry.sdk.metrics.SdkMeterProvider}.
    */
@@ -120,6 +139,7 @@ public final class PrometheusHttpServerBuilder {
         prometheusRegistry,
         otelScopeEnabled,
         allowedResourceAttributesFilter,
-        memoryMode);
+        memoryMode,
+        defaultHandler);
   }
 }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
@@ -35,6 +35,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import io.prometheus.metrics.exporter.httpserver.MetricsHandler;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -243,6 +244,47 @@ class PrometheusHttpServerTest {
                 + "grpc_name_unit_total{kp=\"vp\",otel_scope_name=\"grpc\",otel_scope_version=\"version\"} 5.0\n"
                 + "# TYPE target_info gauge\n"
                 + "target_info{kr=\"vr\"} 1\n");
+  }
+
+  @Test
+  void fetchOverrideDefaultHandler() {
+    PrometheusRegistry registry = new PrometheusRegistry();
+    try (PrometheusHttpServer prometheusServer =
+        PrometheusHttpServer.builder()
+            .setHost("localhost")
+            .setPort(0)
+            .setPrometheusRegistry(registry)
+            // Set the default handler to serve metrics on /**
+            .setDefaultHandler(new MetricsHandler(registry))
+            .build()) {
+      prometheusServer.register(
+          new CollectionRegistration() {
+            @Override
+            public Collection<MetricData> collectAllMetrics() {
+              return metricData.get();
+            }
+          });
+      WebClient client =
+          WebClient.builder("http://localhost:" + prometheusServer.getAddress().getPort())
+              .decorator(RetryingClient.newDecorator(RetryRule.failsafe()))
+              .build();
+
+      // Fetch metrics from / instead of /metrics
+      AggregatedHttpResponse response = client.get("/").aggregate().join();
+      assertThat(response.status()).isEqualTo(HttpStatus.OK);
+      assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
+          .isEqualTo("text/plain; version=0.0.4; charset=utf-8");
+      assertThat(response.contentUtf8())
+          .isEqualTo(
+              "# HELP grpc_name_unit_total long_description\n"
+                  + "# TYPE grpc_name_unit_total counter\n"
+                  + "grpc_name_unit_total{kp=\"vp\",otel_scope_name=\"grpc\",otel_scope_version=\"version\"} 5.0\n"
+                  + "# HELP http_name_unit_total double_description\n"
+                  + "# TYPE http_name_unit_total counter\n"
+                  + "http_name_unit_total{kp=\"vp\",otel_scope_name=\"http\",otel_scope_version=\"version\"} 3.5\n"
+                  + "# TYPE target_info gauge\n"
+                  + "target_info{kr=\"vr\"} 1\n");
+    }
   }
 
   @SuppressWarnings("resource")

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
@@ -229,7 +229,7 @@ class PrometheusHttpServerTest {
   void fetchFiltered() {
     AggregatedHttpResponse response =
         client
-            .get("/?name[]=grpc_name_unit_total&name[]=bears_total&name[]=target_info")
+            .get("/metrics?name[]=grpc_name_unit_total&name[]=bears_total&name[]=target_info")
             .aggregate()
             .join();
     assertThat(response.status()).isEqualTo(HttpStatus.OK);
@@ -275,7 +275,7 @@ class PrometheusHttpServerTest {
   @SuppressWarnings("resource")
   @Test
   void fetchHead() {
-    AggregatedHttpResponse response = client.head("/").aggregate().join();
+    AggregatedHttpResponse response = client.head("/metrics").aggregate().join();
     assertThat(response.status()).isEqualTo(HttpStatus.OK);
     assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
         .isEqualTo("text/plain; version=0.0.4; charset=utf-8");


### PR DESCRIPTION
Currently, the `PrometheusHttpServer` serves Prometheus metrics on _any_ endpoint:

* `/metrics`
* `/liveness`
* `/my/pets/123`
* `/`
* ...

This leads to issues (see #6071), and is uncommon in the Prometheus ecosystem.

For reference, I tested the default behavior of a couple of popular official Prometheus exporters:

* [node_exporter](https://github.com/prometheus/node_exporter)
* [blackbox_exporter](https://github.com/prometheus/blackbox_exporter)
* [mysqld_exporter](https://github.com/prometheus/mysqld_exporter)

The behavior of all of them is:

* The default handler `/*` serves a static HTML page with some info on the exporter, and with a link to `/metrics`
* The `/metrics` handler serves the metrics.

This is also the default behavior of the [HTTPServer](https://prometheus.github.io/client_java/exporters/httpserver/) of the Prometheus Java client library.

This PR makes `opentelemetry-java` use the default behavior. Metrics are only served on `/metrics`. The default handler serves a static HTML page with a link to `/metrics`.

**Note**

This differs from the suggestion in #6071:

* #6071 suggests to respond with HTTP 404 on `/*`. However, this is not what other exporters in the Prometheus ecosystem do, so I'd just stick with HTTP 200 to follow the principle of least surprise.
* #6071 suggests to make the endpoint configurable. I don't have a strong opinion on this, and I'm happy to make it configurable. However, I don't see a good use case for configuring a non-default endpoint. I think we should only add API to configure it if there is a use case for it.