### PR TITLE
Fix broken link to community contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Welcome to OpenTelemetry Java repository!
 
 Before you start - see OpenTelemetry general
-[contributing](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+[contributing](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)
 requirements and recommendations.
 
 If you want to add new features or change behavior, please make sure your changes follow the

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Triagers:
 
 - [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana Labs
 
-*Find more about the triager role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
+*Find more about the triager role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).*
 
 Approvers ([@open-telemetry/java-approvers](https://github.com/orgs/open-telemetry/teams/java-approvers)):
 
@@ -307,7 +307,7 @@ Approvers ([@open-telemetry/java-approvers](https://github.com/orgs/open-telemet
 - [Lauri Tulmin](https://github.com/laurit), Splunk
 - [Trask Stalnaker](https://github.com/trask), Microsoft
 
-*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
+*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*
 
 Maintainers ([@open-telemetry/java-maintainers](https://github.com/orgs/open-telemetry/teams/java-maintainers)):
 
@@ -320,7 +320,7 @@ Emeritus:
 - Maintainer [Carlos Alberto](https://github.com/carlosalberto)
 - Approver [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek)
 
-*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
+*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).*
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
Build is currently [broken](https://github.com/open-telemetry/opentelemetry-java/actions/runs/10206034704/job/28238079974?pr=6615) after https://github.com/open-telemetry/community/pull/2051 moved the community contributor guide.