### PR TITLE
Retry ConnectException, add retry logging

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
@@ -149,8 +149,7 @@ public final class RetryInterceptor implements Interceptor {
     if (e instanceof SocketTimeoutException) {
       String message = e.getMessage();
       // Connect timeouts can produce SocketTimeoutExceptions with no message, or with "connect
-      // timed
-      // out"
+      // timed out"
       return message == null || message.toLowerCase(Locale.ROOT).contains("connect timed out");
     } else if (e instanceof ConnectException) {
       // Exceptions resemble: java.net.ConnectException: Failed to connect to

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
@@ -5,13 +5,19 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
+import static java.util.stream.Collectors.joining;
+
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Locale;
+import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
@@ -22,6 +28,8 @@ import okhttp3.Response;
  * at any time.
  */
 public final class RetryInterceptor implements Interceptor {
+
+  private static final Logger logger = Logger.getLogger(RetryInterceptor.class.getName());
 
   private final RetryPolicy retryPolicy;
   private final Function<Response, Boolean> isRetryable;
@@ -84,12 +92,39 @@ public final class RetryInterceptor implements Interceptor {
       } catch (IOException e) {
         exception = e;
       }
-      if (response != null && !Boolean.TRUE.equals(isRetryable.apply(response))) {
-        return response;
+      if (response != null) {
+        boolean retryable = Boolean.TRUE.equals(isRetryable.apply(response));
+        if (logger.isLoggable(Level.FINER)) {
+          logger.log(
+              Level.FINER,
+              "Attempt "
+                  + attempt
+                  + " returned "
+                  + (retryable ? "retryable" : "non-retryable")
+                  + " response: "
+                  + responseStringRepresentation(response));
+        }
+        if (!retryable) {
+          return response;
+        }
       }
-      if (exception != null && !Boolean.TRUE.equals(isRetryableException.apply(exception))) {
-        throw exception;
+      if (exception != null) {
+        boolean retryable = Boolean.TRUE.equals(isRetryableException.apply(exception));
+        if (logger.isLoggable(Level.FINER)) {
+          logger.log(
+              Level.FINER,
+              "Attempt "
+                  + attempt
+                  + " failed with "
+                  + (retryable ? "retryable" : "non-retryable")
+                  + " exception",
+              exception);
+        }
+        if (!retryable) {
+          throw exception;
+        }
       }
+
     } while (attempt < retryPolicy.getMaxAttempts());
 
     if (response != null) {
@@ -98,15 +133,31 @@ public final class RetryInterceptor implements Interceptor {
     throw exception;
   }
 
+  private static String responseStringRepresentation(Response response) {
+    StringJoiner joiner = new StringJoiner(",", "Response{", "}");
+    joiner.add("code=" + response.code());
+    joiner.add(
+        "headers="
+            + response.headers().toMultimap().entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + String.join(",", entry.getValue()))
+                .collect(joining(",", "[", "]")));
+    return joiner.toString();
+  }
+
   // Visible for testing
   static boolean isRetryableException(IOException e) {
-    if (!(e instanceof SocketTimeoutException)) {
-      return false;
+    if (e instanceof SocketTimeoutException) {
+      String message = e.getMessage();
+      // Connect timeouts can produce SocketTimeoutExceptions with no message, or with "connect
+      // timed
+      // out"
+      return message == null || message.toLowerCase(Locale.ROOT).contains("connect timed out");
+    } else if (e instanceof ConnectException) {
+      // Exceptions resemble: java.net.ConnectException: Failed to connect to
+      // localhost/[0:0:0:0:0:0:0:1]:62611
+      return true;
     }
-    String message = e.getMessage();
-    // Connect timeouts can produce SocketTimeoutExceptions with no message, or with "connect timed
-    // out"
-    return message == null || message.toLowerCase(Locale.ROOT).contains("connect timed out");
+    return false;
   }
 
   // Visible for testing

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
@@ -23,6 +23,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -155,6 +157,34 @@ class RetryInterceptorTest {
     verify(isRetryableException, times(5)).apply(any());
     // Should retry maxAttempts, and sleep maxAttempts - 1 times
     verify(sleeper, times(4)).sleep(anyLong());
+  }
+
+  @Test
+  void connectException() throws Exception {
+    client = connectTimeoutClient();
+    when(random.get(anyLong())).thenReturn(1L);
+    doNothing().when(sleeper).sleep(anyLong());
+
+    // Connecting to localhost on an unused port address to trigger java.net.ConnectException
+    int openPort = freePort();
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCall(new Request.Builder().url("http://localhost:" + openPort).build())
+                    .execute())
+        .isInstanceOf(ConnectException.class);
+
+    verify(isRetryableException, times(5)).apply(any());
+    // Should retry maxAttempts, and sleep maxAttempts - 1 times
+    verify(sleeper, times(4)).sleep(anyLong());
+  }
+
+  private static int freePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes #6587.

I figured out how to reliably reproduce the `java.net.ConnectException` from the issue by connecting an unused port on `localhost`. JdkHttpSender was already retrying on these, but OkHttpSender and OkGrpcSender were not.

Also added some overdue debug logging for the intermediate retry requests so users have a way of determining what is going on. 