### PR TITLE
Set declarative config default OTLP protocol to http/protobuf

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -51,7 +51,14 @@ public final class OtlpConfigUtil {
 
   /** Determine the configured OTLP protocol for the {@code dataType}. */
   public static String getStructuredConfigOtlpProtocol(StructuredConfigProperties config) {
-    return config.getString("protocol", PROTOCOL_GRPC);
+    // NOTE: The default OTLP protocol is different for declarative config than for env var / system
+    // property based config. This is intentional. OpenTelemetry changed the default protocol
+    // recommendation from grpc to http/protobuf, but the autoconfigure's env var / system property
+    // based config did not update to reflect this before stabilizing, and changing is a breaking
+    // change requiring a major version bump. Declarative config is not yet stable and therefore can
+    // switch to the current default recommendation, which aligns also aligns with the behavior of
+    // the OpenTelemetry Java Agent 2.x+.
+    return config.getString("protocol", PROTOCOL_HTTP_PROTOBUF);
   }
 
   /** Invoke the setters with the OTLP configuration for the {@code dataType}. */

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigurationCreateTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigurationCreateTest.java
@@ -123,7 +123,7 @@ class FileConfigurationCreateTest {
     logCapturer.assertContains(
         "Error encountered interpreting model. Closing partially configured components.");
     logCapturer.assertContains(
-        "Closing io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter");
+        "Closing io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter");
     logCapturer.assertContains("Closing io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor");
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
-import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
@@ -61,7 +60,7 @@ class LogRecordExporterFactoryTest {
   void create_OtlpDefaults() {
     spiHelper = spy(spiHelper);
     List<Closeable> closeables = new ArrayList<>();
-    OtlpGrpcLogRecordExporter expectedExporter = OtlpGrpcLogRecordExporter.getDefault();
+    OtlpHttpLogRecordExporter expectedExporter = OtlpHttpLogRecordExporter.getDefault();
     cleanup.addCloseable(expectedExporter);
 
     LogRecordExporter exporter =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
-import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
@@ -53,7 +53,7 @@ class LogRecordProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor expectedProcessor =
         io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor.builder(
-                OtlpGrpcLogRecordExporter.getDefault())
+                OtlpHttpLogRecordExporter.getDefault())
             .build();
     cleanup.addCloseable(expectedProcessor);
 
@@ -77,7 +77,7 @@ class LogRecordProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor expectedProcessor =
         io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor.builder(
-                OtlpGrpcLogRecordExporter.getDefault())
+                OtlpHttpLogRecordExporter.getDefault())
             .setScheduleDelay(Duration.ofMillis(1))
             .setMaxExportBatchSize(2)
             .setExporterTimeout(Duration.ofMillis(3))
@@ -121,7 +121,7 @@ class LogRecordProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.logs.LogRecordProcessor expectedProcessor =
         io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor.create(
-            OtlpGrpcLogRecordExporter.getDefault());
+            OtlpHttpLogRecordExporter.getDefault());
     cleanup.addCloseable(expectedProcessor);
 
     io.opentelemetry.sdk.logs.LogRecordProcessor processor =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
-import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
@@ -84,7 +84,7 @@ class LoggerProviderFactoryTest {
                             .build())
                 .addLogRecordProcessor(
                     io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor.builder(
-                            OtlpGrpcLogRecordExporter.getDefault())
+                            OtlpHttpLogRecordExporter.getDefault())
                         .build())
                 .build()));
   }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
-import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MeterProviderModel;
@@ -57,7 +57,7 @@ class MeterProviderFactoryTest {
         SdkMeterProvider.builder()
             .registerMetricReader(
                 io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.builder(
-                        OtlpGrpcMetricExporter.getDefault())
+                        OtlpHttpMetricExporter.getDefault())
                     .build())
             .registerView(
                 InstrumentSelector.builder().setName("instrument-name").build(),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
-import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
@@ -65,7 +64,7 @@ class MetricExporterFactoryTest {
   void create_OtlpDefaults() {
     spiHelper = spy(spiHelper);
     List<Closeable> closeables = new ArrayList<>();
-    OtlpGrpcMetricExporter expectedExporter = OtlpGrpcMetricExporter.getDefault();
+    OtlpHttpMetricExporter expectedExporter = OtlpHttpMetricExporter.getDefault();
     cleanup.addCloseable(expectedExporter);
 
     MetricExporter exporter =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricReaderFactoryTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import io.github.netmikey.logunit.api.LogCapturer;
-import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
@@ -62,7 +62,7 @@ class MetricReaderFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.metrics.export.PeriodicMetricReader expectedReader =
         io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.builder(
-                OtlpGrpcMetricExporter.getDefault())
+                OtlpHttpMetricExporter.getDefault())
             .build();
     cleanup.addCloseable(expectedReader);
 
@@ -87,7 +87,7 @@ class MetricReaderFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.metrics.export.MetricReader expectedReader =
         io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.builder(
-                OtlpGrpcMetricExporter.getDefault())
+                OtlpHttpMetricExporter.getDefault())
             .setInterval(Duration.ofMillis(1))
             .build();
     cleanup.addCloseable(expectedReader);

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -13,9 +13,9 @@ import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
-import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
@@ -169,7 +169,7 @@ class OpenTelemetryConfigurationFactoryTest {
                                 .build())
                     .addLogRecordProcessor(
                         io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor.builder(
-                                OtlpGrpcLogRecordExporter.getDefault())
+                                OtlpHttpLogRecordExporter.getDefault())
                             .build())
                     .build())
             .setTracerProvider(
@@ -187,7 +187,7 @@ class OpenTelemetryConfigurationFactoryTest {
                     .setSampler(alwaysOn())
                     .addSpanProcessor(
                         io.opentelemetry.sdk.trace.export.BatchSpanProcessor.builder(
-                                OtlpGrpcSpanExporter.getDefault())
+                                OtlpHttpSpanExporter.getDefault())
                             .build())
                     .build())
             .setMeterProvider(
@@ -195,7 +195,7 @@ class OpenTelemetryConfigurationFactoryTest {
                     .setResource(expectedResource)
                     .registerMetricReader(
                         io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.builder(
-                                OtlpGrpcMetricExporter.getDefault())
+                                OtlpHttpMetricExporter.getDefault())
                             .build())
                     .registerView(
                         InstrumentSelector.builder().setName("instrument-name").build(),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactoryTest.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
@@ -63,7 +62,7 @@ class SpanExporterFactoryTest {
   void create_OtlpDefaults() {
     spiHelper = spy(spiHelper);
     List<Closeable> closeables = new ArrayList<>();
-    OtlpGrpcSpanExporter expectedExporter = OtlpGrpcSpanExporter.getDefault();
+    OtlpHttpSpanExporter expectedExporter = OtlpHttpSpanExporter.getDefault();
     cleanup.addCloseable(expectedExporter);
 
     SpanExporter exporter =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanProcessorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanProcessorFactoryTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
@@ -53,7 +53,7 @@ class SpanProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.trace.export.BatchSpanProcessor expectedProcessor =
         io.opentelemetry.sdk.trace.export.BatchSpanProcessor.builder(
-                OtlpGrpcSpanExporter.getDefault())
+                OtlpHttpSpanExporter.getDefault())
             .build();
     cleanup.addCloseable(expectedProcessor);
 
@@ -77,7 +77,7 @@ class SpanProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.trace.export.BatchSpanProcessor expectedProcessor =
         io.opentelemetry.sdk.trace.export.BatchSpanProcessor.builder(
-                OtlpGrpcSpanExporter.getDefault())
+                OtlpHttpSpanExporter.getDefault())
             .setScheduleDelay(Duration.ofMillis(1))
             .setMaxExportBatchSize(2)
             .setExporterTimeout(Duration.ofMillis(3))
@@ -120,7 +120,7 @@ class SpanProcessorFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.trace.SpanProcessor expectedProcessor =
         io.opentelemetry.sdk.trace.export.SimpleSpanProcessor.create(
-            OtlpGrpcSpanExporter.getDefault());
+            OtlpHttpSpanExporter.getDefault());
     cleanup.addCloseable(expectedProcessor);
 
     io.opentelemetry.sdk.trace.SpanProcessor processor =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn;
 
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.internal.testing.CleanupExtension;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AlwaysOnModel;
@@ -95,7 +95,7 @@ class TracerProviderFactoryTest {
                 .setSampler(alwaysOn())
                 .addSpanProcessor(
                     io.opentelemetry.sdk.trace.export.BatchSpanProcessor.builder(
-                            OtlpGrpcSpanExporter.getDefault())
+                            OtlpHttpSpanExporter.getDefault())
                         .build())
                 .build()));
   }


### PR DESCRIPTION
This comment from the code explains the motivation behind this:

>  NOTE: The default OTLP protocol is different for declarative config than for env var / system property based config. This is intentional. OpenTelemetry changed the default protocol recommendation from grpc to http/protobuf, but the autoconfigure's env var / system property based config did not update to reflect this before stabilizing, and changing is a breaking change requiring a major version bump. Declarative config is not yet stable and therefore can switch to the current default recommendation, which aligns also aligns with the behavior of the OpenTelemetry Java Agent 2.x+.