### PR TITLE
Fix build after recent collector release

### DIFF
--- a/exporters/prometheus/src/test/resources/otel-config.yaml
+++ b/exporters/prometheus/src/test/resources/otel-config.yaml
@@ -1,5 +1,6 @@
 extensions:
-  health_check: {}
+  health_check:
+    endpoint: 0.0.0.0:13133
 receivers:
   prometheus:
     config:
@@ -7,12 +8,12 @@ receivers:
         - job_name: 'app'
           scrape_interval: 1s
           static_configs:
-            - targets: ['$APP_ENDPOINT']
+            - targets: ['${APP_ENDPOINT}']
 exporters:
   logging:
-    verbosity: $LOGGING_EXPORTER_VERBOSITY
+    verbosity: ${LOGGING_EXPORTER_VERBOSITY}
   otlp:
-    endpoint: $OTLP_EXPORTER_ENDPOINT
+    endpoint: ${OTLP_EXPORTER_ENDPOINT}
     tls:
       insecure: true
     compression: none

--- a/integration-tests/otlp/src/main/resources/otel-config.yaml
+++ b/integration-tests/otlp/src/main/resources/otel-config.yaml
@@ -1,5 +1,6 @@
 extensions:
-  health_check: {}
+  health_check:
+    endpoint: 0.0.0.0:13133
 receivers:
   otlp:
     protocols:
@@ -12,20 +13,20 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:5317
         tls:
-          client_ca_file: $MTLS_CLIENT_CERTIFICATE
-          cert_file: $MTLS_SERVER_CERTIFICATE
-          key_file: $MTLS_SERVER_KEY
+          client_ca_file: ${MTLS_CLIENT_CERTIFICATE}
+          cert_file: ${MTLS_SERVER_CERTIFICATE}
+          key_file: ${MTLS_SERVER_KEY}
       http:
         endpoint: 0.0.0.0:5318
         tls:
-          client_ca_file: $MTLS_CLIENT_CERTIFICATE
-          cert_file: $MTLS_SERVER_CERTIFICATE
-          key_file: $MTLS_SERVER_KEY
+          client_ca_file: ${MTLS_CLIENT_CERTIFICATE}
+          cert_file: ${MTLS_SERVER_CERTIFICATE}
+          key_file: ${MTLS_SERVER_KEY}
 exporters:
   logging:
-    verbosity: $LOGGING_EXPORTER_VERBOSITY_LEVEL
+    verbosity: ${LOGGING_EXPORTER_VERBOSITY_LEVEL}
   otlp:
-    endpoint: $OTLP_EXPORTER_ENDPOINT
+    endpoint: ${OTLP_EXPORTER_ENDPOINT}
     tls:
       insecure: true
     compression: none


### PR DESCRIPTION
Build is currently broken. Example here: https://github.com/open-telemetry/opentelemetry-java/actions/runs/9765156950/job/26955207437

The [0.104.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0) release of collector contrib remove support for the `$ENV_VAR` syntax, and removes exposing health check on `0.0.0.0` by default. This PR updates the few places we use the collector in testing to reflect those changes.