### PR TITLE
Remove outdated ExtendedSpanBuilder javadoc example

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/trace/ExtendedSpanBuilder.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/trace/ExtendedSpanBuilder.java
@@ -29,13 +29,6 @@ public interface ExtendedSpanBuilder extends SpanBuilder {
    * <p>The span context will be extracted from the <code>carrier</code>, which you usually get from
    * HTTP headers of the metadata of a message you're processing.
    *
-   * <p>A typical usage would be: <code>
-   * ExtendedTracer.create(tracer)
-   * .setSpanKind(SpanKind.SERVER)
-   * .setParentFrom(propagators, carrier)
-   * .run("my-span", () -> { ... });
-   * </code>
-   *
    * @param propagators provide the propagators from {@link OpenTelemetry#getPropagators()}
    * @param carrier the string map where to extract the span context from
    */


### PR DESCRIPTION
Incubator API usage is demonstrated via java snippets, linked in the incubator readme: https://github.com/open-telemetry/opentelemetry-java/tree/main/api/incubator#api-incubator

This helps ensure the usage snippets continue to be correct as the experimental APIs evolve.

Generally, I'm not a fan of embedding usage examples in javadoc. I'd rather have standalone docs with embedded snippets which have good formatting and are properly contextualized, as I propose in this PR: https://github.com/open-telemetry/opentelemetry.io/pull/4966