### PR TITLE
Adds Baggage.getEntry(String key)

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -99,4 +99,13 @@ public interface Baggage extends ImplicitContextKeyed {
    * be set to not use an implicit parent, so any parent assignment must be done manually.
    */
   BaggageBuilder toBuilder();
+
+  /**
+   * Returns the {@code BaggageEntry} associated with the given key.
+   *
+   * @param entryKey entry key to return the {@code BaggageEntry} for, or {@code null} if no {@code
+   *     Entry} with the given {@code entryKey} is in this {@code Baggage}.
+   */
+  @Nullable
+  BaggageEntry getEntry(String entryKey);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -108,6 +108,13 @@ public interface Baggage extends ImplicitContextKeyed {
    */
   @Nullable
   default BaggageEntry getEntry(String entryKey) {
-    return asMap().get(entryKey);
+    BaggageEntry[] result = new BaggageEntry[] {null};
+    forEach(
+        (key, entry) -> {
+          if (entryKey.equals(key)) {
+            result[0] = entry;
+          }
+        });
+    return result[0];
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -107,5 +107,7 @@ public interface Baggage extends ImplicitContextKeyed {
    *     Entry} with the given {@code entryKey} is in this {@code Baggage}.
    */
   @Nullable
-  BaggageEntry getEntry(String entryKey);
+  default BaggageEntry getEntry(String entryKey) {
+    return asMap().get(entryKey);
+  }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -37,7 +37,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
     return entry != null ? entry.getValue() : null;
   }
 
-  // Overrides the default implementation to provide a more performant implementation
+  // Overrides the default implementation to provide a more performant implementation.
   @Nullable
   @Override
   public BaggageEntry getEntry(String entryKey) {

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -37,7 +37,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
     return entry != null ? entry.getValue() : null;
   }
 
-  // Overrides the
+  // Overrides the default implementation to provide a more performant implementation
   @Nullable
   @Override
   public BaggageEntry getEntry(String entryKey) {

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -37,6 +37,13 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
     return entry != null ? entry.getValue() : null;
   }
 
+  // Overrides the
+  @Nullable
+  @Override
+  public BaggageEntry getEntry(String entryKey) {
+    return get(entryKey);
+  }
+
   @Override
   public BaggageBuilder toBuilder() {
     return new Builder(new ArrayList<>(data()));

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -37,7 +37,7 @@ class Parser {
 
   private boolean skipToNext;
 
-  public Parser(String baggageHeader) {
+  Parser(String baggageHeader) {
     this.baggageHeader = baggageHeader;
     reset(0);
   }

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageTest.java
@@ -35,14 +35,14 @@ class BaggageTest {
   @Test
   void getEntryDefault() {
     BaggageEntryMetadata metadata = BaggageEntryMetadata.create("flib");
+    Map<String, BaggageEntry> result = new HashMap<>();
+    result.put("a", ImmutableEntry.create("b", metadata));
     // Implementation that only implements asMap() which is used by getEntry()
     Baggage baggage =
         new Baggage() {
 
           @Override
           public Map<String, BaggageEntry> asMap() {
-            Map<String, BaggageEntry> result = new HashMap<>();
-            result.put("a", ImmutableEntry.create("b", metadata));
             return result;
           }
 
@@ -52,7 +52,9 @@ class BaggageTest {
           }
 
           @Override
-          public void forEach(BiConsumer<? super String, ? super BaggageEntry> consumer) {}
+          public void forEach(BiConsumer<? super String, ? super BaggageEntry> consumer) {
+            result.forEach(consumer);
+          }
 
           @Nullable
           @Override

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageTest.java
@@ -27,4 +27,15 @@ class BaggageTest {
       assertThat(result.getEntryValue("foo")).isEqualTo("bar");
     }
   }
+
+  @Test
+  void getEntry() {
+    BaggageEntryMetadata metadata = BaggageEntryMetadata.create("flib");
+    try (Scope scope =
+        Context.root().with(Baggage.builder().put("a", "b", metadata).build()).makeCurrent()) {
+      Baggage result = Baggage.current();
+      assertThat(result.getEntry("a").getValue()).isEqualTo("b");
+      assertThat(result.getEntry("a").getMetadata().getValue()).isEqualTo("flib");
+    }
+  }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.testing.EqualsTester;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -189,5 +191,16 @@ class ImmutableBaggageTest {
         .addEqualityGroup(Baggage.builder().put(K1, V2, TMD).put(K2, V1, TMD).build())
         .addEqualityGroup(baggage2, baggage3)
         .testEquals();
+  }
+
+  @Test
+  void getEntry() {
+    BaggageEntryMetadata metadata = BaggageEntryMetadata.create("flib");
+    try (Scope scope =
+        Context.root().with(Baggage.builder().put("a", "b", metadata).build()).makeCurrent()) {
+      Baggage result = Baggage.current();
+      assertThat(result.getEntry("a").getValue()).isEqualTo("b");
+      assertThat(result.getEntry("a").getMetadata().getValue()).isEqualTo("flib");
+    }
   }
 }

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,2 +1,5 @@
 Comparing source compatibility of opentelemetry-api-1.43.0-SNAPSHOT.jar against opentelemetry-api-1.42.1.jar
-No changes.
+**** MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.baggage.Baggage  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.baggage.BaggageEntry getEntry(java.lang.String)
+		+++  NEW ANNOTATION: javax.annotation.Nullable

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,5 +1,5 @@
 Comparing source compatibility of opentelemetry-api-1.43.0-SNAPSHOT.jar against opentelemetry-api-1.42.1.jar
-**** MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.baggage.Baggage  (not serializable)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.baggage.Baggage  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++* NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.baggage.BaggageEntry getEntry(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.baggage.BaggageEntry getEntry(java.lang.String)
 		+++  NEW ANNOTATION: javax.annotation.Nullable


### PR DESCRIPTION
Resolves #6729.

This prevents users from having to go through `asMap()` in order to fetch the metadata for a given `BaggageEntry`.