### PR TITLE
Limit prometheus exemplar labels

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
@@ -434,10 +434,10 @@ final class Otel2PrometheusConverter {
 
   private static int getCodePoints(Labels labels) {
     int codePoints = 0;
-    for (Label l : labels) {
+    for (Label label : labels) {
       codePoints +=
-          l.getName().codePointCount(0, l.getName().length())
-              + l.getValue().codePointCount(0, l.getValue().length());
+          label.getName().codePointCount(0, label.getName().length())
+              + label.getValue().codePointCount(0, label.getValue().length());
     }
     return codePoints;
   }

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverter.java
@@ -425,7 +425,7 @@ final class Otel2PrometheusConverter {
           Level.WARNING,
           "exemplar labels have "
               + codePoints
-              + " codePoints, exceeding the limit of "
+              + " unicode code points, exceeding the limit of "
               + EXEMPLAR_MAX_CODE_POINTS);
       return null;
     }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/Otel2PrometheusConverterTest.java
@@ -10,6 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -21,6 +24,7 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramP
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
@@ -422,6 +426,42 @@ class Otel2PrometheusConverterTest {
     throw new IllegalArgumentException("Unsupported metric data type: " + metricDataType);
   }
 
+  static MetricData createLongMetricDataWithExemplar(
+      String metricName,
+      String metricUnit,
+      @Nullable Attributes attributes,
+      @Nullable Resource resource,
+      Attributes exemplarFilteredAttributes) {
+    Attributes attributesToUse = attributes == null ? Attributes.empty() : attributes;
+    Resource resourceToUse = resource == null ? Resource.getDefault() : resource;
+
+    return ImmutableMetricData.createLongSum(
+        resourceToUse,
+        InstrumentationScopeInfo.create("scope"),
+        metricName,
+        "description",
+        metricUnit,
+        ImmutableSumData.create(
+            true,
+            AggregationTemporality.CUMULATIVE,
+            Collections.singletonList(
+                ImmutableLongPointData.create(
+                    0,
+                    100000,
+                    attributesToUse,
+                    1L,
+                    Collections.singletonList(
+                        ImmutableLongExemplarData.create(
+                            exemplarFilteredAttributes,
+                            1L,
+                            SpanContext.create(
+                                "0669315b30dbe08683c19ed9bd24068b",
+                                "049178b29912fdb4",
+                                TraceFlags.getDefault(),
+                                TraceState.getDefault()),
+                            2))))));
+  }
+
   @Test
   void validateCacheIsBounded() {
     AtomicInteger predicateCalledCount = new AtomicInteger();
@@ -477,5 +517,98 @@ class Otel2PrometheusConverterTest {
     // but if the cache was cleared, it used the predicate for each resource, since it as if
     // it never saw those resources before.
     assertThat(predicateCalledCount.get()).isEqualTo(2);
+  }
+
+  @Test
+  void exemplarLabelsWithinLimit() throws IOException {
+
+    Otel2PrometheusConverter converter = new Otel2PrometheusConverter(true, null);
+    Attributes exemplarfilteredAttributes =
+        Attributes.of(
+            stringKey("client_address"),
+            "127.0.0.6",
+            stringKey("network_peer_address"),
+            "127.0.0.6");
+
+    MetricData metricDataWithExemplar =
+        createLongMetricDataWithExemplar(
+            "metric_hertz",
+            "hertz",
+            Attributes.of(stringKey("foo1"), "bar1", stringKey("foo2"), "bar2"),
+            Resource.create(
+                Attributes.of(stringKey("host"), "localhost", stringKey("cluster"), "mycluster")),
+            exemplarfilteredAttributes);
+    String expectedExemplarLabels =
+        "client_address=\"127.0.0.6\""
+            + ",network_peer_address=\"127.0.0.6\",span_id=\"049178b29912fdb4\""
+            + ",trace_id=\"0669315b30dbe08683c19ed9bd24068b\"";
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    MetricSnapshots snapshots =
+        converter.convert(Collections.singletonList(metricDataWithExemplar));
+    ExpositionFormats.init().getOpenMetricsTextFormatWriter().write(out, snapshots);
+    String expositionFormat = new String(out.toByteArray(), StandardCharsets.UTF_8);
+
+    // extract the only metric line
+    List<String> metricLines =
+        Arrays.stream(expositionFormat.split("\n"))
+            .filter(line -> line.startsWith("metric_hertz"))
+            .collect(Collectors.toList());
+    assertThat(metricLines).hasSize(1);
+
+    //  metric_hertz_total{foo1="bar1",foo2="bar2",otel_scope_name="scope"} 1.0 #
+    // {client_address="127.0.0.6",network_peer_address="127.0.0.6",span_id="0002",trace_id="0001"}
+    // 2.0
+    String metricLine = metricLines.get(0);
+    String exemplarPart = metricLine.substring(metricLine.indexOf("#") + 2);
+
+    String exemplarLabels =
+        exemplarPart.substring(exemplarPart.indexOf("{") + 1, exemplarPart.indexOf("}"));
+    assertThat(exemplarLabels).isEqualTo(expectedExemplarLabels);
+  }
+
+  @Test
+  void exemplarLabelsAboveLimit() throws IOException {
+
+    Otel2PrometheusConverter converter = new Otel2PrometheusConverter(true, null);
+    Attributes exemplarfilteredAttributes =
+        Attributes.of(
+            stringKey("client_address"),
+            "127.0.0.6",
+            stringKey("network_peer_address"),
+            "127.0.0.6",
+            stringKey("network_peer_port"),
+            "55579",
+            stringKey("server_address"),
+            "10.3.17.168",
+            stringKey("server_port"),
+            "8081",
+            stringKey("url_path"),
+            "/foo/bar");
+    MetricData metricDataWithExemplar =
+        createLongMetricDataWithExemplar(
+            "metric_hertz",
+            "hertz",
+            Attributes.of(stringKey("foo1"), "bar1", stringKey("foo2"), "bar2"),
+            Resource.create(
+                Attributes.of(stringKey("host"), "localhost", stringKey("cluster"), "mycluster")),
+            exemplarfilteredAttributes);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    MetricSnapshots snapshots =
+        converter.convert(Collections.singletonList(metricDataWithExemplar));
+    ExpositionFormats.init().getOpenMetricsTextFormatWriter().write(out, snapshots);
+    String expositionFormat = new String(out.toByteArray(), StandardCharsets.UTF_8);
+
+    // extract the only metric line
+    List<String> metricLines =
+        Arrays.stream(expositionFormat.split("\n"))
+            .filter(line -> line.startsWith("metric_hertz"))
+            .collect(Collectors.toList());
+    assertThat(metricLines).hasSize(1);
+
+    // metric_hertz_total{foo1="bar1",foo2="bar2",otel_scope_name="scope"} 1.0
+    // no exemplar data as runes limit was reached
+    String metricLine = metricLines.get(0);
+    int exemplarDelimitterPos = metricLine.indexOf("#");
+    assertThat(exemplarDelimitterPos).isEqualTo(-1);
   }
 }


### PR DESCRIPTION
Changes done:
1. create exemplar's labels object before creating the exemplar object. (deduplicated some code there)
2. calculate labels length or runes.
3. compare label runes with the hardcoded max rune. If limit reached, then return null exemplar obj.
4. Added tests with sample LongSum metric data consisting exemplar for scenarios
a) exemplar labels below max rune
b) exemplar labels above max rune

```
> Task :exporters:prometheus:test

Otel2PrometheusConverterTest > exemplarLabelsAboveLimit() STANDARD_ERROR
    [Test worker] WARN io.opentelemetry.exporter.prometheus.Otel2PrometheusConverter - exemplar labels have 193 unicode code points, exceeding the limit of 128
```