### PR TITLE
Add gRPC authenticator for exporter

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/auth/Authenticator.java
@@ -41,7 +41,7 @@ public interface Authenticator {
       field.setAccessible(true);
       Object value = field.get(builder);
       if (value instanceof GrpcExporterBuilder) {
-        throw new IllegalArgumentException("GrpcExporterBuilder not supported yet.");
+        ((GrpcExporterBuilder<?>) value).setAuthenticator(authenticator);
       } else if (value instanceof HttpExporterBuilder) {
         ((HttpExporterBuilder<?>) value).setAuthenticator(authenticator);
       } else {

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.internal.grpc;
 
 import io.grpc.Channel;
+import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
@@ -40,5 +41,6 @@ public interface GrpcSenderProvider {
       Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       @Nullable RetryPolicy retryPolicy,
       @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager);
+      @Nullable X509TrustManager trustManager,
+      @Nullable Authenticator authenticator);
 }

--- a/exporters/common/src/main/resources/META-INF/native-image/io.opentelemetry.opentelemetry-exporter-common/reflect-config.json
+++ b/exporters/common/src/main/resources/META-INF/native-image/io.opentelemetry.opentelemetry-exporter-common/reflect-config.json
@@ -10,5 +10,9 @@
   {
     "name":"io.opentelemetry.exporter.internal.compression.Compressor",
     "queryAllDeclaredMethods":true
+  },
+  {
+    "name":"io.opentelemetry.exporter.internal.auth.Authenticator",
+    "queryAllDeclaredMethods":true
   }
 ]

--- a/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
+++ b/exporters/otlp/all/src/jmh/java/io/opentelemetry/exporter/otlp/trace/OltpExporterBenchmark.java
@@ -105,6 +105,7 @@ public class OltpExporterBenchmark {
                 Collections::emptyMap,
                 null,
                 null,
+                null,
                 null),
             MeterProvider::noop);
 

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
 import io.grpc.Channel;
+import io.opentelemetry.exporter.internal.auth.Authenticator;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.grpc.GrpcSender;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
@@ -41,7 +42,8 @@ public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
       Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
       @Nullable RetryPolicy retryPolicy,
       @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager) {
+      @Nullable X509TrustManager trustManager,
+      @Nullable Authenticator authenticator) {
     return new OkHttpGrpcSender<>(
         endpoint.resolve(endpointPath).toString(),
         compressor,
@@ -50,6 +52,7 @@ public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
         headersSupplier,
         retryPolicy,
         sslContext,
-        trustManager);
+        trustManager,
+        authenticator);
   }
 }

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSuppressionTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSuppressionTest.java
@@ -21,7 +21,7 @@ class OkHttpGrpcSuppressionTest
   @Override
   OkHttpGrpcSender<DummyMarshaler> createSender(String endpoint) {
     return new OkHttpGrpcSender<>(
-        "https://localhost", null, 10L, 10L, Collections::emptyMap, null, null, null);
+        "https://localhost", null, 10L, 10L, Collections::emptyMap, null, null, null, null);
   }
 
   protected static class DummyMarshaler extends MarshalerWithSize {


### PR DESCRIPTION
Adding missing gRPC authentication features to the experimental `Authenticator` api. Closes #6953 