### PR TITLE
Fix CollectorIntegrationTest

### DIFF
--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
@@ -134,6 +134,10 @@ class CollectorIntegrationTest {
             // Resource attributes derived from the prometheus scrape config
             stringKeyValue("service.name", "app"),
             stringKeyValue("service.instance.id", "host.testcontainers.internal:" + prometheusPort),
+            // net.host.name, net.host.port and http.scheme are superseded by server.address,
+            // server.port, and url.scheme respectively and will be removed by default in a future
+            // collector release
+            // https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32829
             stringKeyValue("net.host.name", "host.testcontainers.internal"),
             stringKeyValue("net.host.port", String.valueOf(prometheusPort)),
             stringKeyValue("http.scheme", "http"),

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
@@ -137,6 +137,9 @@ class CollectorIntegrationTest {
             stringKeyValue("net.host.name", "host.testcontainers.internal"),
             stringKeyValue("net.host.port", String.valueOf(prometheusPort)),
             stringKeyValue("http.scheme", "http"),
+            stringKeyValue("server.address", "host.testcontainers.internal"),
+            stringKeyValue("server.port", String.valueOf(prometheusPort)),
+            stringKeyValue("url.scheme", "http"),
             // Resource attributes from the metric SDK resource translated to target_info
             stringKeyValue(
                 "service_name",


### PR DESCRIPTION
Build on main is [broken](https://github.com/open-telemetry/opentelemetry-java/actions/runs/9651727315/job/26620265627) right now due to a change in the collector prometheus receiver logic from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32829