### PR TITLE
Add getters/accessors for readable fields in ReadWriteLogRecord.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,6 +1,2 @@
 Comparing source compatibility of opentelemetry-api-1.46.0-SNAPSHOT.jar against opentelemetry-api-1.45.0.jar
-+++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.common.ComplexAttributeKey  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	GENERIC TEMPLATES: +++ T:java.lang.Object
-	+++  NEW INTERFACE: io.opentelemetry.api.common.AttributeKey
-	+++  NEW SUPERCLASS: java.lang.Object
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-api.txt
@@ -1,2 +1,6 @@
 Comparing source compatibility of opentelemetry-api-1.46.0-SNAPSHOT.jar against opentelemetry-api-1.45.0.jar
-No changes.
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.common.ComplexAttributeKey  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	GENERIC TEMPLATES: +++ T:java.lang.Object
+	+++  NEW INTERFACE: io.opentelemetry.api.common.AttributeKey
+	+++  NEW SUPERCLASS: java.lang.Object

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -5,8 +5,6 @@ Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar aga
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 		GENERIC TEMPLATES: +++ T:java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes getAttributes()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.data.Body getBody()
-		+++  NEW ANNOTATION: java.lang.Deprecated
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Value<?> getBodyValue()
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo getInstrumentationScopeInfo()
@@ -16,4 +14,3 @@ Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar aga
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.SpanContext getSpanContext()
 	+++  NEW METHOD: PUBLIC(+) long getTimestampEpochNanos()
-	+++  NEW METHOD: PUBLIC(+) int getTotalAttributeCount()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,10 +1,13 @@
 Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.45.0.jar
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.logs.ReadWriteLogRecord  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW INTERFACE: io.opentelemetry.sdk.logs.data.LogRecordData
 	+++  NEW METHOD: PUBLIC(+) java.lang.Object getAttribute(io.opentelemetry.api.common.AttributeKey<T>)
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 		GENERIC TEMPLATES: +++ T:java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes getAttributes()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.data.Body getBody()
+		+++  NEW ANNOTATION: java.lang.Deprecated
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Value<?> getBodyValue()
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo getInstrumentationScopeInfo()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,7 +1,6 @@
 Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.45.0.jar
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.logs.ReadWriteLogRecord  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	+++  NEW INTERFACE: io.opentelemetry.sdk.logs.data.LogRecordData
 	+++  NEW METHOD: PUBLIC(+) java.lang.Object getAttribute(io.opentelemetry.api.common.AttributeKey<T>)
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 		GENERIC TEMPLATES: +++ T:java.lang.Object
@@ -12,7 +11,6 @@ Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar aga
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo getInstrumentationScopeInfo()
 	+++  NEW METHOD: PUBLIC(+) long getObservedTimestampEpochNanos()
-	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.resources.Resource getResource()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.logs.Severity getSeverity()
 	+++  NEW METHOD: PUBLIC(+) java.lang.String getSeverityText()
 		+++  NEW ANNOTATION: javax.annotation.Nullable

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,2 +1,18 @@
 Comparing source compatibility of opentelemetry-sdk-logs-1.46.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.45.0.jar
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.logs.ReadWriteLogRecord  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.Object getAttribute(io.opentelemetry.api.common.AttributeKey<T>)
+		+++  NEW ANNOTATION: javax.annotation.Nullable
+		GENERIC TEMPLATES: +++ T:java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Attributes getAttributes()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.common.Value<?> getBodyValue()
+		+++  NEW ANNOTATION: javax.annotation.Nullable
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo getInstrumentationScopeInfo()
+	+++  NEW METHOD: PUBLIC(+) long getObservedTimestampEpochNanos()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.resources.Resource getResource()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.logs.Severity getSeverity()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getSeverityText()
+		+++  NEW ANNOTATION: javax.annotation.Nullable
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.api.trace.SpanContext getSpanContext()
+	+++  NEW METHOD: PUBLIC(+) long getTimestampEpochNanos()
+	+++  NEW METHOD: PUBLIC(+) int getTotalAttributeCount()

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -14,7 +14,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.Nullable;
 
 /**

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -7,7 +7,13 @@ package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.Nullable;
 
 /**
  * A log record that can be read from and written to.
@@ -47,7 +53,70 @@ public interface ReadWriteLogRecord {
   /** Return an immutable {@link LogRecordData} instance representing this log record. */
   LogRecordData toLogRecordData();
 
-  // TODO: add additional log record accessors. Currently, all fields can be accessed indirectly via
-  // #toLogRecordData() at the expense of additional allocations.
+  /**
+   * Returns the value of a given attribute if it exists. This is the equivalent of calling
+   * getAttributes().get(key)
+   */
+  @Nullable
+  default <T> T getAttribute(AttributeKey<T> key) {
+    return toLogRecordData().getAttributes().get(key);
+  }
 
+  /** Returns the resource of this log record. */
+  default Resource getResource() {
+    return toLogRecordData().getResource();
+  }
+
+  /** Returns the instrumentation scope that generated this log. */
+  default InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return toLogRecordData().getInstrumentationScopeInfo();
+  }
+
+  /** Returns the timestamp at which the log record occurred, in epoch nanos. */
+  default long getTimestampEpochNanos() {
+    return toLogRecordData().getTimestampEpochNanos();
+  }
+
+  /** Returns the timestamp at which the log record was observed, in epoch nanos. */
+  default long getObservedTimestampEpochNanos() {
+    return toLogRecordData().getTimestampEpochNanos();
+  }
+
+  /** Return the span context for this log, or {@link SpanContext#getInvalid()} if unset. */
+  default SpanContext getSpanContext() {
+    return toLogRecordData().getSpanContext();
+  }
+
+  /** Returns the severity for this log, or {@link Severity#UNDEFINED_SEVERITY_NUMBER} if unset. */
+  default Severity getSeverity() {
+    return toLogRecordData().getSeverity();
+  }
+
+  /** Returns the severity text for this log, or null if unset. */
+  @Nullable
+  default String getSeverityText() {
+    return toLogRecordData().getSeverityText();
+  }
+
+  /** Returns the {@link Value} representation of the log body, of null if unset. */
+  @Nullable
+  default Value<?> getBodyValue() {
+    return toLogRecordData().getBodyValue();
+  }
+
+  /** Returns the attributes for this log, or {@link Attributes#empty()} if unset. */
+  default Attributes getAttributes() {
+    return toLogRecordData().getAttributes();
+  }
+
+  /**
+   * Returns the total number of attributes that were recorded on this log.
+   *
+   * <p>This number may be larger than the number of attributes that are attached to this log, if
+   * the total number recorded was greater than the configured maximum value. See {@link
+   * LogLimits#getMaxNumberOfAttributes()}.
+   */
+  default int getTotalAttributeCount() {
+    return toLogRecordData().getTotalAttributeCount();
+  }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -94,10 +94,11 @@ public interface ReadWriteLogRecord {
   }
 
   /**
-   * Returns the body for this log, or {@link Body#empty()} if unset.
+   * Returns the body for this log, or {@link io.opentelemetry.sdk.logs.data.Body#empty()} if unset.
    *
    * <p>If the body has been set to some {@link ValueType} other than {@link ValueType#STRING}, this
-   * will return a {@link Body} with a string representation of the {@link Value}.
+   * will return a {@link io.opentelemetry.sdk.logs.data.Body} with a string representation of the
+   * {@link Value}.
    *
    * @deprecated Use {@link #getBodyValue()} instead.
    */

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -64,11 +64,6 @@ public interface ReadWriteLogRecord {
     return toLogRecordData().getAttributes().get(key);
   }
 
-  /** Returns the resource of this log record. */
-  default Resource getResource() {
-    return toLogRecordData().getResource();
-  }
-
   /** Returns the instrumentation scope that generated this log. */
   default InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return toLogRecordData().getInstrumentationScopeInfo();

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  *
  * @since 1.27.0
  */
-public interface ReadWriteLogRecord {
+public interface ReadWriteLogRecord extends LogRecordData {
 
   /**
    * Sets an attribute on the log record. If the log record previously contained a mapping for the
@@ -63,48 +63,64 @@ public interface ReadWriteLogRecord {
   }
 
   /** Returns the resource of this log record. */
+  @Override
   default Resource getResource() {
     return toLogRecordData().getResource();
   }
 
   /** Returns the instrumentation scope that generated this log. */
+  @Override
   default InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return toLogRecordData().getInstrumentationScopeInfo();
   }
 
   /** Returns the timestamp at which the log record occurred, in epoch nanos. */
+  @Override
   default long getTimestampEpochNanos() {
     return toLogRecordData().getTimestampEpochNanos();
   }
 
   /** Returns the timestamp at which the log record was observed, in epoch nanos. */
+  @Override
   default long getObservedTimestampEpochNanos() {
     return toLogRecordData().getTimestampEpochNanos();
   }
 
   /** Return the span context for this log, or {@link SpanContext#getInvalid()} if unset. */
+  @Override
   default SpanContext getSpanContext() {
     return toLogRecordData().getSpanContext();
   }
 
   /** Returns the severity for this log, or {@link Severity#UNDEFINED_SEVERITY_NUMBER} if unset. */
+  @Override
   default Severity getSeverity() {
     return toLogRecordData().getSeverity();
   }
 
   /** Returns the severity text for this log, or null if unset. */
   @Nullable
+  @Override
   default String getSeverityText() {
     return toLogRecordData().getSeverityText();
   }
 
+  @Deprecated
+  @Override
+  @SuppressWarnings("deprecation") // Implementation of deprecated method
+  default io.opentelemetry.sdk.logs.data.Body getBody() {
+    return toLogRecordData().getBody();
+  }
+
   /** Returns the {@link Value} representation of the log body, of null if unset. */
   @Nullable
+  @Override
   default Value<?> getBodyValue() {
     return toLogRecordData().getBodyValue();
   }
 
   /** Returns the attributes for this log, or {@link Attributes#empty()} if unset. */
+  @Override
   default Attributes getAttributes() {
     return toLogRecordData().getAttributes();
   }
@@ -116,6 +132,7 @@ public interface ReadWriteLogRecord {
    * the total number recorded was greater than the configured maximum value. See {@link
    * LogLimits#getMaxNumberOfAttributes()}.
    */
+  @Override
   default int getTotalAttributeCount() {
     return toLogRecordData().getTotalAttributeCount();
   }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -8,9 +8,11 @@ package io.opentelemetry.sdk.logs;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.common.ValueType;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.Nullable;
@@ -20,7 +22,7 @@ import javax.annotation.Nullable;
  *
  * @since 1.27.0
  */
-public interface ReadWriteLogRecord extends LogRecordData {
+public interface ReadWriteLogRecord {
 
   /**
    * Sets an attribute on the log record. If the log record previously contained a mapping for the
@@ -63,50 +65,50 @@ public interface ReadWriteLogRecord extends LogRecordData {
   }
 
   /** Returns the resource of this log record. */
-  @Override
   default Resource getResource() {
     return toLogRecordData().getResource();
   }
 
   /** Returns the instrumentation scope that generated this log. */
-  @Override
   default InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return toLogRecordData().getInstrumentationScopeInfo();
   }
 
   /** Returns the timestamp at which the log record occurred, in epoch nanos. */
-  @Override
   default long getTimestampEpochNanos() {
     return toLogRecordData().getTimestampEpochNanos();
   }
 
   /** Returns the timestamp at which the log record was observed, in epoch nanos. */
-  @Override
   default long getObservedTimestampEpochNanos() {
     return toLogRecordData().getTimestampEpochNanos();
   }
 
   /** Return the span context for this log, or {@link SpanContext#getInvalid()} if unset. */
-  @Override
   default SpanContext getSpanContext() {
     return toLogRecordData().getSpanContext();
   }
 
   /** Returns the severity for this log, or {@link Severity#UNDEFINED_SEVERITY_NUMBER} if unset. */
-  @Override
   default Severity getSeverity() {
     return toLogRecordData().getSeverity();
   }
 
   /** Returns the severity text for this log, or null if unset. */
   @Nullable
-  @Override
   default String getSeverityText() {
     return toLogRecordData().getSeverityText();
   }
 
+  /**
+   * Returns the body for this log, or {@link Body#empty()} if unset.
+   *
+   * <p>If the body has been set to some {@link ValueType} other than {@link ValueType#STRING}, this
+   * will return a {@link Body} with a string representation of the {@link Value}.
+   *
+   * @deprecated Use {@link #getBodyValue()} instead.
+   */
   @Deprecated
-  @Override
   @SuppressWarnings("deprecation") // Implementation of deprecated method
   default io.opentelemetry.sdk.logs.data.Body getBody() {
     return toLogRecordData().getBody();
@@ -114,13 +116,11 @@ public interface ReadWriteLogRecord extends LogRecordData {
 
   /** Returns the {@link Value} representation of the log body, of null if unset. */
   @Nullable
-  @Override
   default Value<?> getBodyValue() {
     return toLogRecordData().getBodyValue();
   }
 
   /** Returns the attributes for this log, or {@link Attributes#empty()} if unset. */
-  @Override
   default Attributes getAttributes() {
     return toLogRecordData().getAttributes();
   }
@@ -132,7 +132,6 @@ public interface ReadWriteLogRecord extends LogRecordData {
    * the total number recorded was greater than the configured maximum value. See {@link
    * LogLimits#getMaxNumberOfAttributes()}.
    */
-  @Override
   default int getTotalAttributeCount() {
     return toLogRecordData().getTotalAttributeCount();
   }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.logs;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Value;
-import io.opentelemetry.api.common.ValueType;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -93,21 +92,6 @@ public interface ReadWriteLogRecord {
     return toLogRecordData().getSeverityText();
   }
 
-  /**
-   * Returns the body for this log, or {@link io.opentelemetry.sdk.logs.data.Body#empty()} if unset.
-   *
-   * <p>If the body has been set to some {@link ValueType} other than {@link ValueType#STRING}, this
-   * will return a {@link io.opentelemetry.sdk.logs.data.Body} with a string representation of the
-   * {@link Value}.
-   *
-   * @deprecated Use {@link #getBodyValue()} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("deprecation") // Implementation of deprecated method
-  default io.opentelemetry.sdk.logs.data.Body getBody() {
-    return toLogRecordData().getBody();
-  }
-
   /** Returns the {@link Value} representation of the log body, of null if unset. */
   @Nullable
   default Value<?> getBodyValue() {
@@ -117,16 +101,5 @@ public interface ReadWriteLogRecord {
   /** Returns the attributes for this log, or {@link Attributes#empty()} if unset. */
   default Attributes getAttributes() {
     return toLogRecordData().getAttributes();
-  }
-
-  /**
-   * Returns the total number of attributes that were recorded on this log.
-   *
-   * <p>This number may be larger than the number of attributes that are attached to this log, if
-   * the total number recorded was greater than the configured maximum value. See {@link
-   * LogLimits#getMaxNumberOfAttributes()}.
-   */
-  default int getTotalAttributeCount() {
-    return toLogRecordData().getTotalAttributeCount();
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ReadWriteLogRecord.java
@@ -12,7 +12,6 @@ import io.opentelemetry.api.common.ValueType;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.logs.data.Body;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import javax.annotation.Nullable;
 

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
@@ -125,4 +125,72 @@ class SdkReadWriteLogRecord implements ReadWriteLogRecord {
           attributes == null ? 0 : attributes.getTotalAddedValues());
     }
   }
+
+  @Override
+  public Resource getResource() {
+    return resource;
+  }
+
+  @Override
+  public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return instrumentationScopeInfo;
+  }
+
+  @Override
+  public long getTimestampEpochNanos() {
+    return timestampEpochNanos;
+  }
+
+  @Override
+  public long getObservedTimestampEpochNanos() {
+    return observedTimestampEpochNanos;
+  }
+
+  @Override
+  public SpanContext getSpanContext() {
+    return spanContext;
+  }
+
+  @Override
+  public Severity getSeverity() {
+    return severity;
+  }
+
+  @Nullable
+  @Override
+  public String getSeverityText() {
+    return severityText;
+  }
+
+  @Nullable
+  @Override
+  public Value<?> getBodyValue() {
+    return body;
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return getImmutableAttributes();
+  }
+
+  @Nullable
+  @Override
+  public <T> T getAttribute(AttributeKey<T> key) {
+    synchronized (lock) {
+      if (attributes == null || attributes.isEmpty()) {
+        return null;
+      }
+      return attributes.get(key);
+    }
+  }
+
+  @Override
+  public int getTotalAttributeCount() {
+    synchronized (lock) {
+      if (attributes == null || attributes.isEmpty()) {
+        return 0;
+      }
+      return attributes.size();
+    }
+  }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
@@ -127,11 +127,6 @@ class SdkReadWriteLogRecord implements ReadWriteLogRecord {
   }
 
   @Override
-  public Resource getResource() {
-    return resource;
-  }
-
-  @Override
   public InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return instrumentationScopeInfo;
   }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkReadWriteLogRecord.java
@@ -178,14 +178,4 @@ class SdkReadWriteLogRecord implements ReadWriteLogRecord {
       return attributes.get(key);
     }
   }
-
-  @Override
-  public int getTotalAttributeCount() {
-    synchronized (lock) {
-      if (attributes == null || attributes.isEmpty()) {
-        return 0;
-      }
-      return attributes.size();
-    }
-  }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/ReadWriteLogRecordTest.java
@@ -26,7 +26,7 @@ class ReadWriteLogRecordTest {
 
     logRecord.setAllAttributes(newAttributes);
 
-    Attributes result = logRecord.toLogRecordData().getAttributes();
+    Attributes result = logRecord.getAttributes();
     assertThat(result.get(stringKey("foo"))).isEqualTo("bar");
     assertThat(result.get(stringKey("bar"))).isEqualTo("buzz");
     assertThat(result.get(stringKey("untouched"))).isEqualTo("yes");
@@ -35,17 +35,17 @@ class ReadWriteLogRecordTest {
   @Test
   void addAllHandlesNull() {
     SdkReadWriteLogRecord logRecord = buildLogRecord();
-    Attributes originalAttributes = logRecord.toLogRecordData().getAttributes();
+    Attributes originalAttributes = logRecord.getAttributes();
     ReadWriteLogRecord result = logRecord.setAllAttributes(null);
-    assertThat(result.toLogRecordData().getAttributes()).isEqualTo(originalAttributes);
+    assertThat(result.getAttributes()).isEqualTo(originalAttributes);
   }
 
   @Test
   void allHandlesEmpty() {
     SdkReadWriteLogRecord logRecord = buildLogRecord();
-    Attributes originalAttributes = logRecord.toLogRecordData().getAttributes();
+    Attributes originalAttributes = logRecord.getAttributes();
     ReadWriteLogRecord result = logRecord.setAllAttributes(Attributes.empty());
-    assertThat(result.toLogRecordData().getAttributes()).isEqualTo(originalAttributes);
+    assertThat(result.getAttributes()).isEqualTo(originalAttributes);
   }
 
   SdkReadWriteLogRecord buildLogRecord() {


### PR DESCRIPTION
Resolves #6895.

To maintain binary compatibility, default implementations were provided.