### PR TITLE
make SdkTracer.tracerEnabled mutable

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,6 +19,7 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
+
   // TODO: add dedicated API for updating scope config.
   @SuppressWarnings("FieldCanBeFinal") // For now, allow updating reflectively.
   private boolean tracerEnabled;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,6 +19,8 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
+  // TODO: add dedicated API for updating scope config.
+  @SuppressWarnings("FieldCanBeFinal") // For now, allow updating reflectively.
   private boolean tracerEnabled;
 
   SdkTracer(

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,7 +19,7 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
-  private final boolean tracerEnabled;
+  private volatile boolean tracerEnabled;
 
   SdkTracer(
       TracerSharedState sharedState,

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,7 +19,7 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
-  private volatile boolean tracerEnabled;
+  private boolean tracerEnabled;
 
   SdkTracer(
       TracerSharedState sharedState,


### PR DESCRIPTION
This allows the tracer to become enabled and disabled dynamically (though only by reflection at this stage). Doing just this change allows downstream agent distros to play around with APIs that would best work while not yet changing anything public in the SDK
Without this change, testing downstream is still possible but much more effortful