### PR TITLE
Don't require empty objects when referencing custom components

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfiguration.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfiguration.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -166,6 +167,9 @@ public final class FileConfiguration {
       Object model, ComponentLoader componentLoader) {
     Map<String, Object> configurationMap =
         MAPPER.convertValue(model, new TypeReference<Map<String, Object>>() {});
+    if (configurationMap == null) {
+      configurationMap = Collections.emptyMap();
+    }
     return YamlStructuredConfigProperties.create(configurationMap, componentLoader);
   }
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigurationCreateTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigurationCreateTest.java
@@ -130,4 +130,23 @@ class FileConfigurationCreateTest {
         "Closing io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter");
     logCapturer.assertContains("Closing io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor");
   }
+
+  @Test
+  void parseAndCreate_EmptyComponentProviderConfig() {
+    String yaml =
+        "file_format: \"0.3\"\n"
+            + "logger_provider:\n"
+            + "  processors:\n"
+            + "    - test:\n"
+            + "tracer_provider:\n"
+            + "  processors:\n"
+            + "    - test:\n";
+
+    assertThatCode(
+            () ->
+                FileConfiguration.parseAndCreate(
+                    new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8))))
+        .doesNotThrowAnyException();
+    ;
+  }
 }


### PR DESCRIPTION
Currently, when referencing a custom processor, exporter, sampler, etc, you need to specify an empty object as config (i.e. `{}`). 

This is a bug. 

This PR fixes the bug.