### PR TITLE
Add getStructured default method, add empty StructuredConfigProperties

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/EmptyStructuredConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/EmptyStructuredConfigProperties.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/** Empty instance of {@link StructuredConfigProperties}. */
+final class EmptyStructuredConfigProperties implements StructuredConfigProperties {
+
+  private static final EmptyStructuredConfigProperties INSTANCE =
+      new EmptyStructuredConfigProperties();
+
+  private EmptyStructuredConfigProperties() {}
+
+  static EmptyStructuredConfigProperties getInstance() {
+    return INSTANCE;
+  }
+
+  @Nullable
+  @Override
+  public String getString(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Boolean getBoolean(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getInt(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getLong(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Double getDouble(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> List<T> getScalarList(String name, Class<T> scalarType) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public StructuredConfigProperties getStructured(String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public List<StructuredConfigProperties> getStructuredList(String name) {
+    return null;
+  }
+
+  @Override
+  public Set<String> getPropertyKeys() {
+    return Collections.emptySet();
+  }
+}

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/StructuredConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/StructuredConfigProperties.java
@@ -25,6 +25,17 @@ import javax.annotation.Nullable;
 public interface StructuredConfigProperties {
 
   /**
+   * Return an empty {@link StructuredConfigProperties} instance.
+   *
+   * <p>Useful for walking the tree without checking for null. For example, to access a string key
+   * nested at .foo.bar.baz, call: {@code config.getStructured("foo", empty()).getStructured("bar",
+   * empty()).getString("baz")}.
+   */
+  static StructuredConfigProperties empty() {
+    return EmptyStructuredConfigProperties.getInstance();
+  }
+
+  /**
    * Returns a {@link String} configuration property.
    *
    * @return null if the property has not been configured
@@ -169,6 +180,18 @@ public interface StructuredConfigProperties {
   StructuredConfigProperties getStructured(String name);
 
   /**
+   * Returns a {@link StructuredConfigProperties} configuration property.
+   *
+   * @return a map-valued configuration property, or {@code defaultValue} if {@code name} has not
+   *     been configured
+   * @throws ConfigurationException if the property is not a mapping
+   */
+  default StructuredConfigProperties getStructured(
+      String name, StructuredConfigProperties defaultValue) {
+    return defaultIfNull(getStructured(name), defaultValue);
+  }
+
+  /**
    * Returns a list of {@link StructuredConfigProperties} configuration property.
    *
    * @return a list of map-valued configuration property, or {@code null} if {@code name} has not
@@ -177,6 +200,18 @@ public interface StructuredConfigProperties {
    */
   @Nullable
   List<StructuredConfigProperties> getStructuredList(String name);
+
+  /**
+   * Returns a list of {@link StructuredConfigProperties} configuration property.
+   *
+   * @return a list of map-valued configuration property, or {@code defaultValue} if {@code name}
+   *     has not been configured
+   * @throws ConfigurationException if the property is not a sequence of mappings
+   */
+  default List<StructuredConfigProperties> getStructuredList(
+      String name, List<StructuredConfigProperties> defaultValue) {
+    return defaultIfNull(getStructuredList(name), defaultValue);
+  }
 
   /**
    * Returns a set of all configuration property keys.

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/YamlStructuredConfigPropertiesTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/YamlStructuredConfigPropertiesTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
+import static io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableSet;
@@ -171,6 +172,18 @@ class YamlStructuredConfigPropertiesTest {
   }
 
   @Test
+  void treeWalking() {
+    // Validate common pattern of walking down tree path which is not defined
+    // Access string at .foo.bar.baz without null checking and without exception.
+    assertThat(
+            structuredConfigProps
+                .getStructured("foo", empty())
+                .getStructured("bar", empty())
+                .getString("baz"))
+        .isNull();
+  }
+
+  @Test
   void defaults() {
     assertThat(structuredConfigProps.getString("foo", "bar")).isEqualTo("bar");
     assertThat(structuredConfigProps.getInt("foo", 1)).isEqualTo(1);
@@ -181,6 +194,9 @@ class YamlStructuredConfigPropertiesTest {
             structuredConfigProps.getScalarList(
                 "foo", String.class, Collections.singletonList("bar")))
         .isEqualTo(Collections.singletonList("bar"));
+    assertThat(structuredConfigProps.getStructured("foo", empty())).isEqualTo(empty());
+    assertThat(structuredConfigProps.getStructuredList("foo", Collections.emptyList()))
+        .isEqualTo(Collections.emptyList());
   }
 
   @Test
@@ -208,5 +224,27 @@ class YamlStructuredConfigPropertiesTest {
     assertThat(otherProps.getScalarList("str_key", String.class)).isNull();
     assertThat(otherProps.getStructured("str_key")).isNull();
     assertThat(otherProps.getStructuredList("str_key")).isNull();
+  }
+
+  @Test
+  void emptyProperties() {
+    assertThat(empty().getString("foo")).isNull();
+    assertThat(empty().getInt("foo")).isNull();
+    assertThat(empty().getLong("foo")).isNull();
+    assertThat(empty().getDouble("foo")).isNull();
+    assertThat(empty().getBoolean("foo")).isNull();
+    assertThat(empty().getScalarList("foo", String.class)).isNull();
+    assertThat(empty().getStructured("foo")).isNull();
+    assertThat(empty().getStructuredList("foo")).isNull();
+    assertThat(empty().getString("foo", "bar")).isEqualTo("bar");
+    assertThat(empty().getInt("foo", 1)).isEqualTo(1);
+    assertThat(empty().getLong("foo", 1)).isEqualTo(1);
+    assertThat(empty().getDouble("foo", 1.1)).isEqualTo(1.1);
+    assertThat(empty().getBoolean("foo", true)).isTrue();
+    assertThat(empty().getScalarList("foo", String.class, Collections.singletonList("bar")))
+        .isEqualTo(Collections.singletonList("bar"));
+    assertThat(empty().getStructured("foo", empty())).isEqualTo(empty());
+    assertThat(empty().getStructuredList("foo", Collections.emptyList()))
+        .isEqualTo(Collections.emptyList());
   }
 }


### PR DESCRIPTION
Add `StructuredConfigProperties.getStructured(String, StructuredConfigProperties)` method to assist with walking trees without null checking. Originated from this [conversation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12265#discussion_r1771964764).