### PR TITLE
[Prototype] How to support complex attributes in logs/events? (Option C)

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttribute.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttribute.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import io.opentelemetry.api.internal.ImmutableKeyValuePairs;
+import java.util.ArrayList;
+import java.util.Comparator;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+final class ArrayBackedComplexAttribute extends ImmutableKeyValuePairs<AttributeKey<?>, Object>
+    implements ComplexAttribute {
+
+  // We only compare the key name, not type, when constructing, to allow deduping keys with the
+  // same name but different type.
+  private static final Comparator<AttributeKey<?>> KEY_COMPARATOR_FOR_CONSTRUCTION =
+      Comparator.comparing(AttributeKey::getKey);
+
+  static final ComplexAttribute EMPTY = ComplexAttribute.builder().build();
+
+  private ArrayBackedComplexAttribute(Object[] data, Comparator<AttributeKey<?>> keyComparator) {
+    super(data, keyComparator);
+  }
+
+  /**
+   * Only use this constructor if you can guarantee that the data has been de-duped, sorted by key
+   * and contains no null values or null/empty keys.
+   *
+   * @param data the raw data
+   */
+  ArrayBackedComplexAttribute(Object[] data) {
+    super(data);
+  }
+
+  @Override
+  public ComplexAttributeBuilder toBuilder() {
+    return new ArrayBackedComplexAttributeBuilder(new ArrayList<>(data()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  @Nullable
+  public <T> T get(AttributeKey<T> key) {
+    return (T) super.get(key);
+  }
+
+  static ComplexAttribute sortAndFilterToAttributes(Object... data) {
+    // null out any empty keys or keys with null values
+    // so they will then be removed by the sortAndFilter method.
+    for (int i = 0; i < data.length; i += 2) {
+      AttributeKey<?> key = (AttributeKey<?>) data[i];
+      if (key != null && key.getKey().isEmpty()) {
+        data[i] = null;
+      }
+    }
+    return new ArrayBackedComplexAttribute(data, KEY_COMPARATOR_FOR_CONSTRUCTION);
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttributeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttributeBuilder.java
@@ -23,8 +23,9 @@ class ArrayBackedComplexAttributeBuilder implements ComplexAttributeBuilder {
 
   @Override
   public ComplexAttribute build() {
-    // If only one key-value pair AND the entry hasn't been set to null (by #remove(AttributeKey<T>)
-    // or #removeIf(Predicate<AttributeKey<?>>)), then we can bypass sorting and filtering
+    // If only one key-value pair AND the entry hasn't been set to null (by
+    // #remove(ComplexAttributeKey<T>)
+    // or #removeIf(Predicate<ComplexAttributeKey<?>>)), then we can bypass sorting and filtering
     if (data.size() == 2 && data.get(0) != null) {
       return new ArrayBackedComplexAttribute(data.toArray());
     }
@@ -32,7 +33,7 @@ class ArrayBackedComplexAttributeBuilder implements ComplexAttributeBuilder {
   }
 
   @Override
-  public <T> ComplexAttributeBuilder put(AttributeKey<T> key, T value) {
+  public <T> ComplexAttributeBuilder put(ComplexAttributeKey<T> key, T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }
@@ -42,19 +43,7 @@ class ArrayBackedComplexAttributeBuilder implements ComplexAttributeBuilder {
   }
 
   @Override
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public ComplexAttributeBuilder putAll(Attributes attributes) {
-    if (attributes == null) {
-      return this;
-    }
-    // Attributes must iterate over their entries with matching types for key / value, so this
-    // downcast to the raw type is safe.
-    attributes.forEach((key, value) -> put((AttributeKey) key, value));
-    return this;
-  }
-
-  @Override
-  public <T> ComplexAttributeBuilder remove(AttributeKey<T> key) {
+  public <T> ComplexAttributeBuilder remove(ComplexAttributeKey<T> key) {
     if (key == null || key.getKey().isEmpty()) {
       return this;
     }
@@ -64,13 +53,13 @@ class ArrayBackedComplexAttributeBuilder implements ComplexAttributeBuilder {
   }
 
   @Override
-  public ComplexAttributeBuilder removeIf(Predicate<AttributeKey<?>> predicate) {
+  public ComplexAttributeBuilder removeIf(Predicate<ComplexAttributeKey<?>> predicate) {
     if (predicate == null) {
       return this;
     }
     for (int i = 0; i < data.size() - 1; i += 2) {
       Object entry = data.get(i);
-      if (entry instanceof AttributeKey && predicate.test((AttributeKey<?>) entry)) {
+      if (entry instanceof ComplexAttributeKey && predicate.test((ComplexAttributeKey<?>) entry)) {
         // null items are filtered out in ArrayBackedAttributes
         data.set(i, null);
         data.set(i + 1, null);

--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttributeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedComplexAttributeBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+class ArrayBackedComplexAttributeBuilder implements ComplexAttributeBuilder {
+  private final List<Object> data;
+
+  ArrayBackedComplexAttributeBuilder() {
+    data = new ArrayList<>();
+  }
+
+  ArrayBackedComplexAttributeBuilder(List<Object> data) {
+    this.data = data;
+  }
+
+  @Override
+  public ComplexAttribute build() {
+    // If only one key-value pair AND the entry hasn't been set to null (by #remove(AttributeKey<T>)
+    // or #removeIf(Predicate<AttributeKey<?>>)), then we can bypass sorting and filtering
+    if (data.size() == 2 && data.get(0) != null) {
+      return new ArrayBackedComplexAttribute(data.toArray());
+    }
+    return ArrayBackedComplexAttribute.sortAndFilterToAttributes(data.toArray());
+  }
+
+  @Override
+  public <T> ComplexAttributeBuilder put(AttributeKey<T> key, T value) {
+    if (key == null || key.getKey().isEmpty() || value == null) {
+      return this;
+    }
+    data.add(key);
+    data.add(value);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public ComplexAttributeBuilder putAll(Attributes attributes) {
+    if (attributes == null) {
+      return this;
+    }
+    // Attributes must iterate over their entries with matching types for key / value, so this
+    // downcast to the raw type is safe.
+    attributes.forEach((key, value) -> put((AttributeKey) key, value));
+    return this;
+  }
+
+  @Override
+  public <T> ComplexAttributeBuilder remove(AttributeKey<T> key) {
+    if (key == null || key.getKey().isEmpty()) {
+      return this;
+    }
+    return removeIf(
+        entryKey ->
+            key.getKey().equals(entryKey.getKey()) && key.getType().equals(entryKey.getType()));
+  }
+
+  @Override
+  public ComplexAttributeBuilder removeIf(Predicate<AttributeKey<?>> predicate) {
+    if (predicate == null) {
+      return this;
+    }
+    for (int i = 0; i < data.size() - 1; i += 2) {
+      Object entry = data.get(i);
+      if (entry instanceof AttributeKey && predicate.test((AttributeKey<?>) entry)) {
+        // null items are filtered out in ArrayBackedAttributes
+        data.set(i, null);
+        data.set(i + 1, null);
+      }
+    }
+    return this;
+  }
+
+  static List<Double> toList(double... values) {
+    Double[] boxed = new Double[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
+  }
+
+  static List<Long> toList(long... values) {
+    Long[] boxed = new Long[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
+  }
+
+  static List<Boolean> toList(boolean... values) {
+    Boolean[] boxed = new Boolean[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxed[i] = values[i];
+    }
+    return Arrays.asList(boxed);
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributeKey.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributeKey.java
@@ -65,4 +65,14 @@ public interface AttributeKey<T> {
   static AttributeKey<List<Double>> doubleArrayKey(String key) {
     return InternalAttributeKeyImpl.create(key, AttributeType.DOUBLE_ARRAY);
   }
+
+  /**
+   * Returns a new AttributeKey for complex valued attributes.
+   *
+   * <p>IMPORTANT: complex valued attributes are only supported by Logs. Spans and Metrics do not
+   * support complex valued attributes.
+   */
+  static AttributeKey<ComplexAttribute> complexKey(String key) {
+    return InternalAttributeKeyImpl.create(key, AttributeType.COMPLEX);
+  }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributeType.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributeType.java
@@ -17,5 +17,10 @@ public enum AttributeType {
   STRING_ARRAY,
   BOOLEAN_ARRAY,
   LONG_ARRAY,
-  DOUBLE_ARRAY
+  DOUBLE_ARRAY,
+  /**
+   * IMPORTANT: complex valued attributes are only supported by Logs. Spans and Metrics do not
+   * support complex valued attributes.
+   */
+  COMPLEX
 }

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttribute.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttribute.java
@@ -29,7 +29,6 @@ import javax.annotation.concurrent.Immutable;
  * <p>For this reason, it is strongly suggested that you use the implementation that is provided
  * here via the factory methods and the {@link ComplexAttributeBuilder}.
  */
-@SuppressWarnings("rawtypes")
 @Immutable
 public interface ComplexAttribute {
 

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttribute.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttribute.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import static io.opentelemetry.api.common.ArrayBackedComplexAttribute.sortAndFilterToAttributes;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * An immutable container for a complex attribute.
+ *
+ * <p>The keys are {@link AttributeKey}s and the values are Object instances that match the type of
+ * the provided key.
+ *
+ * <p>Null keys will be silently dropped.
+ *
+ * <p>Note: The behavior of null-valued attributes is undefined, and hence strongly discouraged.
+ *
+ * <p>Implementations of this interface *must* be immutable and have well-defined value-based
+ * equals/hashCode implementations. If an implementation does not strictly conform to these
+ * requirements, behavior of the OpenTelemetry APIs and default SDK cannot be guaranteed.
+ *
+ * <p>For this reason, it is strongly suggested that you use the implementation that is provided
+ * here via the factory methods and the {@link ComplexAttributeBuilder}.
+ */
+@SuppressWarnings("rawtypes")
+@Immutable
+public interface ComplexAttribute {
+
+  /** Returns the value for the given {@link AttributeKey}, or {@code null} if not found. */
+  @Nullable
+  <T> T get(AttributeKey<T> key);
+
+  /** Iterates over all the key-value pairs of attributes contained by this instance. */
+  void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> consumer);
+
+  /** The number of attributes contained in this. */
+  int size();
+
+  /** Whether there are any attributes contained in this. */
+  boolean isEmpty();
+
+  /** Returns a read-only view of this {@link ComplexAttribute} as a {@link Map}. */
+  Map<AttributeKey<?>, Object> asMap();
+
+  /** Returns a {@link ComplexAttribute} instance with no attributes. */
+  static ComplexAttribute empty() {
+    return ArrayBackedComplexAttribute.EMPTY;
+  }
+
+  /** Returns a {@link ComplexAttribute} instance with a single key-value pair. */
+  static <T> ComplexAttribute of(AttributeKey<T> key, T value) {
+    if (key == null || key.getKey().isEmpty() || value == null) {
+      return empty();
+    }
+    return new ArrayBackedComplexAttribute(new Object[] {key, value});
+  }
+
+  /**
+   * Returns a {@link ComplexAttribute} instance with two key-value pairs. Order of the keys is not
+   * preserved. Duplicate keys will be removed.
+   */
+  static <T, U> ComplexAttribute of(
+      AttributeKey<T> key1, T value1, AttributeKey<U> key2, U value2) {
+    if (key1 == null || key1.getKey().isEmpty() || value1 == null) {
+      return of(key2, value2);
+    }
+    if (key2 == null || key2.getKey().isEmpty() || value2 == null) {
+      return of(key1, value1);
+    }
+    if (key1.getKey().equals(key2.getKey())) {
+      // last one in wins
+      return of(key2, value2);
+    }
+    if (key1.getKey().compareTo(key2.getKey()) > 0) {
+      return new ArrayBackedComplexAttribute(new Object[] {key2, value2, key1, value1});
+    }
+    return new ArrayBackedComplexAttribute(new Object[] {key1, value1, key2, value2});
+  }
+
+  /**
+   * Returns a {@link ComplexAttribute} instance with three key-value pairs. Order of the keys is
+   * not preserved. Duplicate keys will be removed.
+   */
+  static <T, U, V> ComplexAttribute of(
+      AttributeKey<T> key1,
+      T value1,
+      AttributeKey<U> key2,
+      U value2,
+      AttributeKey<V> key3,
+      V value3) {
+    return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3);
+  }
+
+  /**
+   * Returns a {@link ComplexAttribute} instance with four key-value pairs. Order of the keys is not
+   * preserved. Duplicate keys will be removed.
+   */
+  static <T, U, V, W> ComplexAttribute of(
+      AttributeKey<T> key1,
+      T value1,
+      AttributeKey<U> key2,
+      U value2,
+      AttributeKey<V> key3,
+      V value3,
+      AttributeKey<W> key4,
+      W value4) {
+    return sortAndFilterToAttributes(key1, value1, key2, value2, key3, value3, key4, value4);
+  }
+
+  /**
+   * Returns a {@link ComplexAttribute} instance with five key-value pairs. Order of the keys is not
+   * preserved. Duplicate keys will be removed.
+   */
+  @SuppressWarnings("TooManyParameters")
+  static <T, U, V, W, X> ComplexAttribute of(
+      AttributeKey<T> key1,
+      T value1,
+      AttributeKey<U> key2,
+      U value2,
+      AttributeKey<V> key3,
+      V value3,
+      AttributeKey<W> key4,
+      W value4,
+      AttributeKey<X> key5,
+      X value5) {
+    return sortAndFilterToAttributes(
+        key1, value1,
+        key2, value2,
+        key3, value3,
+        key4, value4,
+        key5, value5);
+  }
+
+  /**
+   * Returns a {@link ComplexAttribute} instance with the given key-value pairs. Order of the keys
+   * is not preserved. Duplicate keys will be removed.
+   */
+  @SuppressWarnings("TooManyParameters")
+  static <T, U, V, W, X, Y> ComplexAttribute of(
+      AttributeKey<T> key1,
+      T value1,
+      AttributeKey<U> key2,
+      U value2,
+      AttributeKey<V> key3,
+      V value3,
+      AttributeKey<W> key4,
+      W value4,
+      AttributeKey<X> key5,
+      X value5,
+      AttributeKey<Y> key6,
+      Y value6) {
+    return sortAndFilterToAttributes(
+        key1, value1,
+        key2, value2,
+        key3, value3,
+        key4, value4,
+        key5, value5,
+        key6, value6);
+  }
+
+  /**
+   * Returns a new {@link ComplexAttributeBuilder} instance for creating arbitrary {@link
+   * ComplexAttribute}.
+   */
+  static ComplexAttributeBuilder builder() {
+    return new ArrayBackedComplexAttributeBuilder();
+  }
+
+  /**
+   * Returns a new {@link ComplexAttributeBuilder} instance populated with the data of this {@link
+   * ComplexAttribute}.
+   */
+  ComplexAttributeBuilder toBuilder();
+}

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeBuilder.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.api.common;
 
 import static io.opentelemetry.api.common.ArrayBackedAttributesBuilder.toList;
-import static io.opentelemetry.api.common.AttributeKey.booleanArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.booleanArrayKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.booleanKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.doubleArrayKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.doubleKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.longArrayKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.longKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.ComplexAttributeKey.stringKey;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,22 +25,22 @@ public interface ComplexAttributeBuilder {
   ComplexAttribute build();
 
   /**
-   * Puts a {@link AttributeKey} with associated value into this.
+   * Puts a {@link ComplexAttributeKey} with associated value into this.
    *
    * <p>The type parameter is unused.
    */
-  default ComplexAttributeBuilder put(AttributeKey<Long> key, int value) {
+  default ComplexAttributeBuilder put(ComplexAttributeKey<Long> key, int value) {
     return put(key, (long) value);
   }
 
-  /** Puts a {@link AttributeKey} with associated value into this. */
-  <T> ComplexAttributeBuilder put(AttributeKey<T> key, T value);
+  /** Puts a {@link ComplexAttributeKey} with associated value into this. */
+  <T> ComplexAttributeBuilder put(ComplexAttributeKey<T> key, T value);
 
   /**
    * Puts a String attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -51,8 +51,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a long attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -63,8 +63,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a double attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -75,8 +75,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a boolean attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -87,8 +87,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a String array attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -105,7 +105,7 @@ public interface ComplexAttributeBuilder {
    * @return this Builder
    */
   @SuppressWarnings("unchecked")
-  default <T> ComplexAttributeBuilder put(AttributeKey<List<T>> key, T... value) {
+  default <T> ComplexAttributeBuilder put(ComplexAttributeKey<List<T>> key, T... value) {
     if (value == null) {
       return this;
     }
@@ -115,8 +115,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a Long array attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -130,8 +130,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a Double array attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -145,8 +145,8 @@ public interface ComplexAttributeBuilder {
   /**
    * Puts a Boolean array attribute into this.
    *
-   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
-   * your keys, if possible.
+   * <p>Note: It is strongly recommended to use {@link #put(ComplexAttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
    *
    * @return this Builder
    */
@@ -158,19 +158,12 @@ public interface ComplexAttributeBuilder {
   }
 
   /**
-   * Puts all the provided attributes into this Builder.
+   * Remove all attributes where {@link ComplexAttributeKey#getKey()} and {@link
+   * ComplexAttributeKey#getType()} match the {@code key}.
    *
    * @return this Builder
    */
-  ComplexAttributeBuilder putAll(Attributes attributes);
-
-  /**
-   * Remove all attributes where {@link AttributeKey#getKey()} and {@link AttributeKey#getType()}
-   * match the {@code key}.
-   *
-   * @return this Builder
-   */
-  <T> ComplexAttributeBuilder remove(AttributeKey<T> key);
+  <T> ComplexAttributeBuilder remove(ComplexAttributeKey<T> key);
 
   /**
    * Remove all attributes that satisfy the given predicate. Errors or runtime exceptions thrown by
@@ -178,5 +171,5 @@ public interface ComplexAttributeBuilder {
    *
    * @return this Builder
    */
-  ComplexAttributeBuilder removeIf(Predicate<AttributeKey<?>> filter);
+  ComplexAttributeBuilder removeIf(Predicate<ComplexAttributeKey<?>> filter);
 }

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeBuilder.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import static io.opentelemetry.api.common.ArrayBackedAttributesBuilder.toList;
+import static io.opentelemetry.api.common.AttributeKey.booleanArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+/** A builder of {@link ComplexAttribute} supporting an arbitrary number of key-value pairs. */
+public interface ComplexAttributeBuilder {
+  /** Create the {@link ComplexAttribute} from this. */
+  ComplexAttribute build();
+
+  /**
+   * Puts a {@link AttributeKey} with associated value into this.
+   *
+   * <p>The type parameter is unused.
+   */
+  default ComplexAttributeBuilder put(AttributeKey<Long> key, int value) {
+    return put(key, (long) value);
+  }
+
+  /** Puts a {@link AttributeKey} with associated value into this. */
+  <T> ComplexAttributeBuilder put(AttributeKey<T> key, T value);
+
+  /**
+   * Puts a String attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, String value) {
+    return put(stringKey(key), value);
+  }
+
+  /**
+   * Puts a long attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, long value) {
+    return put(longKey(key), value);
+  }
+
+  /**
+   * Puts a double attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, double value) {
+    return put(doubleKey(key), value);
+  }
+
+  /**
+   * Puts a boolean attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, boolean value) {
+    return put(booleanKey(key), value);
+  }
+
+  /**
+   * Puts a String array attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, String... value) {
+    if (value == null) {
+      return this;
+    }
+    return put(stringArrayKey(key), Arrays.asList(value));
+  }
+
+  /**
+   * Puts a List attribute into this.
+   *
+   * @return this Builder
+   */
+  @SuppressWarnings("unchecked")
+  default <T> ComplexAttributeBuilder put(AttributeKey<List<T>> key, T... value) {
+    if (value == null) {
+      return this;
+    }
+    return put(key, Arrays.asList(value));
+  }
+
+  /**
+   * Puts a Long array attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, long... value) {
+    if (value == null) {
+      return this;
+    }
+    return put(longArrayKey(key), toList(value));
+  }
+
+  /**
+   * Puts a Double array attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, double... value) {
+    if (value == null) {
+      return this;
+    }
+    return put(doubleArrayKey(key), toList(value));
+  }
+
+  /**
+   * Puts a Boolean array attribute into this.
+   *
+   * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
+   * your keys, if possible.
+   *
+   * @return this Builder
+   */
+  default ComplexAttributeBuilder put(String key, boolean... value) {
+    if (value == null) {
+      return this;
+    }
+    return put(booleanArrayKey(key), toList(value));
+  }
+
+  /**
+   * Puts all the provided attributes into this Builder.
+   *
+   * @return this Builder
+   */
+  ComplexAttributeBuilder putAll(Attributes attributes);
+
+  /**
+   * Remove all attributes where {@link AttributeKey#getKey()} and {@link AttributeKey#getType()}
+   * match the {@code key}.
+   *
+   * @return this Builder
+   */
+  <T> ComplexAttributeBuilder remove(AttributeKey<T> key);
+
+  /**
+   * Remove all attributes that satisfy the given predicate. Errors or runtime exceptions thrown by
+   * the predicate are relayed to the caller.
+   *
+   * @return this Builder
+   */
+  ComplexAttributeBuilder removeIf(Predicate<AttributeKey<?>> filter);
+}

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeKey.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeKey.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+import io.opentelemetry.api.internal.InternalComplexAttributeKeyImpl;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * This interface provides a handle for setting the values of {@link Attributes}. The type of value
+ * that can be set with an implementation of this key is denoted by the type parameter.
+ *
+ * <p>Implementations MUST be immutable, as these are used as the keys to Maps.
+ *
+ * @param <T> The type of value that can be set with the key.
+ */
+@SuppressWarnings("rawtypes")
+@Immutable
+public interface ComplexAttributeKey<T> {
+  /** Returns the underlying String representation of the key. */
+  String getKey();
+
+  /** Returns the type of attribute for this key. Useful for building switch statements. */
+  AttributeType getType();
+
+  /** Returns a new AttributeKey for String valued attributes. */
+  static ComplexAttributeKey<String> stringKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.STRING);
+  }
+
+  /** Returns a new AttributeKey for Boolean valued attributes. */
+  static ComplexAttributeKey<Boolean> booleanKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.BOOLEAN);
+  }
+
+  /** Returns a new AttributeKey for Long valued attributes. */
+  static ComplexAttributeKey<Long> longKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.LONG);
+  }
+
+  /** Returns a new AttributeKey for Double valued attributes. */
+  static ComplexAttributeKey<Double> doubleKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.DOUBLE);
+  }
+
+  /** Returns a new AttributeKey for List&lt;String&gt; valued attributes. */
+  static ComplexAttributeKey<List<String>> stringArrayKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.STRING_ARRAY);
+  }
+
+  /** Returns a new AttributeKey for List&lt;Boolean&gt; valued attributes. */
+  static ComplexAttributeKey<List<Boolean>> booleanArrayKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.BOOLEAN_ARRAY);
+  }
+
+  /** Returns a new AttributeKey for List&lt;Long&gt; valued attributes. */
+  static ComplexAttributeKey<List<Long>> longArrayKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.LONG_ARRAY);
+  }
+
+  /** Returns a new AttributeKey for List&lt;Double&gt; valued attributes. */
+  static ComplexAttributeKey<List<Double>> doubleArrayKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, AttributeType.DOUBLE_ARRAY);
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeKey.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeKey.java
@@ -17,52 +17,56 @@ import javax.annotation.concurrent.Immutable;
  *
  * @param <T> The type of value that can be set with the key.
  */
-@SuppressWarnings("rawtypes")
 @Immutable
 public interface ComplexAttributeKey<T> {
   /** Returns the underlying String representation of the key. */
   String getKey();
 
   /** Returns the type of attribute for this key. Useful for building switch statements. */
-  AttributeType getType();
+  ComplexAttributeType getType();
 
   /** Returns a new AttributeKey for String valued attributes. */
   static ComplexAttributeKey<String> stringKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.STRING);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.STRING);
   }
 
   /** Returns a new AttributeKey for Boolean valued attributes. */
   static ComplexAttributeKey<Boolean> booleanKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.BOOLEAN);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.BOOLEAN);
   }
 
   /** Returns a new AttributeKey for Long valued attributes. */
   static ComplexAttributeKey<Long> longKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.LONG);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.LONG);
   }
 
   /** Returns a new AttributeKey for Double valued attributes. */
   static ComplexAttributeKey<Double> doubleKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.DOUBLE);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.DOUBLE);
   }
 
   /** Returns a new AttributeKey for List&lt;String&gt; valued attributes. */
   static ComplexAttributeKey<List<String>> stringArrayKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.STRING_ARRAY);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.STRING_ARRAY);
   }
 
   /** Returns a new AttributeKey for List&lt;Boolean&gt; valued attributes. */
   static ComplexAttributeKey<List<Boolean>> booleanArrayKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.BOOLEAN_ARRAY);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.BOOLEAN_ARRAY);
   }
 
   /** Returns a new AttributeKey for List&lt;Long&gt; valued attributes. */
   static ComplexAttributeKey<List<Long>> longArrayKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.LONG_ARRAY);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.LONG_ARRAY);
   }
 
   /** Returns a new AttributeKey for List&lt;Double&gt; valued attributes. */
   static ComplexAttributeKey<List<Double>> doubleArrayKey(String key) {
-    return InternalComplexAttributeKeyImpl.create(key, AttributeType.DOUBLE_ARRAY);
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.DOUBLE_ARRAY);
+  }
+
+  /** Returns a new AttributeKey for Long valued attributes. */
+  static ComplexAttributeKey<ComplexAttribute> complexKey(String key) {
+    return InternalComplexAttributeKeyImpl.create(key, ComplexAttributeType.COMPLEX);
   }
 }

--- a/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeType.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ComplexAttributeType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.common;
+
+/**
+ * An enum that represents all the possible value types for an {@code ComplexAttributeKey} and hence
+ * the types of values that are allowed for {@link ComplexAttributes}.
+ */
+public enum ComplexAttributeType {
+  STRING,
+  BOOLEAN,
+  LONG,
+  DOUBLE,
+  STRING_ARRAY,
+  BOOLEAN_ARRAY,
+  LONG_ARRAY,
+  DOUBLE_ARRAY,
+  COMPLEX
+}

--- a/api/all/src/main/java/io/opentelemetry/api/internal/InternalComplexAttributeKeyImpl.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/InternalComplexAttributeKeyImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.api.internal;
+
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.ComplexAttributeKey;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+
+/**
+ * Default AttributeKey implementation which preencodes to UTF8 for OTLP export.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class InternalComplexAttributeKeyImpl<T> implements ComplexAttributeKey<T> {
+
+  private final AttributeType type;
+  private final String key;
+  private final int hashCode;
+
+  @Nullable private byte[] keyUtf8;
+
+  private InternalComplexAttributeKeyImpl(AttributeType type, String key) {
+    if (type == null) {
+      throw new NullPointerException("Null type");
+    }
+    this.type = type;
+    if (key == null) {
+      throw new NullPointerException("Null key");
+    }
+    this.key = key;
+    this.hashCode = buildHashCode(type, key);
+  }
+
+  // Used by auto-instrumentation agent. Check with auto-instrumentation before making changes to
+  // this method.
+  //
+  // In particular, do not change this return type to AttributeKeyImpl because auto-instrumentation
+  // hijacks this method and returns a bridged implementation of Context.
+  //
+  // Ideally auto-instrumentation would hijack the public AttributeKey.*Key() instead of this
+  // method, but auto-instrumentation also needs to inject its own implementation of AttributeKey
+  // into the class loader at the same time, which causes a problem because injecting a class into
+  // the class loader automatically resolves its super classes (interfaces), which in this case is
+  // Context, which would be the same class (interface) being instrumented at that time,
+  // which would lead to the JVM throwing a LinkageError "attempted duplicate interface definition"
+  public static <T> ComplexAttributeKey<T> create(@Nullable String key, AttributeType type) {
+    return new InternalComplexAttributeKeyImpl<>(type, key != null ? key : "");
+  }
+
+  @Override
+  public AttributeType getType() {
+    return type;
+  }
+
+  @Override
+  public String getKey() {
+    return key;
+  }
+
+  /** Returns the key, encoded as UTF-8 bytes. */
+  public byte[] getKeyUtf8() {
+    byte[] keyUtf8 = this.keyUtf8;
+    if (keyUtf8 == null) {
+      keyUtf8 = key.getBytes(StandardCharsets.UTF_8);
+      this.keyUtf8 = keyUtf8;
+    }
+    return keyUtf8;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof InternalComplexAttributeKeyImpl) {
+      InternalComplexAttributeKeyImpl<?> that = (InternalComplexAttributeKeyImpl<?>) o;
+      return this.type.equals(that.getType()) && this.key.equals(that.getKey());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+  @Override
+  public String toString() {
+    return key;
+  }
+
+  // this method exists to make EqualsVerifier happy
+  @SuppressWarnings("unused")
+  private int buildHashCode() {
+    return buildHashCode(type, key);
+  }
+
+  private static int buildHashCode(AttributeType type, String key) {
+    int result = 1;
+    result *= 1000003;
+    result ^= type.hashCode();
+    result *= 1000003;
+    result ^= key.hashCode();
+    return result;
+  }
+}

--- a/api/all/src/main/java/io/opentelemetry/api/internal/InternalComplexAttributeKeyImpl.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/InternalComplexAttributeKeyImpl.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.api.internal;
 
-import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.api.common.ComplexAttributeKey;
+import io.opentelemetry.api.common.ComplexAttributeType;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 
@@ -18,13 +18,13 @@ import javax.annotation.Nullable;
  */
 public final class InternalComplexAttributeKeyImpl<T> implements ComplexAttributeKey<T> {
 
-  private final AttributeType type;
+  private final ComplexAttributeType type;
   private final String key;
   private final int hashCode;
 
   @Nullable private byte[] keyUtf8;
 
-  private InternalComplexAttributeKeyImpl(AttributeType type, String key) {
+  private InternalComplexAttributeKeyImpl(ComplexAttributeType type, String key) {
     if (type == null) {
       throw new NullPointerException("Null type");
     }
@@ -48,12 +48,12 @@ public final class InternalComplexAttributeKeyImpl<T> implements ComplexAttribut
   // the class loader automatically resolves its super classes (interfaces), which in this case is
   // Context, which would be the same class (interface) being instrumented at that time,
   // which would lead to the JVM throwing a LinkageError "attempted duplicate interface definition"
-  public static <T> ComplexAttributeKey<T> create(@Nullable String key, AttributeType type) {
+  public static <T> ComplexAttributeKey<T> create(@Nullable String key, ComplexAttributeType type) {
     return new InternalComplexAttributeKeyImpl<>(type, key != null ? key : "");
   }
 
   @Override
-  public AttributeType getType() {
+  public ComplexAttributeType getType() {
     return type;
   }
 
@@ -100,7 +100,7 @@ public final class InternalComplexAttributeKeyImpl<T> implements ComplexAttribut
     return buildHashCode(type, key);
   }
 
-  private static int buildHashCode(AttributeType type, String key) {
+  private static int buildHashCode(ComplexAttributeType type, String key) {
     int result = 1;
     result *= 1000003;
     result ^= type.hashCode();

--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -7,7 +7,6 @@ package io.opentelemetry.api.logs;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.ComplexAttribute;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
@@ -114,20 +113,6 @@ public interface LogRecordBuilder {
    * @return this.
    */
   <T> LogRecordBuilder setAttribute(AttributeKey<T> key, T value);
-
-  /**
-   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
-   * previously contained a mapping for the key, the old value is replaced by the specified value.
-   *
-   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
-   *
-   * @param key the key for this attribute.
-   * @param value the value for this attribute.
-   * @return this.
-   */
-  default <T> LogRecordBuilder setComplexAttribute(AttributeKey<T> key, ComplexAttribute value) {
-    return this;
-  }
 
   /**
    * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}

--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.api.logs;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.ComplexAttribute;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
@@ -85,8 +86,12 @@ public interface LogRecordBuilder {
   }
 
   /**
-   * Sets attributes. If the {@link LogRecordBuilder} previously contained a mapping for any of the
-   * keys, the old values are replaced by the specified values.
+   * Sets attributes to the newly created {@code LogRecord}. If the {@link LogRecordBuilder}
+   * previously contained a mapping for any of the keys, the old values are replaced by the
+   * specified values.
+   *
+   * @param attributes the attributes
+   * @return this.
    */
   @SuppressWarnings("unchecked")
   default LogRecordBuilder setAllAttributes(Attributes attributes) {
@@ -98,8 +103,109 @@ public interface LogRecordBuilder {
     return this;
   }
 
-  /** Sets an attribute. */
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
   <T> LogRecordBuilder setAttribute(AttributeKey<T> key, T value);
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default <T> LogRecordBuilder setComplexAttribute(AttributeKey<T> key, ComplexAttribute value) {
+    return this;
+  }
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>If a null or empty String {@code value} is passed in, the behavior is undefined, and hence
+   * strongly discouraged.
+   *
+   * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default LogRecordBuilder setAttribute(String key, String value) {
+    return setAttribute(AttributeKey.stringKey(key), value);
+  }
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default LogRecordBuilder setAttribute(String key, long value) {
+    return setAttribute(AttributeKey.longKey(key), value);
+  }
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default LogRecordBuilder setAttribute(String key, double value) {
+    return setAttribute(AttributeKey.doubleKey(key), value);
+  }
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default LogRecordBuilder setAttribute(String key, boolean value) {
+    return setAttribute(AttributeKey.booleanKey(key), value);
+  }
+
+  /**
+   * Sets an attribute to the newly created {@code LogRecord}. If {@code LogRecordBuilder}
+   * previously contained a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
+   * pre-allocate your keys, if possible.
+   *
+   * @param key the key for this attribute.
+   * @param value the value for this attribute.
+   * @return this.
+   */
+  default LogRecordBuilder setAttribute(AttributeKey<Long> key, int value) {
+    return setAttribute(key, (long) value);
+  }
 
   /** Emit the log record. */
   void emit();


### PR DESCRIPTION
Another half-baked option.

This is basically Option A, but instead of reusing the `Attributes` class as the property bag for nested attributes, it introduces new types `ComplexAttribute` / `ComplexAttributeBuilder` / `ComplexAttributeKey` which are just copies of `Attributes` / `AttributesBuilder` / `AttributesKey`.

The disadvantage of this option is obviously the copy-pasting.

The advantage of this option is that it is a bit more explicit for users (and so probably a bit less confusing than reusing the top-level Attributes bag to represent complex attributes).

Note: I'm using the term "complex attributes" to mean map-valued attributes. I will see if this (or some other) term can be agreed on in specification / semconv.

Another naming option could be:
* `MapAttribute`
* `MapAttributeBuilder`
* `MapAttributeKey`

If we ever need to support "any valued" attributes (i.e. heterogeneous arrays), then I think we could layer that on top of this using Option B.