### PR TITLE
Explicitly allow null into CompletableResultCode.failExceptionally()

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -123,9 +123,10 @@ public final class CompletableResultCode {
    * Completes this {@link CompletableResultCode} unsuccessfully if it is not already completed,
    * setting the {@link #getFailureThrowable() failure throwable} to {@code throwable}.
    *
+   * @param throwable the Throwable that caused the failure, or null
    * @since 1.41.0
    */
-  public CompletableResultCode failExceptionally(Throwable throwable) {
+  public CompletableResultCode failExceptionally(@Nullable Throwable throwable) {
     return failInternal(throwable);
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -123,7 +123,7 @@ public final class CompletableResultCode {
    * Completes this {@link CompletableResultCode} unsuccessfully if it is not already completed,
    * setting the {@link #getFailureThrowable() failure throwable} to {@code throwable}.
    *
-   * @param throwable the Throwable that caused the failure, or null
+   * @param throwable the {@code Throwable} that caused the failure, or {@code null}
    * @since 1.41.0
    */
   public CompletableResultCode failExceptionally(@Nullable Throwable throwable) {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -161,7 +161,8 @@ public final class CompletableResultCode {
    * via the {@link #whenComplete(Runnable)} method.
    *
    * @return the throwable if failed exceptionally, or null if: {@link #fail() failed without
-   *     exception}, {@link #succeed() succeeded}, or not complete.g
+   *     exception}, {@link #succeed() succeeded}, {@link #failExceptionally(Throwable)} with a null
+   *     {@code throwable}, or not complete.
    * @since 1.41.0
    */
   @Nullable

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -80,6 +80,15 @@ class CompletableResultCodeTest {
   }
 
   @Test
+  void failExceptionallyWithNull() {
+    CompletableResultCode resultCode = new CompletableResultCode();
+    CompletableResultCode result = resultCode.failExceptionally(null);
+    assertThat(result.isDone()).isTrue();
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.getFailureThrowable()).isNull();
+  }
+
+  @Test
   void whenDoublyCompleteSuccessfully() throws InterruptedException {
     CompletableResultCode resultCode = new CompletableResultCode();
 


### PR DESCRIPTION
Relates to this comment: https://github.com/open-telemetry/opentelemetry-android/pull/709#discussion_r1887250785

This is useful when chaining result codes and wanting to not lose an existing throwable. It was completely valid before, but it wasn't documented.