### PR TITLE
Codify stance against using java-test-fixtures plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,13 @@ uses [google-java-format](https://github.com/google/google-java-format) library:
     synchronized (lock) { ... }
   }
   ```
+* Don't
+  use [gradle test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) (
+  i.e. `java-test-fixtures` plugin) to reuse code for internal testing. The test fixtures plugin has
+  side effects where test dependencies are added to the `pom.xml` and publishes an
+  extra `*-test-fixtures.jar` artifact which is unnecessary for internal testing. Instead, create a
+  new `*:testing-internal` module and omit the `otel.java-conventions`. For example,
+  see [/exporters/otlp/testing-internal](./exporters/otlp/testing-internal).
 
 If you notice any practice being applied in the project consistently that isn't listed here, please
 consider a pull request to add it.


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-java/pull/6695#discussion_r1750447194:

> In hindsight, adding java-test-fixtures was overly hasty, since as shown in https://github.com/open-telemetry/opentelemetry-java/issues/6693 it impacts the pom.xml and publishes additional artifacts we didn't intend / account for. When we need to share test code in this repository, we simply add a *:testing-internal module and omit the otel.publish-conventions. I suspect this pattern was selected in the past after investigating test fixtures and seeing these types of side affects.