### PR TITLE
Enable retry by default for OTLP exporters

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -60,7 +60,7 @@ public class GrpcExporterBuilder<T extends Marshaler> {
   private final Map<String, String> constantHeaders = new HashMap<>();
   private Supplier<Map<String, String>> headerSupplier = Collections::emptyMap;
   private TlsConfigHelper tlsConfigHelper = new TlsConfigHelper();
-  @Nullable private RetryPolicy retryPolicy;
+  @Nullable private RetryPolicy retryPolicy = RetryPolicy.getDefault();
   private Supplier<MeterProvider> meterProviderSupplier = GlobalOpenTelemetry::getMeterProvider;
 
   // Use Object type since gRPC may not be on the classpath.
@@ -137,7 +137,7 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public GrpcExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
+  public GrpcExporterBuilder<T> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     this.retryPolicy = retryPolicy;
     return this;
   }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -59,7 +59,7 @@ public final class HttpExporterBuilder<T extends Marshaler> {
   private Supplier<Map<String, String>> headerSupplier = Collections::emptyMap;
 
   private TlsConfigHelper tlsConfigHelper = new TlsConfigHelper();
-  @Nullable private RetryPolicy retryPolicy;
+  @Nullable private RetryPolicy retryPolicy = RetryPolicy.getDefault();
   private Supplier<MeterProvider> meterProviderSupplier = GlobalOpenTelemetry::getMeterProvider;
   @Nullable private Authenticator authenticator;
 
@@ -128,7 +128,7 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     return this;
   }
 
-  public HttpExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
+  public HttpExporterBuilder<T> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     this.retryPolicy = retryPolicy;
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -166,12 +167,12 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpHttpLogRecordExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpHttpLogRecordExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -212,12 +213,12 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpHttpMetricExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpHttpMetricExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -167,12 +168,12 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpHttpSpanExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpHttpSpanExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -151,10 +151,16 @@ public final class OtlpConfigUtil {
       setClientTls.accept(clientKeyBytes, clientKeyChainBytes);
     }
 
-    boolean retryEnabled =
-        config.getBoolean("otel.experimental.exporter.otlp.retry.enabled", false);
-    if (retryEnabled) {
-      setRetryPolicy.accept(RetryPolicy.getDefault());
+    Boolean retryDisabled = config.getBoolean("otel.java.exporter.otlp.retry.disabled");
+    if (retryDisabled == null) {
+      Boolean experimentalRetryEnabled =
+          config.getBoolean("otel.experimental.exporter.otlp.retry.enabled");
+      if (experimentalRetryEnabled != null) {
+        retryDisabled = !experimentalRetryEnabled;
+      }
+    }
+    if (retryDisabled != null && retryDisabled) {
+      setRetryPolicy.accept(null);
     }
 
     ExporterBuilderUtil.configureExporterMemoryMode(config, setMemoryMode);

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -210,12 +211,12 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpGrpcLogRecordExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpGrpcLogRecordExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -256,12 +257,12 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpGrpcMetricExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpGrpcMetricExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -207,12 +208,12 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
-   * Set the retry policy. Retry is disabled by default.
+   * Set the retry policy, or {@code null} to disable retry. Retry policy is {@link
+   * RetryPolicy#getDefault()} by default
    *
    * @since 1.28.0
    */
-  public OtlpGrpcSpanExporterBuilder setRetryPolicy(RetryPolicy retryPolicy) {
-    requireNonNull(retryPolicy, "retryPolicy");
+  public OtlpGrpcSpanExporterBuilder setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProviderTest.java
@@ -127,7 +127,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(grpcBuilder, never()).setTimeout(any());
       verify(grpcBuilder, never()).setTrustedCertificates(any());
       verify(grpcBuilder, never()).setClientTls(any(), any());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
@@ -143,7 +143,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (LogRecordExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -156,7 +156,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(grpcBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(grpcBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -210,7 +210,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(httpBuilder, never()).setTimeout(any());
       verify(httpBuilder, never()).setTrustedCertificates(any());
       verify(httpBuilder, never()).setClientTls(any(), any());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
@@ -227,7 +227,7 @@ class OtlpLogRecordExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (LogRecordExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -240,7 +240,7 @@ class OtlpLogRecordExporterProviderTest {
       verify(httpBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProviderTest.java
@@ -127,7 +127,7 @@ class OtlpMetricExporterProviderTest {
       verify(grpcBuilder, never()).setTimeout(any());
       verify(grpcBuilder, never()).setTrustedCertificates(any());
       verify(grpcBuilder, never()).setClientTls(any(), any());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter.getMemoryMode()).isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
@@ -143,7 +143,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (MetricExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -156,7 +156,7 @@ class OtlpMetricExporterProviderTest {
       verify(grpcBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(grpcBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -211,7 +211,7 @@ class OtlpMetricExporterProviderTest {
       verify(httpBuilder, never()).setTimeout(any());
       verify(httpBuilder, never()).setTrustedCertificates(any());
       verify(httpBuilder, never()).setClientTls(any(), any());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter.getMemoryMode()).isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
@@ -228,7 +228,7 @@ class OtlpMetricExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (MetricExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -241,7 +241,7 @@ class OtlpMetricExporterProviderTest {
       verify(httpBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
     }
     Mockito.verifyNoInteractions(grpcBuilder);
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -128,7 +128,7 @@ class OtlpSpanExporterProviderTest {
       verify(grpcBuilder, never()).setTimeout(any());
       verify(grpcBuilder, never()).setTrustedCertificates(any());
       verify(grpcBuilder, never()).setClientTls(any(), any());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(httpBuilder);
@@ -144,7 +144,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.enabled", "false");
 
     try (SpanExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -157,7 +157,7 @@ class OtlpSpanExporterProviderTest {
       verify(grpcBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(grpcBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(grpcBuilder).extracting("delegate").extracting("retryPolicy").isNull();
     }
     Mockito.verifyNoInteractions(httpBuilder);
   }
@@ -211,7 +211,7 @@ class OtlpSpanExporterProviderTest {
       verify(httpBuilder, never()).setTimeout(any());
       verify(httpBuilder, never()).setTrustedCertificates(any());
       verify(httpBuilder, never()).setClientTls(any(), any());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
       assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);
@@ -229,7 +229,7 @@ class OtlpSpanExporterProviderTest {
         "otel.exporter.otlp.headers", "header-key1=header%20value1,header-key2=header value2");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.experimental.exporter.otlp.retry.enabled", "true");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (SpanExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {
@@ -243,7 +243,7 @@ class OtlpSpanExporterProviderTest {
       verify(httpBuilder).setTrustedCertificates(serverTls.certificate().getEncoded());
       verify(httpBuilder)
           .setClientTls(clientTls.privateKey().getEncoded(), clientTls.certificate().getEncoded());
-      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNotNull();
+      assertThat(httpBuilder).extracting("delegate").extracting("retryPolicy").isNull();
       assertThat(exporter).extracting("memoryMode").isEqualTo(MemoryMode.IMMUTABLE_DATA);
     }
     Mockito.verifyNoInteractions(grpcBuilder);

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -144,7 +144,7 @@ class OtlpSpanExporterProviderTest {
     config.put("otel.exporter.otlp.headers", "header-key=header-value");
     config.put("otel.exporter.otlp.compression", "gzip");
     config.put("otel.exporter.otlp.timeout", "15s");
-    config.put("otel.java.exporter.otlp.retry.enabled", "false");
+    config.put("otel.java.exporter.otlp.retry.disabled", "true");
 
     try (SpanExporter exporter =
         provider.createExporter(DefaultConfigProperties.createFromMap(config))) {

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterOkHttpSenderTest.java
@@ -99,6 +99,7 @@ class OtlpHttpMetricExporterOkHttpSenderTest
                   + ", "
                   + "exportAsJson=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "retryPolicy=RetryPolicy\\{.*\\}, "
                   + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
                   + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
                   + "memoryMode=IMMUTABLE_DATA"

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterOkHttpSenderTest.java
@@ -48,6 +48,7 @@ class OtlpHttpSpanExporterOkHttpSenderTest
                   + ", "
                   + "exportAsJson=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "retryPolicy=RetryPolicy\\{.*\\}, "
                   + "memoryMode=IMMUTABLE_DATA"
                   + "\\}");
     }

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterTest.java
@@ -99,6 +99,7 @@ class OtlpGrpcMetricExporterTest
                   + ", "
                   + "compressorEncoding=null, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "retryPolicy=RetryPolicy\\{.*\\}, "
                   + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
                   + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
                   + "memoryMode=IMMUTABLE_DATA"

--- a/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/traces/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/all/src/testDefaultSender/java/io/opentelemetry/exporter/otlp/traces/OtlpGrpcSpanExporterTest.java
@@ -48,6 +48,7 @@ class OtlpGrpcSpanExporterTest extends AbstractGrpcTelemetryExporterTest<SpanDat
                   + ", "
                   + "compressorEncoding=null, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "retryPolicy=RetryPolicy\\{.*\\}, "
                   + "memoryMode=IMMUTABLE_DATA"
                   + "\\}");
     }

--- a/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterJdkSenderTest.java
+++ b/exporters/otlp/all/src/testJdkHttpSender/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterJdkSenderTest.java
@@ -100,6 +100,7 @@ class OtlpHttpMetricExporterJdkSenderTest
                   + ", "
                   + "exportAsJson=false, "
                   + "headers=Headers\\{User-Agent=OBFUSCATED\\}, "
+                  + "retryPolicy=RetryPolicy\\{.*\\}, "
                   + "aggregationTemporalitySelector=AggregationTemporalitySelector\\{.*\\}, "
                   + "defaultAggregationSelector=DefaultAggregationSelector\\{.*\\}, "
                   + "memoryMode=IMMUTABLE_DATA"

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -187,7 +187,17 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
   @BeforeAll
   void setUp() {
-    exporter = exporterBuilder().setEndpoint(server.httpUri().toString()).build();
+    exporter =
+        exporterBuilder()
+            .setEndpoint(server.httpUri().toString())
+            // We don't validate backoff time itself in these tests, just that retries
+            // occur. Keep the tests fast by using minimal backoff.
+            .setRetryPolicy(
+                RetryPolicy.getDefault().toBuilder()
+                    .setMaxAttempts(2)
+                    .setInitialBackoff(Duration.ofMillis(1))
+                    .build())
+            .build();
 
     // Sanity check that TLS files are in PEM format.
     assertThat(certificate.certificateFile())
@@ -469,6 +479,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
             // Connecting to a non-routable IP address to trigger connection error
             .setEndpoint("http://10.255.255.1")
             .setConnectTimeout(Duration.ofMillis(1))
+            .setRetryPolicy(null)
             .build();
     try {
       long startTimeMillis = System.currentTimeMillis();
@@ -530,112 +541,147 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   @SuppressLogger(GrpcExporter.class)
   void error() {
     addGrpcError(13, null);
-    assertThat(
-            exporter
-                .export(Collections.singletonList(generateFakeTelemetry()))
-                .join(10, TimeUnit.SECONDS)
-                .isSuccess())
-        .isFalse();
-    LoggingEvent log =
-        logs.assertContains(
-            "Failed to export "
-                + type
-                + "s. Server responded with gRPC status code 13. Error message:");
-    assertThat(log.getLevel()).isEqualTo(Level.WARN);
+
+    TelemetryExporter<T> exporter = nonRetryingExporter();
+
+    try {
+      assertThat(
+              exporter
+                  .export(Collections.singletonList(generateFakeTelemetry()))
+                  .join(10, TimeUnit.SECONDS)
+                  .isSuccess())
+          .isFalse();
+      LoggingEvent log =
+          logs.assertContains(
+              "Failed to export "
+                  + type
+                  + "s. Server responded with gRPC status code 13. Error message:");
+      assertThat(log.getLevel()).isEqualTo(Level.WARN);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test
   @SuppressLogger(GrpcExporter.class)
   void errorWithMessage() {
     addGrpcError(8, "out of quota");
-    assertThat(
-            exporter
-                .export(Collections.singletonList(generateFakeTelemetry()))
-                .join(10, TimeUnit.SECONDS)
-                .isSuccess())
-        .isFalse();
-    LoggingEvent log =
-        logs.assertContains(
-            "Failed to export "
-                + type
-                + "s. Server responded with gRPC status code 8. Error message: out of quota");
-    assertThat(log.getLevel()).isEqualTo(Level.WARN);
+
+    TelemetryExporter<T> exporter = nonRetryingExporter();
+
+    try {
+      assertThat(
+              exporter
+                  .export(Collections.singletonList(generateFakeTelemetry()))
+                  .join(10, TimeUnit.SECONDS)
+                  .isSuccess())
+          .isFalse();
+      LoggingEvent log =
+          logs.assertContains(
+              "Failed to export "
+                  + type
+                  + "s. Server responded with gRPC status code 8. Error message: out of quota");
+      assertThat(log.getLevel()).isEqualTo(Level.WARN);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test
   @SuppressLogger(GrpcExporter.class)
   void errorWithEscapedMessage() {
     addGrpcError(5, "クマ🐻");
-    assertThat(
-            exporter
-                .export(Collections.singletonList(generateFakeTelemetry()))
-                .join(10, TimeUnit.SECONDS)
-                .isSuccess())
-        .isFalse();
-    LoggingEvent log =
-        logs.assertContains(
-            "Failed to export "
-                + type
-                + "s. Server responded with gRPC status code 5. Error message: クマ🐻");
-    assertThat(log.getLevel()).isEqualTo(Level.WARN);
+
+    TelemetryExporter<T> exporter = nonRetryingExporter();
+
+    try {
+      assertThat(
+              exporter
+                  .export(Collections.singletonList(generateFakeTelemetry()))
+                  .join(10, TimeUnit.SECONDS)
+                  .isSuccess())
+          .isFalse();
+      LoggingEvent log =
+          logs.assertContains(
+              "Failed to export "
+                  + type
+                  + "s. Server responded with gRPC status code 5. Error message: クマ🐻");
+      assertThat(log.getLevel()).isEqualTo(Level.WARN);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test
   @SuppressLogger(GrpcExporter.class)
   void testExport_Unavailable() {
     addGrpcError(14, null);
-    assertThat(
-            exporter
-                .export(Collections.singletonList(generateFakeTelemetry()))
-                .join(10, TimeUnit.SECONDS)
-                .isSuccess())
-        .isFalse();
-    LoggingEvent log =
-        logs.assertContains(
-            "Failed to export "
-                + type
-                + "s. Server is UNAVAILABLE. "
-                + "Make sure your collector is running and reachable from this network.");
-    assertThat(log.getLevel()).isEqualTo(Level.ERROR);
+
+    TelemetryExporter<T> exporter = nonRetryingExporter();
+
+    try {
+      assertThat(
+              exporter
+                  .export(Collections.singletonList(generateFakeTelemetry()))
+                  .join(10, TimeUnit.SECONDS)
+                  .isSuccess())
+          .isFalse();
+      LoggingEvent log =
+          logs.assertContains(
+              "Failed to export "
+                  + type
+                  + "s. Server is UNAVAILABLE. "
+                  + "Make sure your collector is running and reachable from this network.");
+      assertThat(log.getLevel()).isEqualTo(Level.ERROR);
+    } finally {
+      exporter.shutdown();
+    }
   }
 
   @Test
   @SuppressLogger(GrpcExporter.class)
   void testExport_Unimplemented() {
     addGrpcError(12, "UNIMPLEMENTED");
-    assertThat(
-            exporter
-                .export(Collections.singletonList(generateFakeTelemetry()))
-                .join(10, TimeUnit.SECONDS)
-                .isSuccess())
-        .isFalse();
-    String envVar;
-    switch (type) {
-      case "span":
-        envVar = "OTEL_TRACES_EXPORTER";
-        break;
-      case "metric":
-        envVar = "OTEL_METRICS_EXPORTER";
-        break;
-      case "log":
-        envVar = "OTEL_LOGS_EXPORTER";
-        break;
-      default:
-        throw new AssertionError();
+
+    TelemetryExporter<T> exporter = nonRetryingExporter();
+
+    try {
+      assertThat(
+              exporter
+                  .export(Collections.singletonList(generateFakeTelemetry()))
+                  .join(10, TimeUnit.SECONDS)
+                  .isSuccess())
+          .isFalse();
+      String envVar;
+      switch (type) {
+        case "span":
+          envVar = "OTEL_TRACES_EXPORTER";
+          break;
+        case "metric":
+          envVar = "OTEL_METRICS_EXPORTER";
+          break;
+        case "log":
+          envVar = "OTEL_LOGS_EXPORTER";
+          break;
+        default:
+          throw new AssertionError();
+      }
+      LoggingEvent log =
+          logs.assertContains(
+              "Failed to export "
+                  + type
+                  + "s. Server responded with UNIMPLEMENTED. "
+                  + "This usually means that your collector is not configured with an otlp "
+                  + "receiver in the \"pipelines\" section of the configuration. "
+                  + "If export is not desired and you are using OpenTelemetry autoconfiguration or the javaagent, "
+                  + "disable export by setting "
+                  + envVar
+                  + "=none. "
+                  + "Full error message: UNIMPLEMENTED");
+      assertThat(log.getLevel()).isEqualTo(Level.ERROR);
+    } finally {
+      exporter.shutdown();
     }
-    LoggingEvent log =
-        logs.assertContains(
-            "Failed to export "
-                + type
-                + "s. Server responded with UNIMPLEMENTED. "
-                + "This usually means that your collector is not configured with an otlp "
-                + "receiver in the \"pipelines\" section of the configuration. "
-                + "If export is not desired and you are using OpenTelemetry autoconfiguration or the javaagent, "
-                + "disable export by setting "
-                + envVar
-                + "=none. "
-                + "Full error message: UNIMPLEMENTED");
-    assertThat(log.getLevel()).isEqualTo(Level.ERROR);
   }
 
   @ParameterizedTest
@@ -644,18 +690,12 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   void retryableError(int code) {
     addGrpcError(code, null);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isTrue();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
 
     assertThat(attempts).hasValue(2);
   }
@@ -666,18 +706,12 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     addGrpcError(1, null);
     addGrpcError(1, null);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isFalse();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
 
     assertThat(attempts).hasValue(2);
   }
@@ -688,18 +722,12 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   void nonRetryableError(int code) {
     addGrpcError(code, null);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isFalse();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
 
     assertThat(attempts).hasValue(1);
   }
@@ -951,19 +979,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
         .collect(Collectors.toList());
   }
 
-  private TelemetryExporter<T> retryingExporter() {
-    return exporterBuilder()
-        .setEndpoint(server.httpUri().toString())
-        .setRetryPolicy(
-            RetryPolicy.builder()
-                .setMaxAttempts(2)
-                // We don't validate backoff time itself in these tests, just that retries
-                // occur. Keep the tests fast by using minimal backoff.
-                .setInitialBackoff(Duration.ofMillis(1))
-                .setMaxBackoff(Duration.ofMillis(1))
-                .setBackoffMultiplier(1)
-                .build())
-        .build();
+  private TelemetryExporter<T> nonRetryingExporter() {
+    return exporterBuilder().setEndpoint(server.httpUri().toString()).setRetryPolicy(null).build();
   }
 
   private static void addGrpcError(int code, @Nullable String message) {

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -937,10 +937,6 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
         .collect(Collectors.toList());
   }
 
-  private TelemetryExporter<T> nonRetryingExporter() {
-    return exporterBuilder().setEndpoint(server.httpUri() + path).setRetryPolicy(null).build();
-  }
-
   private static void addHttpError(int code) {
     httpErrors.add(HttpResponse.of(code));
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -223,7 +223,18 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
 
   @BeforeAll
   void setUp() {
-    exporter = exporterBuilder().setEndpoint(server.httpUri() + path).build();
+    //
+    exporter =
+        exporterBuilder()
+            .setEndpoint(server.httpUri() + path)
+            // We don't validate backoff time itself in these tests, just that retries
+            // occur. Keep the tests fast by using minimal backoff.
+            .setRetryPolicy(
+                RetryPolicy.getDefault().toBuilder()
+                    .setMaxAttempts(2)
+                    .setInitialBackoff(Duration.ofMillis(1))
+                    .build())
+            .build();
 
     // Sanity check that TLS files are in PEM format.
     assertThat(certificate.certificateFile())
@@ -518,6 +529,7 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
             // Connecting to a non-routable IP address to trigger connection error
             .setEndpoint("http://10.255.255.1")
             .setConnectTimeout(Duration.ofMillis(1))
+            .setRetryPolicy(null)
             .build();
     try {
       long startTimeMillis = System.currentTimeMillis();
@@ -598,18 +610,12 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
   void retryableError(int code) {
     addHttpError(code);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isTrue();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isTrue();
 
     assertThat(attempts).hasValue(2);
   }
@@ -620,18 +626,12 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
     addHttpError(502);
     addHttpError(502);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isFalse();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
 
     assertThat(attempts).hasValue(2);
   }
@@ -642,18 +642,12 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
   void nonRetryableError(int code) {
     addHttpError(code);
 
-    TelemetryExporter<T> exporter = retryingExporter();
-
-    try {
-      assertThat(
-              exporter
-                  .export(Collections.singletonList(generateFakeTelemetry()))
-                  .join(10, TimeUnit.SECONDS)
-                  .isSuccess())
-          .isFalse();
-    } finally {
-      exporter.shutdown();
-    }
+    assertThat(
+            exporter
+                .export(Collections.singletonList(generateFakeTelemetry()))
+                .join(10, TimeUnit.SECONDS)
+                .isSuccess())
+        .isFalse();
 
     assertThat(attempts).hasValue(1);
   }
@@ -943,19 +937,8 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
         .collect(Collectors.toList());
   }
 
-  private TelemetryExporter<T> retryingExporter() {
-    return exporterBuilder()
-        .setEndpoint(server.httpUri() + path)
-        .setRetryPolicy(
-            RetryPolicy.builder()
-                .setMaxAttempts(2)
-                // We don't validate backoff time itself in these tests, just that retries
-                // occur. Keep the tests fast by using minimal backoff.
-                .setInitialBackoff(Duration.ofMillis(1))
-                .setMaxBackoff(Duration.ofMillis(1))
-                .setBackoffMultiplier(1)
-                .build())
-        .build();
+  private TelemetryExporter<T> nonRetryingExporter() {
+    return exporterBuilder().setEndpoint(server.httpUri() + path).setRetryPolicy(null).build();
   }
 
   private static void addHttpError(int code) {

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcLogRecordExporterBuilderWrapper.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -100,7 +101,7 @@ final class GrpcLogRecordExporterBuilderWrapper implements TelemetryExporterBuil
   }
 
   @Override
-  public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcMetricExporterBuilderWrapper.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -100,7 +101,7 @@ final class GrpcMetricExporterBuilderWrapper implements TelemetryExporterBuilder
   }
 
   @Override
-  public TelemetryExporterBuilder<MetricData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<MetricData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/GrpcSpanExporterBuilderWrapper.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -101,7 +102,7 @@ final class GrpcSpanExporterBuilderWrapper implements TelemetryExporterBuilder<S
   }
 
   @Override
-  public TelemetryExporterBuilder<SpanData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<SpanData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpLogRecordExporterBuilderWrapper.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -102,7 +103,7 @@ public class HttpLogRecordExporterBuilderWrapper
   }
 
   @Override
-  public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<LogRecordData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpMetricExporterBuilderWrapper.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -101,7 +102,7 @@ public class HttpMetricExporterBuilderWrapper implements TelemetryExporterBuilde
   }
 
   @Override
-  public TelemetryExporterBuilder<MetricData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<MetricData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/HttpSpanExporterBuilderWrapper.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -101,7 +102,7 @@ public class HttpSpanExporterBuilderWrapper implements TelemetryExporterBuilder<
   }
 
   @Override
-  public TelemetryExporterBuilder<SpanData> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<SpanData> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     builder.setRetryPolicy(retryPolicy);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/ManagedChannelTelemetryExporterBuilder.java
@@ -134,8 +134,11 @@ public final class ManagedChannelTelemetryExporterBuilder<T>
   }
 
   @Override
-  public TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy) {
+  public TelemetryExporterBuilder<T> setRetryPolicy(@Nullable RetryPolicy retryPolicy) {
     delegate.setRetryPolicy(retryPolicy);
+    if (retryPolicy == null) {
+      return this;
+    }
     String grpcServiceName;
     if (delegate instanceof GrpcLogRecordExporterBuilderWrapper) {
       grpcServiceName = "opentelemetry.proto.collector.logs.v1.LogsService";

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporterBuilder.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 
@@ -59,7 +60,7 @@ public interface TelemetryExporterBuilder<T> {
 
   TelemetryExporterBuilder<T> setSslContext(SSLContext sslContext, X509TrustManager trustManager);
 
-  TelemetryExporterBuilder<T> setRetryPolicy(RetryPolicy retryPolicy);
+  TelemetryExporterBuilder<T> setRetryPolicy(@Nullable RetryPolicy retryPolicy);
 
   TelemetryExporterBuilder<T> setProxyOptions(ProxyOptions proxyOptions);
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
@@ -104,6 +104,7 @@ class OpenTelemetrySpanImpl extends Span
 
   @Override
   public void addLink(Link link) {
+    // TODO (jack-berg): Revisit now that adding links after creation is allowed
     LOGGER.warning("OpenTelemetry does not support links added after a span is created.");
   }
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetrySpanImpl.java
@@ -104,7 +104,6 @@ class OpenTelemetrySpanImpl extends Span
 
   @Override
   public void addLink(Link link) {
-    // TODO (jack-berg): Revisit now that adding links after creation is allowed
     LOGGER.warning("OpenTelemetry does not support links added after a span is created.");
   }
 


### PR DESCRIPTION
Resolves #5641.

- Changes all `OtlpHttp{Signal}Exporter`s and `OtlpGrpc{Signal}Exporter`s to enable retry by default.
- Adds new `otel.java.exporter.otlp.retry.disabled` (defaults to false) property to superseed `otel.experimental.java.exporter.otlp.retry.enabled` (defaults to true). The old property will be retained for some time for backwards compatibility.

Context:

- OTLP retry has been around years in this project and the programmatic configuration has been stable since july 2023.
- My employer (New Relic) has recommended it for production use for that entire time without any reports of issues
- The [spec mandates](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#retry) retrying transient errors with a retry strategy. By defaulting to not retrying, I believe we've technically been non-compliant this whole time. This was justified by the desire to wait for some additional emerging standard describing more details about how that retry strategy should work. I now believe its impossible to unify the implementations with a common algorithm and options, since there are many stable implementations with different designs.
- The moratorium on new env vars and the progress of file config means its unlikely that a new env var is going to be introduced to replace out experimental `otel.experimental.java.exporter.otlp.retry.enabled`. We can't remove this property because users rely on it, so we might as well embrace it and introduce a stable java-specific property. The new name `otel.java.exporter.otlp.retry.disabled` aligns with [spec naming](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#boolean-value) for booleans "All Boolean environment variables SHOULD be named and defined such that false is the expected safe default behavior".