### PR TITLE
Remove android animalsniffer check from prometheus exporter

### DIFF
--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
-
-  id("otel.animalsniffer-conventions")
 }
 
 description = "OpenTelemetry Prometheus Exporter"


### PR DESCRIPTION
It doesn't make sense to scrape metrics from an android device. Furthermore, the android API doesn't contain `com.sun.net.httpserver.HttpHandler` and this is a key part of the implementation of prometheus. So animalsniffer checks for usages of unsupported APIs directly, it doesn't appear to walk all the code paths so it missed this usage in the prometheus client library dependency.

See convo in #6476 for more details.