### PR TITLE
Remove outdated TODOs

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/package-info.java
@@ -13,7 +13,6 @@
  * <p>Note that entries are independent of the tracing data that is propagated in the {@link
  * io.opentelemetry.context.Context}, such as trace ID.
  */
-// TODO: Add code examples.
 @ParametersAreNonnullByDefault
 package io.opentelemetry.api.baggage;
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/package-info.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/package-info.java
@@ -18,7 +18,6 @@
  * io.opentelemetry.context.Context} and between process using one of the wire propagation formats
  * supported in the {@code opentelemetry.trace.propagation} package.
  */
-// TODO: Add code examples.
 @ParametersAreNonnullByDefault
 package io.opentelemetry.api.trace;
 


### PR DESCRIPTION
We have no plans to add code examples to our `package-info.java` files.