### PR TITLE
tests: update references to logging exporter

### DIFF
--- a/exporters/prometheus/src/test/resources/otel-config.yaml
+++ b/exporters/prometheus/src/test/resources/otel-config.yaml
@@ -10,7 +10,7 @@ receivers:
           static_configs:
             - targets: ['${APP_ENDPOINT}']
 exporters:
-  logging:
+  debug:
     verbosity: ${LOGGING_EXPORTER_VERBOSITY}
   otlp:
     endpoint: ${OTLP_EXPORTER_ENDPOINT}
@@ -22,4 +22,4 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]

--- a/integration-tests/otlp/src/main/resources/otel-config.yaml
+++ b/integration-tests/otlp/src/main/resources/otel-config.yaml
@@ -23,7 +23,7 @@ receivers:
           cert_file: ${MTLS_SERVER_CERTIFICATE}
           key_file: ${MTLS_SERVER_KEY}
 exporters:
-  logging:
+  debug:
     verbosity: ${LOGGING_EXPORTER_VERBOSITY_LEVEL}
   otlp:
     endpoint: ${OTLP_EXPORTER_ENDPOINT}
@@ -35,10 +35,10 @@ service:
   pipelines:
     metrics:
       receivers: [otlp, otlp/mtls]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
     traces:
       receivers: [otlp, otlp/mtls]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
     logs:
       receivers: [otlp, otlp/mtls]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]

--- a/perf-harness/src/test/resources/otel-collector-config-perf.yaml
+++ b/perf-harness/src/test/resources/otel-collector-config-perf.yaml
@@ -4,8 +4,8 @@ receivers:
         grpc:
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: normal
     sampling_initial: 1
     sampling_thereafter: 1
 
@@ -25,8 +25,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/sdk/trace/src/jmh/resources/otel.yaml
+++ b/sdk/trace/src/jmh/resources/otel.yaml
@@ -11,7 +11,7 @@ extensions:
   health_check:
 
 exporters:
-  logging:
+  debug:
 
 service:
   extensions: [health_check]
@@ -19,4 +19,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037