### PR TITLE
Add experimental updateTracerConfigurations for dynamically updateable on/off instrumentation

### DIFF
--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -19,6 +19,8 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.io.Closeable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -167,6 +169,20 @@ public final class OpenTelemetrySdk implements OpenTelemetry, Closeable {
 
     public SdkTracerProvider unobfuscate() {
       return delegate;
+    }
+
+    // currently not public as experimental
+    void updateTracerConfigurations() {
+      // and delegate method is experimental so also not public
+      // It would be: delegate.updateTracerConfigurations();
+      try {
+        Method method = SdkTracerProvider.class.getDeclaredMethod("updateTracerConfigurations");
+        method.setAccessible(true);
+        method.invoke(delegate);
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        throw new IllegalStateException(
+            "Error calling SdkTracerProvider.updateTracerConfigurations(): ", e);
+      }
     }
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,6 +19,8 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
+  // deliberately not volatile because of performance concerns
+  // - which means its eventually consistent
   private boolean tracerEnabled;
 
   SdkTracer(

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java
@@ -19,9 +19,6 @@ final class SdkTracer implements ExtendedTracer {
 
   private final TracerSharedState sharedState;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
-
-  // TODO: add dedicated API for updating scope config.
-  @SuppressWarnings("FieldCanBeFinal") // For now, allow updating reflectively.
   private boolean tracerEnabled;
 
   SdkTracer(
@@ -52,6 +49,11 @@ final class SdkTracer implements ExtendedTracer {
   // Visible for testing
   InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return instrumentationScopeInfo;
+  }
+
+  // currently not public as experimental
+  void updateTracerConfig(TracerConfig tracerConfig) {
+    this.tracerEnabled = tracerConfig.isEnabled();
   }
 
   @Override

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -100,6 +100,16 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
     return sharedState.getSampler();
   }
 
+  // currently not public as experimental
+  void updateTracerConfigurations() {
+    this.tracerSdkComponentRegistry
+        .getComponents()
+        .forEach(
+            sdkTracer ->
+                sdkTracer.updateTracerConfig(
+                    getTracerConfig(sdkTracer.getInstrumentationScopeInfo())));
+  }
+
   /**
    * Attempts to stop all the activity for {@link Tracer}s created by this provider. Calls {@link
    * SpanProcessor#shutdown()} for all registered {@link SpanProcessor}s.

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -51,6 +51,14 @@ class SdkTracerTest {
   }
 
   @Test
+  void updateEnabled() {
+    tracer.updateTracerConfig(TracerConfig.disabled());
+    assertThat(tracer.isEnabled()).isFalse();
+    tracer.updateTracerConfig(TracerConfig.enabled());
+    assertThat(tracer.isEnabled()).isTrue();
+  }
+
+  @Test
   void propagatesInstrumentationScopeInfoToSpan() {
     ReadableSpan readableSpan = (ReadableSpan) tracer.spanBuilder("spanName").startSpan();
     assertThat(readableSpan.getInstrumentationScopeInfo()).isEqualTo(instrumentationScopeInfo);

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.trace.StressTestRunner.OperationUpdater;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.internal.TracerConfig;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This enables dynamic config - it's all that is needed at the experimental level. For the complete solution it would be a `TracerProvider.updateTracerConfigurations()` interface method addition.

A usage example is https://github.com/elastic/elastic-otel-java/blob/main/custom/src/main/java/co/elastic/otel/config/DynamicInstrumentation.java

Essentially, the configuration is set with an updatable ScopeConfigurator (see below fragment), then that can be updated at any time with eg `GlobalOpenTelemetry.getTracerProvider().updateTracerConfigurations()`

```
  public void customize(AutoConfigurationCustomizer autoConfiguration) {
    autoConfiguration.addTracerProviderCustomizer(
        (providerBuilder, properties) -> {
          providerBuilder.setTracerConfigurator(
              UpdatableConfigurator.INSTANCE);
          return providerBuilder;
        });
  }

  public static class UpdatableConfigurator implements ScopeConfigurator<TracerConfig> {
    public static final UpdatableConfigurator INSTANCE = new UpdatableConfigurator();
    private final ConcurrentMap<String, TracerConfig> map = new ConcurrentHashMap<>();

    private UpdatableConfigurator() {}

    @Override
    public TracerConfig apply(InstrumentationScopeInfo scopeInfo) {
      return map.getOrDefault(scopeInfo.getName(), TracerConfig.defaultConfig());
    }

    public void put(InstrumentationScopeInfo scope, TracerConfig tracerConfig) {
      map.put(scope.getName(), tracerConfig);
    }
  }
```

I haven't added implementations for `DefaultTracerProvider` and `ExtendedDefaultTracerProvider` nor tests, because I feel this is fine for the experimental stage, but those could be added easily
