### PR TITLE
Rename Marshaler#writeJsonToGenerator to allow jackson runtimeOnly dependency

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Marshaler.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Marshaler.java
@@ -32,7 +32,7 @@ public abstract class Marshaler {
   }
 
   /** Marshals into the {@link JsonGenerator} in proto JSON format. */
-  public final void writeJsonTo(JsonGenerator output) throws IOException {
+  public final void writeJsonToGenerator(JsonGenerator output) throws IOException {
     try (JsonSerializer serializer = new JsonSerializer(output)) {
       serializer.writeMessageValue(this);
     }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Marshaler.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/Marshaler.java
@@ -32,6 +32,9 @@ public abstract class Marshaler {
   }
 
   /** Marshals into the {@link JsonGenerator} in proto JSON format. */
+  // Intentionally not overloading writeJsonTo(OutputStream) in order to avoid compilation
+  // dependency on jackson when using writeJsonTo(OutputStream). See:
+  // https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1551#discussion_r1849064365
   public final void writeJsonToGenerator(JsonGenerator output) throws IOException {
     try (JsonSerializer serializer = new JsonSerializer(output)) {
       serializer.writeMessageValue(this);

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/writer/LoggerJsonWriter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/writer/LoggerJsonWriter.java
@@ -33,7 +33,7 @@ public class LoggerJsonWriter implements JsonWriter {
   public CompletableResultCode write(Marshaler exportRequest) {
     SegmentedStringWriter sw = new SegmentedStringWriter(JSON_FACTORY._getBufferRecycler());
     try (JsonGenerator gen = JsonUtil.create(sw)) {
-      exportRequest.writeJsonTo(gen);
+      exportRequest.writeJsonToGenerator(gen);
     } catch (IOException e) {
       logger.log(Level.WARNING, "Unable to write OTLP JSON " + type, e);
       return CompletableResultCode.ofFailure();

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/writer/LoggerJsonWriterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/internal/writer/LoggerJsonWriterTest.java
@@ -32,7 +32,9 @@ class LoggerJsonWriterTest {
   @Test
   void error() throws IOException {
     Marshaler marshaler = mock(Marshaler.class);
-    Mockito.doThrow(new IOException("test")).when(marshaler).writeJsonTo(any(JsonGenerator.class));
+    Mockito.doThrow(new IOException("test"))
+        .when(marshaler)
+        .writeJsonToGenerator(any(JsonGenerator.class));
 
     Logger logger = Logger.getLogger(LoggerJsonWriter.class.getName());
 


### PR DESCRIPTION
See this comment for explanation: https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1551#discussion_r1849064365