### PR TITLE
Remove nullable from file config Factory contract

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/FileConfigurationTest.java
@@ -17,11 +17,7 @@ import static org.mockito.Mockito.verify;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.incubator.events.GlobalEventLoggerProvider;
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
-import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -91,11 +87,6 @@ class FileConfigurationTest {
                         Resource.getDefault().toBuilder().put("service.name", "test").build())
                     .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
                     .build())
-            .setPropagators(
-                ContextPropagators.create(
-                    TextMapPropagator.composite(
-                        W3CTraceContextPropagator.getInstance(),
-                        W3CBaggagePropagator.getInstance())))
             .build();
     cleanup.addCloseable(expectedSdk);
     AutoConfiguredOpenTelemetrySdkBuilder builder = spy(AutoConfiguredOpenTelemetrySdk.builder());

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactory.java
@@ -12,7 +12,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Base2E
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExplicitBucketHistogram;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class AggregationFactory
     implements Factory<Aggregation, io.opentelemetry.sdk.metrics.Aggregation> {
@@ -27,11 +26,7 @@ final class AggregationFactory
 
   @Override
   public io.opentelemetry.sdk.metrics.Aggregation create(
-      @Nullable Aggregation model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null) {
-      return io.opentelemetry.sdk.metrics.Aggregation.defaultAggregation();
-    }
-
+      Aggregation model, SpiHelper spiHelper, List<Closeable> closeables) {
     if (model.getDrop() != null) {
       return io.opentelemetry.sdk.metrics.Aggregation.drop();
     }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributesFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributesFactory.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Attributes;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class AttributesFactory
     implements Factory<Attributes, io.opentelemetry.api.common.Attributes> {
@@ -29,11 +28,7 @@ final class AttributesFactory
 
   @Override
   public io.opentelemetry.api.common.Attributes create(
-      @Nullable Attributes model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null) {
-      return io.opentelemetry.api.common.Attributes.empty();
-    }
-
+      Attributes model, SpiHelper spiHelper, List<Closeable> closeables) {
     AttributesBuilder builder = io.opentelemetry.api.common.Attributes.builder();
 
     String serviceName = model.getServiceName();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/Factory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/Factory.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 interface Factory<ModelT, ResultT> {
 
@@ -20,5 +19,5 @@ interface Factory<ModelT, ResultT> {
    * @param closeables mutable list of closeables created
    * @return the {@link ResultT}
    */
-  ResultT create(@Nullable ModelT model, SpiHelper spiHelper, List<Closeable> closeables);
+  ResultT create(ModelT model, SpiHelper spiHelper, List<Closeable> closeables);
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigUtil.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigUtil.java
@@ -34,6 +34,13 @@ final class FileConfigUtil {
     return object;
   }
 
+  static <T> T requireNonNull(@Nullable T object, String description) {
+    if (object == null) {
+      throw new ConfigurationException(description + " is required but is null");
+    }
+    return object;
+  }
+
   /**
    * Find a registered {@link ComponentProvider} which {@link ComponentProvider#getType()} matching
    * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactory.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.metrics.InstrumentSelectorBuilder;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class InstrumentSelectorFactory implements Factory<Selector, InstrumentSelector> {
 
@@ -27,11 +26,7 @@ final class InstrumentSelectorFactory implements Factory<Selector, InstrumentSel
 
   @Override
   public InstrumentSelector create(
-      @Nullable Selector model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null) {
-      throw new ConfigurationException("selector must not be null");
-    }
-
+      Selector model, SpiHelper spiHelper, List<Closeable> closeables) {
     InstrumentSelectorBuilder builder = InstrumentSelector.builder();
     if (model.getInstrumentName() != null) {
       builder.setName(model.getInstrumentName());

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
@@ -12,7 +12,6 @@ import io.opentelemetry.sdk.logs.LogLimits;
 import io.opentelemetry.sdk.logs.LogLimitsBuilder;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class LogLimitsFactory implements Factory<LogRecordLimitsAndAttributeLimits, LogLimits> {
 
@@ -26,12 +25,7 @@ final class LogLimitsFactory implements Factory<LogRecordLimitsAndAttributeLimit
 
   @Override
   public LogLimits create(
-      @Nullable LogRecordLimitsAndAttributeLimits model,
-      SpiHelper spiHelper,
-      List<Closeable> closeables) {
-    if (model == null) {
-      return LogLimits.getDefault();
-    }
+      LogRecordLimitsAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
     LogLimitsBuilder builder = LogLimits.builder();
 
     AttributeLimits attributeLimitsModel = model.getAttributeLimits();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
@@ -19,7 +19,6 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 final class LogRecordExporterFactory
     implements Factory<
@@ -36,15 +35,9 @@ final class LogRecordExporterFactory
 
   @Override
   public LogRecordExporter create(
-      @Nullable
-          io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporter
-              model,
+      io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporter model,
       SpiHelper spiHelper,
       List<Closeable> closeables) {
-    if (model == null) {
-      return LogRecordExporter.composite();
-    }
-
     Otlp otlpModel = model.getOtlp();
     if (otlpModel != null) {
       return FileConfigUtil.addAndReturn(closeables, createOtlpExporter(otlpModel, spiHelper));
@@ -55,9 +48,9 @@ final class LogRecordExporterFactory
       throw new ConfigurationException(
           "Unrecognized log record exporter(s): "
               + model.getAdditionalProperties().keySet().stream().collect(joining(",", "[", "]")));
+    } else {
+      throw new ConfigurationException("log exporter must be set");
     }
-
-    return LogRecordExporter.composite();
   }
 
   private static LogRecordExporter createOtlpExporter(Otlp otlp, SpiHelper spiHelper) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactory.java
@@ -13,7 +13,6 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class LoggerProviderFactory
     implements Factory<LoggerProviderAndAttributeLimits, SdkLoggerProviderBuilder> {
@@ -28,13 +27,9 @@ final class LoggerProviderFactory
 
   @Override
   public SdkLoggerProviderBuilder create(
-      @Nullable LoggerProviderAndAttributeLimits model,
-      SpiHelper spiHelper,
-      List<Closeable> closeables) {
+      LoggerProviderAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
     SdkLoggerProviderBuilder builder = SdkLoggerProvider.builder();
-    if (model == null) {
-      return builder;
-    }
+
     LoggerProvider loggerProviderModel = model.getLoggerProvider();
     if (loggerProviderModel == null) {
       return builder;

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 final class MetricExporterFactory
     implements Factory<
@@ -35,18 +34,11 @@ final class MetricExporterFactory
     return INSTANCE;
   }
 
-  @SuppressWarnings("NullAway") // Override superclass non-null response
   @Override
-  @Nullable
   public MetricExporter create(
-      @Nullable
-          io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricExporter model,
+      io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricExporter model,
       SpiHelper spiHelper,
       List<Closeable> closeables) {
-    if (model == null) {
-      return null;
-    }
-
     OtlpMetric otlpModel = model.getOtlp();
     if (otlpModel != null) {
       return FileConfigUtil.addAndReturn(closeables, createOtlpExporter(otlpModel, spiHelper));
@@ -65,9 +57,9 @@ final class MetricExporterFactory
       throw new ConfigurationException(
           "Unrecognized metric exporter(s): "
               + model.getAdditionalProperties().keySet().stream().collect(joining(",", "[", "]")));
+    } else {
+      throw new ConfigurationException("metric exporter must be set");
     }
-
-    return null;
   }
 
   private static MetricExporter createOtlpExporter(OtlpMetric model, SpiHelper spiHelper) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
+import static io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfigUtil.requireNonNull;
+
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricExporter;
@@ -16,7 +18,6 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class MetricReaderFactory
     implements Factory<
@@ -31,29 +32,17 @@ final class MetricReaderFactory
     return INSTANCE;
   }
 
-  @SuppressWarnings("NullAway") // Override superclass non-null response
   @Override
-  @Nullable
   public MetricReader create(
-      @Nullable
-          io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricReader model,
+      io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricReader model,
       SpiHelper spiHelper,
       List<Closeable> closeables) {
-    if (model == null) {
-      return null;
-    }
-
     PeriodicMetricReader periodicModel = model.getPeriodic();
     if (periodicModel != null) {
-      MetricExporter exporterModel = periodicModel.getExporter();
-      if (exporterModel == null) {
-        throw new ConfigurationException("exporter required for periodic reader");
-      }
+      MetricExporter exporterModel =
+          requireNonNull(periodicModel.getExporter(), "periodic metric reader exporter");
       io.opentelemetry.sdk.metrics.export.MetricExporter metricExporter =
           MetricExporterFactory.getInstance().create(exporterModel, spiHelper, closeables);
-      if (metricExporter == null) {
-        return null;
-      }
       PeriodicMetricReaderBuilder builder =
           io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.builder(
               FileConfigUtil.addAndReturn(closeables, metricExporter));
@@ -65,10 +54,8 @@ final class MetricReaderFactory
 
     PullMetricReader pullModel = model.getPull();
     if (pullModel != null) {
-      MetricExporter exporterModel = pullModel.getExporter();
-      if (exporterModel == null) {
-        throw new ConfigurationException("exporter required for pull reader");
-      }
+      MetricExporter exporterModel =
+          requireNonNull(pullModel.getExporter(), "pull metric reader exporter");
       Prometheus prometheusModel = exporterModel.getPrometheus();
       if (prometheusModel != null) {
         MetricReader metricReader =
@@ -80,6 +67,6 @@ final class MetricReaderFactory
       throw new ConfigurationException("prometheus is the only currently supported pull reader");
     }
 
-    return null;
+    throw new ConfigurationException("reader must be set");
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 final class OpenTelemetryConfigurationFactory
     implements Factory<OpenTelemetryConfiguration, OpenTelemetrySdk> {
@@ -30,12 +29,8 @@ final class OpenTelemetryConfigurationFactory
 
   @Override
   public OpenTelemetrySdk create(
-      @Nullable OpenTelemetryConfiguration model, SpiHelper spiHelper, List<Closeable> closeables) {
+      OpenTelemetryConfiguration model, SpiHelper spiHelper, List<Closeable> closeables) {
     OpenTelemetrySdkBuilder builder = OpenTelemetrySdk.builder();
-    if (model == null) {
-      return FileConfigUtil.addAndReturn(closeables, builder.build());
-    }
-
     if (!"0.1".equals(model.getFileFormat())) {
       throw new ConfigurationException("Unsupported file format. Supported formats include: 0.1");
     }
@@ -44,11 +39,15 @@ final class OpenTelemetryConfigurationFactory
       return builder.build();
     }
 
-    builder.setPropagators(
-        PropagatorFactory.getInstance().create(model.getPropagator(), spiHelper, closeables));
+    if (model.getPropagator() != null) {
+      builder.setPropagators(
+          PropagatorFactory.getInstance().create(model.getPropagator(), spiHelper, closeables));
+    }
 
-    Resource resource =
-        ResourceFactory.getInstance().create(model.getResource(), spiHelper, closeables);
+    Resource resource = Resource.getDefault();
+    if (model.getResource() != null) {
+      resource = ResourceFactory.getInstance().create(model.getResource(), spiHelper, closeables);
+    }
 
     if (model.getLoggerProvider() != null) {
       builder.setLoggerProvider(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactory.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
+import static io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfigUtil.requireNonNull;
+
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Propagator;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class PropagatorFactory implements Factory<Propagator, ContextPropagators> {
 
@@ -25,11 +26,8 @@ final class PropagatorFactory implements Factory<Propagator, ContextPropagators>
 
   @Override
   public ContextPropagators create(
-      @Nullable Propagator model, SpiHelper spiHelper, List<Closeable> closeables) {
-    List<String> compositeModel = null;
-    if (model != null) {
-      compositeModel = model.getComposite();
-    }
+      Propagator model, SpiHelper spiHelper, List<Closeable> closeables) {
+    List<String> compositeModel = requireNonNull(model.getComposite(), "composite propagator");
     TextMapPropagator textMapPropagator =
         TextMapPropagatorFactory.getInstance().create(compositeModel, spiHelper, closeables);
     return ContextPropagators.create(textMapPropagator);

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
@@ -11,7 +11,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Resour
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class ResourceFactory implements Factory<Resource, io.opentelemetry.sdk.resources.Resource> {
 
@@ -25,11 +24,7 @@ final class ResourceFactory implements Factory<Resource, io.opentelemetry.sdk.re
 
   @Override
   public io.opentelemetry.sdk.resources.Resource create(
-      @Nullable Resource model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null) {
-      return io.opentelemetry.sdk.resources.Resource.getDefault();
-    }
-
+      Resource model, SpiHelper spiHelper, List<Closeable> closeables) {
     ResourceBuilder builder = io.opentelemetry.sdk.resources.Resource.getDefault().toBuilder();
 
     Attributes attributesModel = model.getAttributes();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 final class SamplerFactory
     implements Factory<
@@ -39,13 +38,9 @@ final class SamplerFactory
 
   @Override
   public Sampler create(
-      @Nullable io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Sampler model,
+      io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Sampler model,
       SpiHelper spiHelper,
       List<Closeable> closeables) {
-    if (model == null) {
-      return Sampler.parentBased(Sampler.alwaysOn());
-    }
-
     if (model.getAlwaysOn() != null) {
       return Sampler.alwaysOn();
     }
@@ -121,9 +116,9 @@ final class SamplerFactory
       throw new ConfigurationException(
           "Unrecognized sampler(s): "
               + model.getAdditionalProperties().keySet().stream().collect(joining(",", "[", "]")));
+    } else {
+      throw new ConfigurationException("sampler must be set");
     }
-
-    return Sampler.parentBased(Sampler.alwaysOn());
   }
 
   private static NamedSpiManager<Sampler> samplerSpiManager(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 final class SpanExporterFactory
     implements Factory<
@@ -38,14 +37,9 @@ final class SpanExporterFactory
 
   @Override
   public SpanExporter create(
-      @Nullable
-          io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporter model,
+      io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporter model,
       SpiHelper spiHelper,
       List<Closeable> closeables) {
-    if (model == null) {
-      return SpanExporter.composite();
-    }
-
     Otlp otlpModel = model.getOtlp();
     if (otlpModel != null) {
       return FileConfigUtil.addAndReturn(closeables, createOtlpExporter(otlpModel, spiHelper));
@@ -65,9 +59,9 @@ final class SpanExporterFactory
       throw new ConfigurationException(
           "Unrecognized span exporter(s): "
               + model.getAdditionalProperties().keySet().stream().collect(joining(",", "[", "]")));
+    } else {
+      throw new ConfigurationException("span exporter must be set");
     }
-
-    return SpanExporter.composite();
   }
 
   private static SpanExporter createOtlpExporter(Otlp model, SpiHelper spiHelper) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
@@ -11,7 +11,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLi
 import io.opentelemetry.sdk.trace.SpanLimitsBuilder;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class SpanLimitsFactory
     implements Factory<SpanLimitsAndAttributeLimits, io.opentelemetry.sdk.trace.SpanLimits> {
@@ -26,13 +25,7 @@ final class SpanLimitsFactory
 
   @Override
   public io.opentelemetry.sdk.trace.SpanLimits create(
-      @Nullable SpanLimitsAndAttributeLimits model,
-      SpiHelper spiHelper,
-      List<Closeable> closeables) {
-    if (model == null) {
-      return io.opentelemetry.sdk.trace.SpanLimits.getDefault();
-    }
-
+      SpanLimitsAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
     SpanLimitsBuilder builder = io.opentelemetry.sdk.trace.SpanLimits.builder();
 
     AttributeLimits attributeLimitsModel = model.getAttributeLimits();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactory.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 final class TextMapPropagatorFactory implements Factory<List<String>, TextMapPropagator> {
 
@@ -33,8 +32,8 @@ final class TextMapPropagatorFactory implements Factory<List<String>, TextMapPro
 
   @Override
   public TextMapPropagator create(
-      @Nullable List<String> model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null || model.isEmpty()) {
+      List<String> model, SpiHelper spiHelper, List<Closeable> closeables) {
+    if (model.isEmpty()) {
       model = Arrays.asList("tracecontext", "baggage");
     }
 

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactory.java
@@ -14,7 +14,6 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.Closeable;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class TracerProviderFactory
     implements Factory<TracerProviderAndAttributeLimits, SdkTracerProviderBuilder> {
@@ -29,13 +28,8 @@ final class TracerProviderFactory
 
   @Override
   public SdkTracerProviderBuilder create(
-      @Nullable TracerProviderAndAttributeLimits model,
-      SpiHelper spiHelper,
-      List<Closeable> closeables) {
+      TracerProviderAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
     SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
-    if (model == null) {
-      return builder;
-    }
     TracerProvider tracerProviderModel = model.getTracerProvider();
     if (tracerProviderModel == null) {
       return builder;
@@ -50,10 +44,12 @@ final class TracerProviderFactory
                 closeables);
     builder.setSpanLimits(spanLimits);
 
-    Sampler sampler =
-        SamplerFactory.getInstance()
-            .create(tracerProviderModel.getSampler(), spiHelper, closeables);
-    builder.setSampler(sampler);
+    if (tracerProviderModel.getSampler() != null) {
+      Sampler sampler =
+          SamplerFactory.getInstance()
+              .create(tracerProviderModel.getSampler(), spiHelper, closeables);
+      builder.setSampler(sampler);
+    }
 
     List<SpanProcessor> processors = tracerProviderModel.getProcessors();
     if (processors != null) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactory.java
@@ -6,14 +6,12 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Stream;
 import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.metrics.ViewBuilder;
 import java.io.Closeable;
 import java.util.HashSet;
 import java.util.List;
-import javax.annotation.Nullable;
 
 final class ViewFactory implements Factory<Stream, View> {
 
@@ -26,11 +24,7 @@ final class ViewFactory implements Factory<Stream, View> {
   }
 
   @Override
-  public View create(@Nullable Stream model, SpiHelper spiHelper, List<Closeable> closeables) {
-    if (model == null) {
-      throw new ConfigurationException("stream must not be null");
-    }
-
+  public View create(Stream model, SpiHelper spiHelper, List<Closeable> closeables) {
     ViewBuilder builder = View.builder();
     if (model.getName() != null) {
       builder.setName(model.getName());

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactoryTest.java
@@ -17,23 +17,12 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LastVa
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Sum;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AggregationFactoryTest {
-
-  @Test
-  void create_Null() {
-    assertThat(
-            AggregationFactory.getInstance()
-                .create(null, mock(SpiHelper.class), Collections.emptyList())
-                .toString())
-        .isEqualTo(io.opentelemetry.sdk.metrics.Aggregation.defaultAggregation().toString());
-  }
 
   @ParameterizedTest
   @MethodSource("createTestCases")

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributesFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributesFactoryTest.java
@@ -22,14 +22,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class AttributesFactoryTest {
 
-  @Test
-  void create_Null() {
-    assertThat(
-            AttributesFactory.getInstance()
-                .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(io.opentelemetry.api.common.Attributes.empty());
-  }
-
   @ParameterizedTest
   @MethodSource("invalidAttributes")
   void create_InvalidAttributes(Attributes model, String expectedMessage) {

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactoryTest.java
@@ -20,16 +20,6 @@ import org.junit.jupiter.api.Test;
 class InstrumentSelectorFactoryTest {
 
   @Test
-  void create_Null() {
-    assertThatThrownBy(
-            () ->
-                InstrumentSelectorFactory.getInstance()
-                    .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessage("selector must not be null");
-  }
-
-  @Test
   void create_Defaults() {
     assertThatThrownBy(
             () ->

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
@@ -31,7 +31,6 @@ class LogLimitsFactoryTest {
 
   private static Stream<Arguments> createArguments() {
     return Stream.of(
-        Arguments.of(null, LogLimits.builder().build()),
         Arguments.of(
             LogRecordLimitsAndAttributeLimits.create(null, null), LogLimits.builder().build()),
         Arguments.of(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
@@ -57,16 +57,6 @@ class LogRecordExporterFactoryTest {
       SpiHelper.create(LogRecordExporterFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    LogRecordExporter expectedExporter = LogRecordExporter.composite();
-
-    LogRecordExporter exporter =
-        LogRecordExporterFactory.getInstance().create(null, spiHelper, new ArrayList<>());
-
-    assertThat(exporter.toString()).isEqualTo(expectedExporter.toString());
-  }
-
-  @Test
   void create_OtlpDefaults() {
     spiHelper = spy(spiHelper);
     List<Closeable> closeables = new ArrayList<>();

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
@@ -34,33 +34,16 @@ class LogRecordProcessorFactoryTest {
       SpiHelper.create(LogRecordProcessorFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.logs.LogRecordProcessor processor =
-        LogRecordProcessorFactory.getInstance().create(null, spiHelper, Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.logs.LogRecordProcessor.composite().toString());
-  }
-
-  @Test
   void create_BatchNullExporter() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.logs.LogRecordProcessor processor =
-        LogRecordProcessorFactory.getInstance()
-            .create(
-                new LogRecordProcessor().withBatch(new BatchLogRecordProcessor()),
-                spiHelper,
-                Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.logs.LogRecordProcessor.composite().toString());
+    assertThatThrownBy(
+            () ->
+                LogRecordProcessorFactory.getInstance()
+                    .create(
+                        new LogRecordProcessor().withBatch(new BatchLogRecordProcessor()),
+                        spiHelper,
+                        Collections.emptyList()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("batch log record processor exporter is required but is null");
   }
 
   @Test
@@ -119,19 +102,15 @@ class LogRecordProcessorFactoryTest {
 
   @Test
   void create_SimpleNullExporter() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.logs.LogRecordProcessor processor =
-        LogRecordProcessorFactory.getInstance()
-            .create(
-                new LogRecordProcessor().withSimple(new SimpleLogRecordProcessor()),
-                spiHelper,
-                Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.logs.LogRecordProcessor.composite().toString());
+    assertThatThrownBy(
+            () ->
+                LogRecordProcessorFactory.getInstance()
+                    .create(
+                        new LogRecordProcessor().withSimple(new SimpleLogRecordProcessor()),
+                        spiHelper,
+                        Collections.emptyList()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("simple log record processor exporter is required but is null");
   }
 
   @Test

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
@@ -52,7 +52,6 @@ class LoggerProviderFactoryTest {
 
   private static Stream<Arguments> createArguments() {
     return Stream.of(
-        Arguments.of(null, SdkLoggerProvider.builder().build()),
         Arguments.of(
             LoggerProviderAndAttributeLimits.create(null, null),
             SdkLoggerProvider.builder().build()),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
@@ -35,20 +35,6 @@ class MeterProviderFactoryTest {
       SpiHelper.create(MeterProviderFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    List<Closeable> closeables = new ArrayList<>();
-    SdkMeterProvider expectedProvider = SdkMeterProvider.builder().build();
-    cleanup.addCloseable(expectedProvider);
-
-    SdkMeterProvider provider =
-        MeterProviderFactory.getInstance().create(null, spiHelper, closeables).build();
-    cleanup.addCloseable(provider);
-    cleanup.addCloseables(closeables);
-
-    assertThat(provider.toString()).isEqualTo(expectedProvider.toString());
-  }
-
-  @Test
   void create_Defaults() {
     List<Closeable> closeables = new ArrayList<>();
     SdkMeterProvider expectedProvider = SdkMeterProvider.builder().build();

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
@@ -64,12 +64,6 @@ class MetricExporterFactoryTest {
   private SpiHelper spiHelper = SpiHelper.create(MetricExporterFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    assertThat(MetricExporterFactory.getInstance().create(null, spiHelper, new ArrayList<>()))
-        .isNull();
-  }
-
-  @Test
   void create_OtlpDefaults() {
     spiHelper = spy(spiHelper);
     List<Closeable> closeables = new ArrayList<>();

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactoryTest.java
@@ -44,12 +44,6 @@ class MetricReaderFactoryTest {
   private SpiHelper spiHelper = SpiHelper.create(MetricReaderFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    assertThat(MetricReaderFactory.getInstance().create(null, spiHelper, Collections.emptyList()))
-        .isNull();
-  }
-
-  @Test
   void create_PeriodicNullExporter() {
     assertThatThrownBy(
             () ->
@@ -59,7 +53,7 @@ class MetricReaderFactoryTest {
                         spiHelper,
                         Collections.emptyList()))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("exporter required for periodic reader");
+        .hasMessage("periodic metric reader exporter is required but is null");
   }
 
   @Test
@@ -181,7 +175,7 @@ class MetricReaderFactoryTest {
                         spiHelper,
                         Collections.emptyList()))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("exporter required for pull reader");
+        .hasMessage("pull metric reader exporter is required but is null");
 
     assertThatThrownBy(
             () ->

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -70,20 +70,6 @@ class OpenTelemetryConfigurationFactoryTest {
       SpiHelper.create(OpenTelemetryConfigurationFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    List<Closeable> closeables = new ArrayList<>();
-    OpenTelemetrySdk expectedSdk = OpenTelemetrySdk.builder().build();
-    cleanup.addCloseable(expectedSdk);
-
-    OpenTelemetrySdk sdk =
-        OpenTelemetryConfigurationFactory.getInstance().create(null, spiHelper, closeables);
-    cleanup.addCloseable(sdk);
-    cleanup.addCloseables(closeables);
-
-    assertThat(sdk.toString()).isEqualTo(expectedSdk.toString());
-  }
-
-  @Test
   void create_InvalidFileFormat() {
     List<OpenTelemetryConfiguration> testCases =
         Arrays.asList(
@@ -104,14 +90,7 @@ class OpenTelemetryConfigurationFactoryTest {
   @Test
   void create_Defaults() {
     List<Closeable> closeables = new ArrayList<>();
-    OpenTelemetrySdk expectedSdk =
-        OpenTelemetrySdk.builder()
-            .setPropagators(
-                ContextPropagators.create(
-                    TextMapPropagator.composite(
-                        W3CTraceContextPropagator.getInstance(),
-                        W3CBaggagePropagator.getInstance())))
-            .build();
+    OpenTelemetrySdk expectedSdk = OpenTelemetrySdk.builder().build();
     cleanup.addCloseable(expectedSdk);
 
     OpenTelemetrySdk sdk =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactoryTest.java
@@ -40,11 +40,6 @@ class PropagatorFactoryTest {
   private static Stream<Arguments> createArguments() {
     return Stream.of(
         Arguments.of(
-            null,
-            ContextPropagators.create(
-                TextMapPropagator.composite(
-                    W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()))),
-        Arguments.of(
             new Propagator()
                 .withComposite(
                     Arrays.asList("tracecontext", "baggage", "ottrace", "b3multi", "b3", "jaeger")),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
@@ -17,14 +17,6 @@ import org.junit.jupiter.api.Test;
 class ResourceFactoryTest {
 
   @Test
-  void create_Null() {
-    assertThat(
-            ResourceFactory.getInstance()
-                .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isEqualTo(Resource.getDefault());
-  }
-
-  @Test
   void create() {
     assertThat(
             ResourceFactory.getInstance()

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
@@ -61,10 +61,6 @@ class SamplerFactoryTest {
   private static Stream<Arguments> createArguments() {
     return Stream.of(
         Arguments.of(
-            null,
-            io.opentelemetry.sdk.trace.samplers.Sampler.parentBased(
-                io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn())),
-        Arguments.of(
             new Sampler().withAlwaysOn(new AlwaysOn()),
             io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn()),
         Arguments.of(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
@@ -32,7 +32,6 @@ class SpanLimitsFactoryTest {
 
   private static Stream<Arguments> createArguments() {
     return Stream.of(
-        Arguments.of(null, io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
         Arguments.of(
             SpanLimitsAndAttributeLimits.create(null, null),
             io.opentelemetry.sdk.trace.SpanLimits.getDefault()),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanProcessorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanProcessorFactoryTest.java
@@ -34,33 +34,16 @@ class SpanProcessorFactoryTest {
       SpiHelper.create(SpanProcessorFactoryTest.class.getClassLoader());
 
   @Test
-  void create_Null() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.trace.SpanProcessor processor =
-        SpanProcessorFactory.getInstance().create(null, spiHelper, Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.trace.SpanProcessor.composite().toString());
-  }
-
-  @Test
   void create_BatchNullExporter() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.trace.SpanProcessor processor =
-        SpanProcessorFactory.getInstance()
-            .create(
-                new SpanProcessor().withBatch(new BatchSpanProcessor()),
-                spiHelper,
-                Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.trace.SpanProcessor.composite().toString());
+    assertThatThrownBy(
+            () ->
+                SpanProcessorFactory.getInstance()
+                    .create(
+                        new SpanProcessor().withBatch(new BatchSpanProcessor()),
+                        spiHelper,
+                        Collections.emptyList()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("batch span processor exporter is required but is null");
   }
 
   @Test
@@ -119,19 +102,15 @@ class SpanProcessorFactoryTest {
 
   @Test
   void create_SimpleNullExporter() {
-    List<Closeable> closeables = new ArrayList<>();
-
-    io.opentelemetry.sdk.trace.SpanProcessor processor =
-        SpanProcessorFactory.getInstance()
-            .create(
-                new SpanProcessor().withSimple(new SimpleSpanProcessor()),
-                spiHelper,
-                Collections.emptyList());
-    cleanup.addCloseable(processor);
-    cleanup.addCloseables(closeables);
-
-    assertThat(processor.toString())
-        .isEqualTo(io.opentelemetry.sdk.trace.SpanProcessor.composite().toString());
+    assertThatThrownBy(
+            () ->
+                SpanProcessorFactory.getInstance()
+                    .create(
+                        new SpanProcessor().withSimple(new SimpleSpanProcessor()),
+                        spiHelper,
+                        Collections.emptyList()))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("simple span processor exporter is required but is null");
   }
 
   @Test

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactoryTest.java
@@ -42,10 +42,6 @@ class TextMapPropagatorFactoryTest {
   private static Stream<Arguments> createArguments() {
     return Stream.of(
         Arguments.of(
-            null,
-            TextMapPropagator.composite(
-                W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance())),
-        Arguments.of(
             Collections.emptyList(),
             TextMapPropagator.composite(
                 W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance())),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
@@ -54,7 +54,6 @@ class TracerProviderFactoryTest {
 
   private static Stream<Arguments> createArguments() {
     return Stream.of(
-        Arguments.of(null, SdkTracerProvider.builder().build()),
         Arguments.of(
             TracerProviderAndAttributeLimits.create(null, null),
             SdkTracerProvider.builder().build()),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactoryTest.java
@@ -6,11 +6,9 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Aggregation;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExplicitBucketHistogram;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Stream;
@@ -21,16 +19,6 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 class ViewFactoryTest {
-
-  @Test
-  void create_Null() {
-    assertThatThrownBy(
-            () ->
-                ViewFactory.getInstance()
-                    .create(null, mock(SpiHelper.class), Collections.emptyList()))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessage("stream must not be null");
-  }
 
   @Test
   void create_Defaults() {


### PR DESCRIPTION
Originally I reached a misguided conclusion that the file config [Factory]() interface needed its model argument to be nullable. This PR fixes that, simplifying the implementation quite a bit in the process.

Originally discussed here: https://github.com/open-telemetry/opentelemetry-java/pull/6493#discussion_r1677021374