### PR TITLE
Require exporter timeouts to be positive

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -56,7 +56,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -78,7 +78,7 @@ public final class OtlpHttpLogRecordExporterBuilder {
    */
   public OtlpHttpLogRecordExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -70,7 +70,7 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -92,7 +92,7 @@ public final class OtlpHttpMetricExporterBuilder {
    */
   public OtlpHttpMetricExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -56,7 +56,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -78,7 +78,7 @@ public final class OtlpHttpSpanExporterBuilder {
    */
   public OtlpHttpSpanExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -92,7 +92,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    */
   public OtlpGrpcLogRecordExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -115,7 +115,7 @@ public final class OtlpGrpcLogRecordExporterBuilder {
    */
   public OtlpGrpcLogRecordExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -106,7 +106,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    */
   public OtlpGrpcMetricExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -129,7 +129,7 @@ public final class OtlpGrpcMetricExporterBuilder {
    */
   public OtlpGrpcMetricExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -88,7 +88,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    */
   public OtlpGrpcSpanExporterBuilder setTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setTimeout(timeout, unit);
     return this;
   }
@@ -111,7 +111,7 @@ public final class OtlpGrpcSpanExporterBuilder {
    */
   public OtlpGrpcSpanExporterBuilder setConnectTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     delegate.setConnectTimeout(timeout, unit);
     return this;
   }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -814,9 +814,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   @Test
   @SuppressWarnings("PreferJavaTimeOverload")
   void validConfig() {
-    assertThatCode(() -> exporterBuilder().setTimeout(0, TimeUnit.MILLISECONDS))
+    assertThatCode(() -> exporterBuilder().setTimeout(1, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
-    assertThatCode(() -> exporterBuilder().setTimeout(Duration.ofMillis(0)))
+    assertThatCode(() -> exporterBuilder().setTimeout(Duration.ofMillis(1)))
         .doesNotThrowAnyException();
     assertThatCode(() -> exporterBuilder().setTimeout(10, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
@@ -848,9 +848,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   @Test
   @SuppressWarnings({"PreferJavaTimeOverload", "NullAway"})
   void invalidConfig() {
-    assertThatThrownBy(() -> exporterBuilder().setTimeout(-1, TimeUnit.MILLISECONDS))
+    assertThatThrownBy(() -> exporterBuilder().setTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
     assertThatThrownBy(() -> exporterBuilder().setTimeout(1, null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("unit");

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -728,18 +728,18 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
   @Test
   @SuppressWarnings("PreferJavaTimeOverload")
   void validConfig() {
-    assertThatCode(() -> exporterBuilder().setTimeout(0, TimeUnit.MILLISECONDS))
+    assertThatCode(() -> exporterBuilder().setTimeout(1, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
-    assertThatCode(() -> exporterBuilder().setTimeout(Duration.ofMillis(0)))
+    assertThatCode(() -> exporterBuilder().setTimeout(Duration.ofMillis(1)))
         .doesNotThrowAnyException();
     assertThatCode(() -> exporterBuilder().setTimeout(10, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
     assertThatCode(() -> exporterBuilder().setTimeout(Duration.ofMillis(10)))
         .doesNotThrowAnyException();
 
-    assertThatCode(() -> exporterBuilder().setConnectTimeout(0, TimeUnit.MILLISECONDS))
+    assertThatCode(() -> exporterBuilder().setConnectTimeout(1, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
-    assertThatCode(() -> exporterBuilder().setConnectTimeout(Duration.ofMillis(0)))
+    assertThatCode(() -> exporterBuilder().setConnectTimeout(Duration.ofMillis(1)))
         .doesNotThrowAnyException();
     assertThatCode(() -> exporterBuilder().setConnectTimeout(10, TimeUnit.MILLISECONDS))
         .doesNotThrowAnyException();
@@ -771,9 +771,9 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
   @Test
   @SuppressWarnings({"PreferJavaTimeOverload", "NullAway"})
   void invalidConfig() {
-    assertThatThrownBy(() -> exporterBuilder().setTimeout(-1, TimeUnit.MILLISECONDS))
+    assertThatThrownBy(() -> exporterBuilder().setTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
     assertThatThrownBy(() -> exporterBuilder().setTimeout(1, null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("unit");
@@ -781,9 +781,9 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
         .isInstanceOf(NullPointerException.class)
         .hasMessage("timeout");
 
-    assertThatThrownBy(() -> exporterBuilder().setConnectTimeout(-1, TimeUnit.MILLISECONDS))
+    assertThatThrownBy(() -> exporterBuilder().setConnectTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
     assertThatThrownBy(() -> exporterBuilder().setConnectTimeout(1, null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("unit");

--- a/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
+++ b/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterBuilder.java
@@ -155,7 +155,7 @@ public final class ZipkinSpanExporterBuilder {
    */
   public ZipkinSpanExporterBuilder setReadTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     this.readTimeoutMillis = unit.toMillis(timeout);
     return this;
   }

--- a/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
+++ b/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporterTest.java
@@ -137,9 +137,9 @@ class ZipkinSpanExporterTest {
   @SuppressWarnings({"PreferJavaTimeOverload", "deprecation"})
   // we have to use the deprecated setEncoder overload to test it
   void invalidConfig() {
-    assertThatThrownBy(() -> ZipkinSpanExporter.builder().setReadTimeout(-1, TimeUnit.MILLISECONDS))
+    assertThatThrownBy(() -> ZipkinSpanExporter.builder().setReadTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
 
     assertThatThrownBy(() -> ZipkinSpanExporter.builder().setReadTimeout(1, null))
         .isInstanceOf(NullPointerException.class)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
@@ -70,7 +70,7 @@ public final class BatchLogRecordProcessorBuilder {
    */
   public BatchLogRecordProcessorBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     exporterTimeoutNanos = unit.toNanos(timeout);
     return this;
   }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
@@ -99,9 +99,9 @@ class BatchLogRecordProcessorTest {
     assertThatThrownBy(
             () ->
                 BatchLogRecordProcessor.builder(mockLogRecordExporter)
-                    .setExporterTimeout(-1, TimeUnit.MILLISECONDS))
+                    .setExporterTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
     assertThatThrownBy(
             () ->
                 BatchLogRecordProcessor.builder(mockLogRecordExporter).setExporterTimeout(1, null))

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorBuilder.java
@@ -78,7 +78,7 @@ public final class BatchSpanProcessorBuilder {
    */
   public BatchSpanProcessorBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
-    checkArgument(timeout >= 0, "timeout must be non-negative");
+    checkArgument(timeout > 0, "timeout must be positive");
     exporterTimeoutNanos = unit.toNanos(timeout);
     return this;
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -111,9 +111,9 @@ class BatchSpanProcessorTest {
     assertThatThrownBy(
             () ->
                 BatchSpanProcessor.builder(mockSpanExporter)
-                    .setExporterTimeout(-1, TimeUnit.MILLISECONDS))
+                    .setExporterTimeout(0, TimeUnit.MILLISECONDS))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("timeout must be non-negative");
+        .hasMessage("timeout must be positive");
     assertThatThrownBy(
             () -> BatchSpanProcessor.builder(mockSpanExporter).setExporterTimeout(1, null))
         .isInstanceOf(NullPointerException.class)


### PR DESCRIPTION
Resolves #6245.

This is a behavior change, which I would consider a bug. The behavior when exporter timeout 0 is at best ambiguous, and at worst non-functional. As discussed in this [comment](https://github.com/open-telemetry/opentelemetry-java/pull/6079#discussion_r1497874596): 

>  There's different interpretations of 0 for different http clients:
> - okhttp allows you to set the connect timeout to 0 with "no timeout" semantics.
> - jdk http client throws if you set connect timeout to 0

> I figured we get around this by only accepting positive values. If a user wants forever semantics, they can se timeout to be Long.MAX_VALUE.

Configuration options impacted:
- OtlpHttpSpanExporterBuilder#setTimeout
- OtlpHttpSpanExporterBuilder#setConnectTimeout
- OtlpHttpMetricExporterBuilder#setTimeout
- OtlpHttpMetricExporterBuilder#setConnectTimeout
- OtlpHttpLogRecordExporterBuilder#setTimeout
- OtlpHttpLogRecordExporterBuilder#setConnectTimeout
- OtlpGrpcSpanExporterBuilder#setTimeout
- OtlpGrpcSpanExporterBuilder#setConnectTimeout
- OtlpGrpcMetricExporterBuilder#setTimeout
- OtlpGrpcMetricExporterBuilder#setConnectTimeout
- OtlpGrpcLogRecordExporterBuilder#setTimeout
- OtlpGrpcLogRecordExporterBuilder#setConnectTimeout
- BatchLogRecordProcessorBuilder#setExporterTimeout
- BatchSpanProcessorBuilder#setExporterTimeout