### PR TITLE
Stabilizing `otel.experimental.resource.disabled.keys`

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java
@@ -125,7 +125,7 @@ public final class ResourceConfiguration {
       disabledAttibuteKeys = configProperties.getList(EXPERIMENTAL_DISABLED_ATTRIBUTE_KEYS);
       if (!disabledAttibuteKeys.isEmpty()) {
         logger.warning(
-            "otel.experimental.resource.disabled.keys is deprecated. Please use otel.resource.disabled.keys instead.");
+            "otel.experimental.resource.disabled.keys is deprecated and will be removed after 1.45.0 release. Please use otel.resource.disabled.keys instead.");
       }
     }
     Set<String> disabledKeys = new HashSet<>(disabledAttibuteKeys);

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -112,8 +112,7 @@ class ResourceConfigurationTest {
   @Test
   void filterAttributes() {
     ConfigProperties configProperties =
-        DefaultConfigProperties.createFromMap(
-            ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
+        DefaultConfigProperties.createFromMap(ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
 
     Resource resourceNoSchema =
         Resource.builder().put("foo", "val").put("bar", "val").put("baz", "val").build();

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -112,7 +112,8 @@ class ResourceConfigurationTest {
   @Test
   void filterAttributes() {
     ConfigProperties configProperties =
-        DefaultConfigProperties.createFromMap(ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
+        DefaultConfigProperties.createFromMap(
+            ImmutableMap.of(DISABLED_ATTRIBUTE_KEYS, "foo,bar"));
 
     Resource resourceNoSchema =
         Resource.builder().put("foo", "val").put("bar", "val").put("baz", "val").build();

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -26,7 +26,28 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ResourceConfigurationTest {
 
   @Test
-  void customConfigResource() {
+  void customConfigResourceWithDisabledKeys() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.service.name", "test-service");
+    props.put(
+        "otel.resource.attributes", "food=cheesecake,drink=juice,animal=  ,color=,shape=square");
+    props.put("otel.resource.disabled-keys", "drink");
+
+    assertThat(
+            ResourceConfiguration.configureResource(
+                DefaultConfigProperties.create(props),
+                SpiHelper.create(ResourceConfigurationTest.class.getClassLoader()),
+                (r, c) -> r))
+        .isEqualTo(
+            Resource.getDefault().toBuilder()
+                .put(stringKey("service.name"), "test-service")
+                .put("food", "cheesecake")
+                .put("shape", "square")
+                .build());
+  }
+
+  @Test
+  void customConfigResourceWithExperimentalDisabledKeys() {
     Map<String, String> props = new HashMap<>();
     props.put("otel.service.name", "test-service");
     props.put(


### PR DESCRIPTION
I kept `otel.experimental.resource.disabled.keys` for backwards compatibility and promoted them to a newer stabilized version as `otel.resource.disabled.keys`. Please take a look and let me know if this looks good. This resolves [6777](https://github.com/open-telemetry/opentelemetry-java/issues/6777)