### PR TITLE
Stop publishing test fixtures with opentelemetry-api

### DIFF
--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
-  id("java-test-fixtures")
 
   id("otel.jmh-conventions")
   id("otel.animalsniffer-conventions")
@@ -16,12 +15,10 @@ dependencies {
 
   annotationProcessor("com.google.auto.value:auto-value")
 
+  testImplementation(project(":api:testing-internal"))
+
   testImplementation("edu.berkeley.cs.jqf:jqf-fuzz")
   testImplementation("com.google.guava:guava-testlib")
-  testFixturesApi(project(":testing-internal"))
-  testFixturesApi("junit:junit")
-  testFixturesApi("org.assertj:assertj-core")
-  testFixturesApi("org.mockito:mockito-core")
 }
 
 tasks.test {

--- a/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/OpenTelemetryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api;
 
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.testing.internal.AbstractOpenTelemetryTest;
 import io.opentelemetry.api.trace.TracerProvider;
 
 class OpenTelemetryTest extends AbstractOpenTelemetryTest {

--- a/api/all/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/logs/DefaultLoggerTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.logs;
 
+import io.opentelemetry.api.testing.internal.AbstractDefaultLoggerTest;
+
 class DefaultLoggerTest extends AbstractDefaultLoggerTest {
 
   @Override

--- a/api/all/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/metrics/DefaultMeterTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.metrics;
 
+import io.opentelemetry.api.testing.internal.AbstractDefaultMeterTest;
+
 public class DefaultMeterTest extends AbstractDefaultMeterTest {
 
   @Override

--- a/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/DefaultTracerTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.trace;
 
+import io.opentelemetry.api.testing.internal.AbstractDefaultTracerTest;
+
 class DefaultTracerTest extends AbstractDefaultTracerTest {
 
   @Override

--- a/api/incubator/build.gradle.kts
+++ b/api/incubator/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   annotationProcessor("com.google.auto.value:auto-value")
 
   testImplementation(project(":sdk:testing"))
-  testImplementation(testFixtures(project(":api:all")))
+  testImplementation(project(":api:testing-internal"))
 
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
 

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/ExtendedOpenTelemetryTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/ExtendedOpenTelemetryTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api.incubator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.AbstractOpenTelemetryTest;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.logs.ExtendedDefaultLoggerProvider;
 import io.opentelemetry.api.incubator.logs.ExtendedLogger;
@@ -17,6 +16,7 @@ import io.opentelemetry.api.incubator.trace.ExtendedDefaultTracerProvider;
 import io.opentelemetry.api.incubator.trace.ExtendedTracer;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.testing.internal.AbstractOpenTelemetryTest;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import org.junit.jupiter.api.Test;

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLoggerTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLoggerTest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.api.incubator.logs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Value;
-import io.opentelemetry.api.logs.AbstractDefaultLoggerTest;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.api.testing.internal.AbstractDefaultLoggerTest;
 import org.junit.jupiter.api.Test;
 
 class ExtendedDefaultLoggerTest extends AbstractDefaultLoggerTest {

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeterTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeterTest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.api.incubator.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.metrics.AbstractDefaultMeterTest;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.testing.internal.AbstractDefaultMeterTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracerTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracerTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.api.incubator.trace;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.AbstractDefaultTracerTest;
+import io.opentelemetry.api.testing.internal.AbstractDefaultTracerTest;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.junit.jupiter.api.Test;

--- a/api/testing-internal/build.gradle.kts
+++ b/api/testing-internal/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("otel.java-conventions")
+}
+
+description = "OpenTelemetry API Testing (Internal)"
+otelJava.moduleName.set("io.opentelemetry.api.testing.internal")
+
+dependencies {
+  api(project(":api:all"))
+
+  implementation(project(":testing-internal"))
+
+  implementation("com.linecorp.armeria:armeria-junit5")
+  implementation("org.assertj:assertj-core")
+  implementation("org.mockito:mockito-core")
+}
+
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultLoggerTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultLoggerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api.logs;
+package io.opentelemetry.api.testing.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -11,12 +11,15 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DefaultLogger}. */
+/** Unit tests for No-op {@link Logger}. */
 public abstract class AbstractDefaultLoggerTest {
 
   protected abstract LoggerProvider getLoggerProvider();

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
@@ -3,16 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api.metrics;
+package io.opentelemetry.api.testing.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DefaultMeter}. */
+/** Unit tests for No-op {@link Meter}. */
 @SuppressLogger()
 public abstract class AbstractDefaultMeterTest {
   private final Meter meter = getMeter();
@@ -245,6 +257,7 @@ public abstract class AbstractDefaultMeterTest {
   }
 
   @Test
+  @SuppressWarnings("NullAway")
   void noopBatchCallback_doesNotThrow() {
     meter.batchCallback(() -> {}, null);
   }

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultTracerTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultTracerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api.testing.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -20,7 +21,6 @@ import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for No-op {@link Tracer}. */
@@ -119,7 +119,7 @@ public abstract class AbstractDefaultTracerTest {
   @Test
   @SuppressWarnings("NullAway")
   void doNotCrash_NoopImplementation() {
-    Assertions.assertThatCode(
+    assertThatCode(
             () -> {
               SpanBuilder spanBuilder = defaultTracer.spanBuilder(null);
               spanBuilder.setSpanKind(null);

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultTracerTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultTracerTest.java
@@ -3,20 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api.trace;
+package io.opentelemetry.api.testing.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DefaultTracer}. */
+/** Unit tests for No-op {@link Tracer}. */
 // Need to suppress warnings for MustBeClosed because Android 14 does not support
 // try-with-resources.
 @SuppressWarnings("MustBeClosedChecker")
@@ -56,6 +63,7 @@ public abstract class AbstractDefaultTracerTest {
   }
 
   @Test
+  @SuppressWarnings("NullAway")
   void spanContextPropagationExplicitParent() {
     assertThat(
             defaultTracer
@@ -109,8 +117,9 @@ public abstract class AbstractDefaultTracerTest {
   }
 
   @Test
+  @SuppressWarnings("NullAway")
   void doNotCrash_NoopImplementation() {
-    assertThatCode(
+    Assertions.assertThatCode(
             () -> {
               SpanBuilder spanBuilder = defaultTracer.spanBuilder(null);
               spanBuilder.setSpanKind(null);

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.testing.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -13,7 +14,6 @@ import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,7 @@ public abstract class AbstractOpenTelemetryTest {
   @Test
   void setThenSet() {
     setOpenTelemetry();
-    Assertions.assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
+    assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("setOpenTelemetry");
@@ -101,7 +101,7 @@ public abstract class AbstractOpenTelemetryTest {
   void getThenSet() {
     assertThat(getGlobalOpenTelemetry().getClass().getName())
         .isEqualTo("io.opentelemetry.api.DefaultOpenTelemetry");
-    Assertions.assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
+    assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("getGlobalOpenTelemetry");

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
@@ -3,22 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.api;
+package io.opentelemetry.api.testing.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-/** Unit tests for {@link OpenTelemetry}. */
+/** Unit tests for No-op {@link OpenTelemetry}. */
 public abstract class AbstractOpenTelemetryTest {
+
   @BeforeAll
   public static void beforeClass() {
     GlobalOpenTelemetry.resetForTest();
@@ -88,7 +91,7 @@ public abstract class AbstractOpenTelemetryTest {
   @Test
   void setThenSet() {
     setOpenTelemetry();
-    assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
+    Assertions.assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("setOpenTelemetry");
@@ -96,8 +99,9 @@ public abstract class AbstractOpenTelemetryTest {
 
   @Test
   void getThenSet() {
-    assertThat(getGlobalOpenTelemetry()).isInstanceOf(DefaultOpenTelemetry.class);
-    assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
+    assertThat(getGlobalOpenTelemetry().getClass().getName())
+        .isEqualTo("io.opentelemetry.api.DefaultOpenTelemetry");
+    Assertions.assertThatThrownBy(() -> GlobalOpenTelemetry.set(getOpenTelemetry()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalOpenTelemetry.set has already been called")
         .hasStackTraceContaining("getGlobalOpenTelemetry");

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ rootProject.name = "opentelemetry-java"
 include(":all")
 include(":api:all")
 include(":api:incubator")
+include(":api:testing-internal")
 include(":bom")
 include(":bom-alpha")
 include(":context")


### PR DESCRIPTION
Resolves #6693.

Will need to publish in 1.42.1 patch release. 