### PR TITLE
Add ByteBuffer field type marshaling support to exporter.

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/JsonSerializer.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -124,6 +125,13 @@ final class JsonSerializer extends Serializer {
   @Override
   public void writeBytes(ProtoFieldInfo field, byte[] value) throws IOException {
     generator.writeBinaryField(field.getJsonName(), value);
+  }
+
+  @Override
+  public void writeByteBuffer(ProtoFieldInfo field, ByteBuffer value) throws IOException {
+    byte[] data = new byte[value.capacity()];
+    ((ByteBuffer) value.duplicate().clear()).get(data);
+    generator.writeBinaryField(field.getJsonName(), data);
   }
 
   @Override

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -344,6 +345,14 @@ public final class MarshalerUtil {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(message);
+  }
+
+  /** Returns the size of a bytes field based on the buffer's capacity. */
+  public static int sizeByteBuffer(ProtoFieldInfo field, ByteBuffer message) {
+    if (message.capacity() == 0) {
+      return 0;
+    }
+    return field.getTagSize() + CodedOutputStream.computeByteBufferSizeNoTag(message);
   }
 
   /** Returns the size of a enum field. */

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/ProtoSerializer.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -166,6 +167,12 @@ final class ProtoSerializer extends Serializer implements AutoCloseable {
   public void writeBytes(ProtoFieldInfo field, byte[] value) throws IOException {
     output.writeUInt32NoTag(field.getTag());
     output.writeByteArrayNoTag(value);
+  }
+
+  @Override
+  public void writeByteBuffer(ProtoFieldInfo field, ByteBuffer value) throws IOException {
+    output.writeUInt32NoTag(field.getTag());
+    output.writeByteBufferNoTag(value);
   }
 
   @Override

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Serializer.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.internal.DynamicPrimitiveLongList;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -253,7 +254,21 @@ public abstract class Serializer implements AutoCloseable {
     writeBytes(field, value);
   }
 
+  /**
+   * Serializes a protobuf {@code bytes} field. Writes all content of the ByteBuffer regardless of
+   * the current position and limit. Does not alter the position or limit of the provided
+   * ByteBuffer.
+   */
+  public void serializeByteBuffer(ProtoFieldInfo field, ByteBuffer value) throws IOException {
+    if (value.capacity() == 0) {
+      return;
+    }
+    writeByteBuffer(field, value);
+  }
+
   public abstract void writeBytes(ProtoFieldInfo field, byte[] value) throws IOException;
+
+  public abstract void writeByteBuffer(ProtoFieldInfo field, ByteBuffer value) throws IOException;
 
   protected abstract void writeStartMessage(ProtoFieldInfo field, int protoMessageSize)
       throws IOException;


### PR DESCRIPTION
The marshaling utility code has not previously needed to support encoding of ByteBuffer type fields, as they are not used by any existing protocol. With the creation of the new experimental profiling signal type, that changes.

https://github.com/open-telemetry/opentelemetry-java/pull/6680 adds support for marshaling the new signal, but converts the ByteBuffer field into byte[] first, which is not ideal. To allow the ByteBuffer to be passed directly to the serialization code, we add support through Serializer and MarshalerUtil. The bulk of the change is in CodedOutputStream, the upstream protobuf version of which has ByteBuffer support already, so this is really just reinstating it in the fork.

In so doing, I've opted to keep the data handling behaviour based on 'buffer capacity, not position/limit' semantics of the protobuf lib for consistency, though that may be seen as running contrary to the intended API usage semantics of ByteBuffer. What we expose at the user API level may or may not be the same -  ProfileContainerMarshaler currently uses position/limit instead.