### PR TITLE
Docs: Update Windows-specific guidance for running Prometheus exporter test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,9 @@ analysis.
    formatting:
 
    `gradlew.bat`
+  
+  > **Note:** For Windows users, the command `./gradlew :exporters:prometheus:test` may fail. It is recommended to use `./gradlew assemble` instead.
+
 
 ## Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ analysis.
    formatting:
 
    `gradlew.bat`
-  
+
   > **Note:** For Windows users, the command `./gradlew :exporters:prometheus:test` may fail. It is recommended to use `./gradlew assemble` instead.
 
 


### PR DESCRIPTION
Referencing the issue noted here  [JApiCmp Failure in setting up opentelemetry-java locally](https://github.com/open-telemetry/opentelemetry-java/issues/6789#top), it would be beneficial for beginner contributors to include guidance on handling Prometheus test failures on Windows, along with an alternative command. This addition will help new contributors navigate the setup process more smoothly and contribute effectively to the repository.
@trask @shalk 