### PR TITLE
Fix broken markdown links

### DIFF
--- a/sdk-extensions/incubator/README.md
+++ b/sdk-extensions/incubator/README.md
@@ -4,7 +4,7 @@ This artifact contains experimental code related to the trace and metric SDKs.
 
 ## File Configuration
 
-Allows for YAML based file configuration of `OpenTelemetrySdk` as defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md).
+Allows for YAML based file configuration of `OpenTelemetrySdk` as defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#file-based-configuration-model).
 
 Usage:
 
@@ -18,7 +18,7 @@ try (FileInputStream yamlConfigFileInputStream = new FileInputStream("/path/to/c
 ```
 
 Notes:
-* Environment variable substitution is supported as [defined in the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution)
+* Environment variable substitution is supported as [defined in the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution)
 * Currently, there is no support for the SPIs defined in [opentelemetry-sdk-extension-autoconfigure-spi](../autoconfigure-spi). Only built in samplers, processors, exporters, etc can be configured.
 * You can use file configuration with [autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#file-configuration) to specify a configuration file via environment variable, e.g. `OTEL_EXPERIMENTAL_CONFIG_FILE=/path/to/config.yaml`.
 


### PR DESCRIPTION
Fixes few broken markdown links that prevent jobs from executing properly in CI now that markdown lint has been enabled.

The targeted file was removed in https://github.com/open-telemetry/opentelemetry-specification/pull/4128.

Command to validate (copy-paste from what is executed in CI).
```
find . -type f \                                                                                                                                                                                                                                                                   git:(fix-broken-links)
         -name '*.md' \
         -not -path './CHANGELOG.md' \
       | xargs .github/scripts/markdown-link-check-with-retry.sh
```