### PR TITLE
Add exporter data model impl for profiling signal type.

### DIFF
--- a/exporters/otlp/profiles/build.gradle.kts
+++ b/exporters/otlp/profiles/build.gradle.kts
@@ -10,4 +10,6 @@ otelJava.moduleName.set("io.opentelemetry.exporter.otlp.profiles")
 
 dependencies {
   api(project(":sdk:common"))
+
+  annotationProcessor("com.google.auto.value:auto-value")
 }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableAttributeUnitData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableAttributeUnitData.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.AttributeUnitData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableAttributeUnitData implements AttributeUnitData {
+
+  public static AttributeUnitData create(long attributeKey, long unitIndex) {
+    return new AutoValue_ImmutableAttributeUnitData(attributeKey, unitIndex);
+  }
+
+  ImmutableAttributeUnitData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableAttributeUnitData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableAttributeUnitData.java
@@ -9,10 +9,22 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.exporter.otlp.profiles.AttributeUnitData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link AttributeUnitData}, which represents a mapping between
+ * Attribute Keys and Units.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableAttributeUnitData implements AttributeUnitData {
 
+  /**
+   * Returns a new AttributeUnitData mapping the given key to the given unit.
+   *
+   * @return a new AttributeUnitData mapping the given key to the given unit.
+   */
   public static AttributeUnitData create(long attributeKey, long unitIndex) {
     return new AutoValue_ImmutableAttributeUnitData(attributeKey, unitIndex);
   }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableFunctionData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableFunctionData.java
@@ -9,10 +9,21 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.exporter.otlp.profiles.FunctionData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link FunctionData}, which describes a code function.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableFunctionData implements FunctionData {
 
+  /**
+   * Returns a new FunctionData describing the given function characteristics.
+   *
+   * @return a new FunctionData describing the given function characteristics.
+   */
   public static FunctionData create(
       long nameIndex, long systemNameIndex, long filenameIndex, long startLine) {
     return new AutoValue_ImmutableFunctionData(

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableFunctionData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableFunctionData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.FunctionData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableFunctionData implements FunctionData {
+
+  public static FunctionData create(
+      long nameIndex, long systemNameIndex, long filenameIndex, long startLine) {
+    return new AutoValue_ImmutableFunctionData(
+        nameIndex, systemNameIndex, filenameIndex, startLine);
+  }
+
+  ImmutableFunctionData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLabelData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLabelData.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.LabelData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableLabelData implements LabelData {
+
+  public static LabelData create(long keyIndex, long strIndex, long num, long numUnitIndex) {
+    return new AutoValue_ImmutableLabelData(keyIndex, strIndex, num, numUnitIndex);
+  }
+
+  ImmutableLabelData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLabelData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLabelData.java
@@ -9,10 +9,21 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.exporter.otlp.profiles.LabelData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link LabelData}, which provides additional context for a sample.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableLabelData implements LabelData {
 
+  /**
+   * Returns a new LabelData describing the given context for a sample.
+   *
+   * @return a new LabelData describing the given context for a sample.
+   */
   public static LabelData create(long keyIndex, long strIndex, long num, long numUnitIndex) {
     return new AutoValue_ImmutableLabelData(keyIndex, strIndex, num, numUnitIndex);
   }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLineData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLineData.java
@@ -9,10 +9,22 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.exporter.otlp.profiles.LineData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link LineData}, which details a specific line in a source code,
+ * linked to a function.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableLineData implements LineData {
 
+  /**
+   * Returns a new LineData describing the given details a specific line in a source code.
+   *
+   * @return a new LineData describing the given details a specific line in a source code.
+   */
   public static LineData create(long functionIndex, long line, long column) {
     return new AutoValue_ImmutableLineData(functionIndex, line, column);
   }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLineData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLineData.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.LineData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableLineData implements LineData {
+
+  public static LineData create(long functionIndex, long line, long column) {
+    return new AutoValue_ImmutableLineData(functionIndex, line, column);
+  }
+
+  ImmutableLineData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLinkData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLinkData.java
@@ -9,10 +9,22 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.exporter.otlp.profiles.LinkData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link LinkData}, which represents a connection from a profile
+ * Sample to a trace Span.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableLinkData implements LinkData {
 
+  /**
+   * Returns a new LinkData representing an association to the given trace span.
+   *
+   * @return a new LinkData representing an association to the given trace span.
+   */
   public static LinkData create(String traceId, String spanId) {
     return new AutoValue_ImmutableLinkData(traceId, spanId);
   }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLinkData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLinkData.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.LinkData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableLinkData implements LinkData {
+
+  public static LinkData create(String traceId, String spanId) {
+    return new AutoValue_ImmutableLinkData(traceId, spanId);
+  }
+
+  ImmutableLinkData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLocationData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLocationData.java
@@ -11,10 +11,22 @@ import io.opentelemetry.exporter.otlp.profiles.LocationData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link LocationData}, which describes function and line table debug
+ * information.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableLocationData implements LocationData {
 
+  /**
+   * Returns a new LocationData describing the given function and line table information.
+   *
+   * @return a new LocationData describing the given function and line table information.
+   */
   public static LocationData create(
       long mappingIndex,
       long address,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLocationData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableLocationData.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.LineData;
+import io.opentelemetry.exporter.otlp.profiles.LocationData;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableLocationData implements LocationData {
+
+  public static LocationData create(
+      long mappingIndex,
+      long address,
+      List<LineData> lines,
+      boolean folded,
+      int typeIndex,
+      List<Long> attributes) {
+    return new AutoValue_ImmutableLocationData(
+        mappingIndex, address, lines, folded, typeIndex, attributes);
+  }
+
+  ImmutableLocationData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableMappingData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableMappingData.java
@@ -11,10 +11,22 @@ import io.opentelemetry.exporter.otlp.profiles.MappingData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link MappingData}, which describes the mapping of a binary in
+ * memory.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableMappingData implements MappingData {
 
+  /**
+   * Returns a new MappingData describing the given mapping of a binary in memory.
+   *
+   * @return a new MappingData describing the given mapping of a binary in memory.
+   */
   @SuppressWarnings("TooManyParameters")
   public static MappingData create(
       long memoryStart,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableMappingData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableMappingData.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.BuildIdKind;
+import io.opentelemetry.exporter.otlp.profiles.MappingData;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableMappingData implements MappingData {
+
+  @SuppressWarnings("TooManyParameters")
+  public static MappingData create(
+      long memoryStart,
+      long memoryLimit,
+      long fileOffset,
+      long filenameIndex,
+      long buildIdIndex,
+      BuildIdKind buildIdKind,
+      List<Long> attributeIndices,
+      boolean hasFunctions,
+      boolean hasFilenames,
+      boolean hasLineNumbers,
+      boolean hasInlineFrames) {
+    return new AutoValue_ImmutableMappingData(
+        memoryStart,
+        memoryLimit,
+        fileOffset,
+        filenameIndex,
+        buildIdIndex,
+        buildIdKind,
+        attributeIndices,
+        hasFunctions,
+        hasFilenames,
+        hasLineNumbers,
+        hasInlineFrames);
+  }
+
+  ImmutableMappingData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileContainerData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileContainerData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.otlp.profiles.ProfileContainerData;
+import io.opentelemetry.exporter.otlp.profiles.ProfileData;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableProfileContainerData implements ProfileContainerData {
+
+  @SuppressWarnings("TooManyParameters")
+  public static ProfileContainerData create(
+      Resource resource,
+      InstrumentationScopeInfo instrumentationScopeInfo,
+      String profileId,
+      long startEpochNanos,
+      long endEpochNanos,
+      Attributes attributes,
+      int totalAttributeCount,
+      @Nullable String originalPayloadFormat,
+      ByteBuffer originalPayload,
+      ProfileData profile) {
+    return new AutoValue_ImmutableProfileContainerData(
+        resource,
+        instrumentationScopeInfo,
+        profileId,
+        startEpochNanos,
+        endEpochNanos,
+        attributes,
+        totalAttributeCount,
+        originalPayloadFormat,
+        originalPayload,
+        profile);
+  }
+
+  ImmutableProfileContainerData() {}
+
+  public ByteBuffer getOriginalPayloadReadOnly() {
+    return getOriginalPayload().asReadOnlyBuffer();
+  }
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileContainerData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileContainerData.java
@@ -15,10 +15,21 @@ import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link ProfileContainerData}, which represents a single profile.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableProfileContainerData implements ProfileContainerData {
 
+  /**
+   * Returns a new ProfileContainerData representing the given profile information.
+   *
+   * @return a new ProfileContainerData representing the given profile information.
+   */
   @SuppressWarnings("TooManyParameters")
   public static ProfileContainerData create(
       Resource resource,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.otlp.profiles.AttributeUnitData;
+import io.opentelemetry.exporter.otlp.profiles.FunctionData;
+import io.opentelemetry.exporter.otlp.profiles.LinkData;
+import io.opentelemetry.exporter.otlp.profiles.LocationData;
+import io.opentelemetry.exporter.otlp.profiles.MappingData;
+import io.opentelemetry.exporter.otlp.profiles.ProfileData;
+import io.opentelemetry.exporter.otlp.profiles.SampleData;
+import io.opentelemetry.exporter.otlp.profiles.ValueTypeData;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableProfileData implements ProfileData {
+
+  @SuppressWarnings("TooManyParameters")
+  public static ProfileData create(
+      List<ValueTypeData> sampleTypes,
+      List<SampleData> samples,
+      List<MappingData> mappings,
+      List<LocationData> locations,
+      List<Long> locationIndices,
+      List<FunctionData> functions,
+      Attributes attributes,
+      List<AttributeUnitData> attributeUnits,
+      List<LinkData> links,
+      List<String> stringTable,
+      long dropFrames,
+      long keepFrames,
+      long timeNanos,
+      long durationNanos,
+      ValueTypeData periodType,
+      long period,
+      List<Long> comment,
+      long defaultSampleType) {
+    return new AutoValue_ImmutableProfileData(
+        sampleTypes,
+        samples,
+        mappings,
+        locations,
+        locationIndices,
+        functions,
+        attributes,
+        attributeUnits,
+        links,
+        stringTable,
+        dropFrames,
+        keepFrames,
+        timeNanos,
+        durationNanos,
+        periodType,
+        period,
+        comment,
+        defaultSampleType);
+  }
+
+  ImmutableProfileData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
@@ -18,10 +18,23 @@ import io.opentelemetry.exporter.otlp.profiles.ValueTypeData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link ProfileData}, which represents a complete profile, including
+ * sample types, samples, mappings to binaries, locations, functions, string table, and additional
+ * metadata.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableProfileData implements ProfileData {
 
+  /**
+   * Returns a new ProfileData representing the given data.
+   *
+   * @return a new ProfileData representing the given data.
+   */
   @SuppressWarnings("TooManyParameters")
   public static ProfileData create(
       List<ValueTypeData> sampleTypes,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableSampleData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableSampleData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.SampleData;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableSampleData implements SampleData {
+
+  public static SampleData create(
+      long locationsStartIndex,
+      long locationsLength,
+      int stacktraceIdIndex,
+      List<Long> values,
+      List<Long> attributes,
+      long link,
+      List<Long> timestamps) {
+    return new AutoValue_ImmutableSampleData(
+        locationsStartIndex,
+        locationsLength,
+        stacktraceIdIndex,
+        values,
+        attributes,
+        link,
+        timestamps);
+  }
+
+  ImmutableSampleData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableSampleData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableSampleData.java
@@ -10,10 +10,22 @@ import io.opentelemetry.exporter.otlp.profiles.SampleData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link SampleData}, which records values encountered in some program
+ * context.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableSampleData implements SampleData {
 
+  /**
+   * Returns a new SampleData representing the given program context.
+   *
+   * @return a new SampleData representing the given program context.
+   */
   public static SampleData create(
       long locationsStartIndex,
       long locationsLength,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableValueTypeData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableValueTypeData.java
@@ -10,10 +10,22 @@ import io.opentelemetry.exporter.otlp.profiles.AggregationTemporality;
 import io.opentelemetry.exporter.otlp.profiles.ValueTypeData;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Auto value implementation of {@link ValueTypeData}, which describes the type and units of a
+ * value.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
 @Immutable
 @AutoValue
 public abstract class ImmutableValueTypeData implements ValueTypeData {
 
+  /**
+   * Returns a new ValueTypeData describing the given type and unit characteristics.
+   *
+   * @return a new ValueTypeData describing the given type and unit characteristics.
+   */
   public static ValueTypeData create(
       long type, long unit, AggregationTemporality aggregationTemporality) {
     return new AutoValue_ImmutableValueTypeData(type, unit, aggregationTemporality);

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableValueTypeData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableValueTypeData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.otlp.internal.data;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.otlp.profiles.AggregationTemporality;
+import io.opentelemetry.exporter.otlp.profiles.ValueTypeData;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class ImmutableValueTypeData implements ValueTypeData {
+
+  public static ValueTypeData create(
+      long type, long unit, AggregationTemporality aggregationTemporality) {
+    return new AutoValue_ImmutableValueTypeData(type, unit, aggregationTemporality);
+  }
+
+  ImmutableValueTypeData() {}
+}

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationData.java
@@ -9,7 +9,7 @@ import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Describes a function.
+ * Describes function and line table debug information.
  *
  * @see "pprofextended.proto::Location"
  */


### PR DESCRIPTION
Second step towards supporting the new experimental signal type for profiling...

Following on from the interfaces in https://github.com/open-telemetry/opentelemetry-java/pull/6374 this adds the AutoValue generated implementation classes.  Less to discuss here, it's much more straightforward than the interfaces!

- Still no test coverage, since most of the code is auto generated anyhow. For other similar classes the test coverage is indirect via the Marshaler tests, which for these classes won't be along until the next PR. Meanwhile codecov will probably continue to sulk.

- The ByteBuffer use in ProfileContainerData presents a challenge. For other similar cases, the mutable object could be wrapped during the static create(...) call with e.g. Collections.unmodifiableList, such that the auto-generated getter can simply return the immutable wrapper. That pattern doesn't work with .asReadOnlyBuffer() since the resulting wrapper object is not immutable, though the content is. For now I've gone with adding an extra getter, as AutoValue won't support overriding the default one. The usability of the resulting API isn't great, but perhaps adequate as the only real use case is the Marshalers and they use it correctly. The alternative design is to disable AutoValue for that class and hand-tool all the getters, but that increases maintenance and cognitive load.