### PR TITLE
Adds Max Scale and Max Buckets Config for Base2ExpenentialBucket Histogram

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -312,7 +312,7 @@ public final class OtlpConfigUtil {
         config.getString("otel.exporter.otlp.metrics.default.histogram.aggregation");
     if (defaultHistogramAggregation != null) {
       ExporterBuilderUtil.configureHistogramDefaultAggregation(
-          defaultHistogramAggregation, defaultAggregationSelectorConsumer);
+          defaultHistogramAggregation, defaultAggregationSelectorConsumer, config);
     }
   }
 

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/internal/PrometheusMetricReaderProvider.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/internal/PrometheusMetricReaderProvider.java
@@ -40,7 +40,7 @@ public class PrometheusMetricReaderProvider implements ConfigurableMetricReaderP
             "otel.java.experimental.exporter.prometheus.metrics.default.histogram.aggregation");
     if (defaultHistogramAggregation != null) {
       ExporterBuilderUtil.configureHistogramDefaultAggregation(
-          defaultHistogramAggregation, prometheusBuilder::setDefaultAggregationSelector);
+          defaultHistogramAggregation, prometheusBuilder::setDefaultAggregationSelector, config);
     }
 
     return prometheusBuilder.build();


### PR DESCRIPTION
This PR adds two configs `otel.java.experimental.histogram.base2ExponentialBucket.maxBuckets` and `otel.java.experimental.histogram.base2ExponentialBucket.maxScale` to set max buckets and max scale for Base2ExponentialBucket Histogram. 

Right now, max scale and max buckets are configurable via views only, but with this PR, their default values could configured while specifying `default.histogram.aggregation` itself.