### PR TITLE
change polling interval property name to match spec

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactory.java
@@ -91,7 +91,7 @@ final class SamplerFactory
         properties.put("endpoint", jaegerRemoteModel.getEndpoint());
       }
       if (jaegerRemoteModel.getInterval() != null) {
-        properties.put("pollingInterval", String.valueOf(jaegerRemoteModel.getInterval()));
+        properties.put("pollingIntervalMs", String.valueOf(jaegerRemoteModel.getInterval()));
       }
       // TODO(jack-berg): determine how to support initial sampler. This is first case where a
       // component configured via SPI has property that isn't available in the environment variable

--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProvider.java
@@ -19,7 +19,7 @@ public class JaegerRemoteSamplerProvider implements ConfigurableSamplerProvider 
   static final String SAMPLER_ARG_PROPERTY = "otel.traces.sampler.arg";
   static final String RESOURCE_ATTRIBUTE_SERVICE_NAME_PROPERTY = "service.name";
   private static final String ENDPOINT_KEY = "endpoint";
-  private static final String POLLING_INTERVAL = "pollingInterval";
+  private static final String POLLING_INTERVAL = "pollingIntervalMs";
   private static final String INITIAL_SAMPLING_RATE = "initialSamplingRate";
 
   @Override

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerProviderTest.java
@@ -34,7 +34,7 @@ public class JaegerRemoteSamplerProviderTest {
         .thenReturn("test_service");
     HashMap<String, String> samplerArgs = new HashMap<>();
     samplerArgs.put("endpoint", "http://localhost:9999");
-    samplerArgs.put("pollingInterval", "99");
+    samplerArgs.put("pollingIntervalMs", "99");
     double samplingRate = 0.33;
     samplerArgs.put("initialSamplingRate", String.valueOf(samplingRate));
     when(mockConfig.getMap(JaegerRemoteSamplerProvider.SAMPLER_ARG_PROPERTY))


### PR DESCRIPTION
This PR fixes the name of polling interval property used by the `jaeger_remote` and `parentbased_jaeger_remote` samplers to align with the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/0b3328bb17fa6f86af521f8d22dbbcddea2ac914/specification/configuration/sdk-environment-variables.md?plain=1#L150-L152).

I originally updated the docs (https://github.com/open-telemetry/opentelemetry.io/pull/5100) to reflect the current behavior of Java SDK, but that was not the right choice -- we should fix it here instead.

Other implementations seem to be aligned with the current spec. For example:

- https://github.com/search?q=org%3Aopen-telemetry%20pollingIntervalMs&type=code
- https://github.com/open-telemetry/opentelemetry-operator/blob/50008928f34f21f388e59558789a9025fe2bf13f/apis/v1alpha1/instrumentation_webhook.go#L231
- https://github.com/open-telemetry/opentelemetry-operator/blob/50008928f34f21f388e59558789a9025fe2bf13f/apis/v1alpha1/instrumentation_webhook.go#L260

Related: 
- https://github.com/open-telemetry/opentelemetry-specification/pull/4195
- https://github.com/open-telemetry/opentelemetry.io/pull/5103