### PR TITLE
Add file configuration ComponentProvider support for resources

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/SpiHelper.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/internal/SpiHelper.java
@@ -81,9 +81,9 @@ public final class SpiHelper {
   }
 
   /**
-   * Find a registered {@link ComponentProvider} which {@link ComponentProvider#getType()} matching
+   * Find a registered {@link ComponentProvider} with {@link ComponentProvider#getType()} matching
    * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link
-   * ComponentProvider#create(StructuredConfigProperties)} with the given {@code model}.
+   * ComponentProvider#create(StructuredConfigProperties)} with the given {@code config}.
    *
    * @throws ConfigurationException if no matching providers are found, or if multiple are found
    *     (i.e. conflict), or if {@link ComponentProvider#create(StructuredConfigProperties)} throws

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
@@ -63,7 +63,7 @@ final class ResourceFactory
   }
 
   /**
-   * Load resources from resource detectors, in order over lowest priority to highest priority.
+   * Load resources from resource detectors, in order of lowest priority to highest priority.
    *
    * <p>In file configuration, a resource detector is a {@link ComponentProvider} with {@link
    * ComponentProvider#getType()} set to {@link Resource}. Unlike other {@link ComponentProvider}s,

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
@@ -6,15 +6,26 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Attributes;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Resource;
-import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.sdk.resources.Resource;
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-final class ResourceFactory implements Factory<Resource, io.opentelemetry.sdk.resources.Resource> {
+final class ResourceFactory
+    implements Factory<
+        io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Resource, Resource> {
 
+  private static final StructuredConfigProperties EMPTY_CONFIG =
+      FileConfiguration.toConfigProperties(Collections.emptyMap());
   private static final ResourceFactory INSTANCE = new ResourceFactory();
 
   private ResourceFactory() {}
@@ -24,20 +35,86 @@ final class ResourceFactory implements Factory<Resource, io.opentelemetry.sdk.re
   }
 
   @Override
-  public io.opentelemetry.sdk.resources.Resource create(
-      @Nullable Resource model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public Resource create(
+      @Nullable io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Resource model,
+      SpiHelper spiHelper,
+      List<Closeable> closeables) {
     if (model == null) {
-      return io.opentelemetry.sdk.resources.Resource.getDefault();
+      return Resource.getDefault();
     }
 
-    ResourceBuilder builder = io.opentelemetry.sdk.resources.Resource.getDefault().toBuilder();
+    Resource result = Resource.getDefault();
+
+    List<Resource> resourceDetectorResources = loadFromResourceDetectors(spiHelper);
+    for (Resource resourceProviderResource : resourceDetectorResources) {
+      result = result.merge(resourceProviderResource);
+    }
 
     Attributes attributesModel = model.getAttributes();
     if (attributesModel != null) {
-      builder.putAll(
-          AttributesFactory.getInstance().create(attributesModel, spiHelper, closeables));
+      result =
+          result.toBuilder()
+              .putAll(
+                  AttributesFactory.getInstance().create(attributesModel, spiHelper, closeables))
+              .build();
     }
 
-    return builder.build();
+    return result;
+  }
+
+  /**
+   * Load resources from resource detectors, in order over lowest priority to highest priority.
+   *
+   * <p>In file configuration, a resource detector is a {@link ComponentProvider} with {@link
+   * ComponentProvider#getType()} set to {@link Resource}. Unlike other {@link ComponentProvider}s,
+   * the resource detector version does not use {@link ComponentProvider#getName()} (except for
+   * debug messages), and {@link ComponentProvider#create(StructuredConfigProperties)} is called
+   * with an empty instance. Additionally, the {@link Ordered#order()} value is respected for
+   * resource detectors which implement {@link Ordered}.
+   */
+  @SuppressWarnings("rawtypes")
+  private static List<Resource> loadFromResourceDetectors(SpiHelper spiHelper) {
+    List<ComponentProvider> componentProviders = spiHelper.load(ComponentProvider.class);
+    List<ResourceAndOrder> resourceAndOrders = new ArrayList<>();
+    for (ComponentProvider<?> componentProvider : componentProviders) {
+      if (componentProvider.getType() != Resource.class) {
+        continue;
+      }
+      Resource resource;
+      try {
+        resource = (Resource) componentProvider.create(EMPTY_CONFIG);
+      } catch (Throwable throwable) {
+        throw new ConfigurationException(
+            "Error configuring "
+                + Resource.class.getName()
+                + " with name \""
+                + componentProvider.getName()
+                + "\"",
+            throwable);
+      }
+      int order =
+          (componentProvider instanceof Ordered) ? ((Ordered) componentProvider).order() : 0;
+      resourceAndOrders.add(new ResourceAndOrder(resource, order));
+    }
+    resourceAndOrders.sort(Comparator.comparing(ResourceAndOrder::order));
+    return resourceAndOrders.stream().map(ResourceAndOrder::resource).collect(Collectors.toList());
+  }
+
+  private static final class ResourceAndOrder {
+    private final Resource resource;
+    private final int order;
+
+    private ResourceAndOrder(Resource resource, int order) {
+      this.resource = resource;
+      this.order = order;
+    }
+
+    private Resource resource() {
+      return resource;
+    }
+
+    private int order() {
+      return order;
+    }
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -161,6 +161,10 @@ class OpenTelemetryConfigurationFactoryTest {
         io.opentelemetry.sdk.resources.Resource.getDefault().toBuilder()
             .put("service.name", "my-service")
             .put("key", "val")
+            // resource attributes from resource ComponentProviders
+            .put("color", "red")
+            .put("shape", "square")
+            .put("order", "second")
             .build();
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdk.builder()

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Attributes;
@@ -15,6 +16,8 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class ResourceFactoryTest {
+
+  private SpiHelper spiHelper = SpiHelper.create(MetricExporterFactoryTest.class.getClassLoader());
 
   @Test
   void create_Null() {
@@ -26,6 +29,7 @@ class ResourceFactoryTest {
 
   @Test
   void create() {
+    spiHelper = spy(spiHelper);
     assertThat(
             ResourceFactory.getInstance()
                 .create(
@@ -34,13 +38,21 @@ class ResourceFactoryTest {
                         .withAttributes(
                             new Attributes()
                                 .withServiceName("my-service")
-                                .withAdditionalProperty("key", "val")),
-                    mock(SpiHelper.class),
+                                .withAdditionalProperty("key", "val")
+                                // Should override shape attribute from ResourceComponentProvider
+                                .withAdditionalProperty("shape", "circle")),
+                    spiHelper,
                     Collections.emptyList()))
         .isEqualTo(
             Resource.getDefault().toBuilder()
                 .put("service.name", "my-service")
                 .put("key", "val")
+                .put("shape", "circle")
+                // From ResourceComponentProvider
+                .put("color", "red")
+                // From ResourceOrderedSecondComponentProvider, which takes priority over
+                // ResourceOrderedFirstComponentProvider
+                .put("order", "second")
                 .build());
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceComponentProvider.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceComponentProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig.component;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class ResourceComponentProvider implements ComponentProvider<Resource> {
+  @Override
+  public Class<Resource> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return "unused";
+  }
+
+  @Override
+  public Resource create(StructuredConfigProperties config) {
+    return Resource.builder().put("shape", "square").put("color", "red").build();
+  }
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceOrderedFirstComponentProvider.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceOrderedFirstComponentProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig.component;
+
+import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class ResourceOrderedFirstComponentProvider implements ComponentProvider<Resource>, Ordered {
+  @Override
+  public Class<Resource> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return "unused";
+  }
+
+  @Override
+  public Resource create(StructuredConfigProperties config) {
+    return Resource.builder().put("order", "first").build();
+  }
+
+  @Override
+  public int order() {
+    return 1;
+  }
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceOrderedSecondComponentProvider.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/component/ResourceOrderedSecondComponentProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig.component;
+
+import io.opentelemetry.sdk.autoconfigure.spi.Ordered;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class ResourceOrderedSecondComponentProvider
+    implements ComponentProvider<Resource>, Ordered {
+  @Override
+  public Class<Resource> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return "unused";
+  }
+
+  @Override
+  public Resource create(StructuredConfigProperties config) {
+    return Resource.builder().put("order", "second").build();
+  }
+
+  @Override
+  public int order() {
+    return 2;
+  }
+}

--- a/sdk-extensions/incubator/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
+++ b/sdk-extensions/incubator/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
@@ -1,3 +1,6 @@
 io.opentelemetry.sdk.extension.incubator.fileconfig.component.MetricExporterComponentProvider
 io.opentelemetry.sdk.extension.incubator.fileconfig.component.SpanExporterComponentProvider
 io.opentelemetry.sdk.extension.incubator.fileconfig.component.LogRecordExporterComponentProvider
+io.opentelemetry.sdk.extension.incubator.fileconfig.component.ResourceComponentProvider
+io.opentelemetry.sdk.extension.incubator.fileconfig.component.ResourceOrderedFirstComponentProvider
+io.opentelemetry.sdk.extension.incubator.fileconfig.component.ResourceOrderedSecondComponentProvider


### PR DESCRIPTION
Related to #6574.

In the issue, I said this about resources:

> For resources, should likely add support for ResourceProvider instead of loading via ComponentProvider since ResourceDeteector is already a first class concept in the specification, and ResourceProvider is the java implementation of ResourceDetector.

I had a change of heart in the implementation. Implementations of ResourceProvider expect to be participating in a configuration scenario which is based on the env var / system property configuration scheme. They receive a ConfigProperties instead of the StructuredConfigProperties used in file config, and look for things in it like `otel.resource.attributes` and `otel.service.name` to influence their behavior. 

Instead, in this PR I use `ComponentProvider` to provide resource attributes. This will require me to go and update the various resource provider artifacts and implement `ComponentProvider`, but will be more precise, and more consistent with the clean separation approach we've been taking with file configuration.