### PR TITLE
Improve profiles attribute table handling

### DIFF
--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/internal/data/ImmutableProfileData.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.exporter.otlp.internal.data;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValue;
 import io.opentelemetry.exporter.otlp.profiles.AttributeUnitData;
 import io.opentelemetry.exporter.otlp.profiles.FunctionData;
 import io.opentelemetry.exporter.otlp.profiles.LinkData;
@@ -48,7 +48,7 @@ public abstract class ImmutableProfileData implements ProfileData {
       List<LocationData> locationTable,
       List<Integer> locationIndices,
       List<FunctionData> functionTable,
-      Attributes attributeTable,
+      List<AttributeKeyValue<?>> attributeTable,
       List<AttributeUnitData> attributeUnits,
       List<LinkData> linkTable,
       List<String> stringTable,

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationData.java
@@ -38,5 +38,5 @@ public interface LocationData {
   boolean isFolded();
 
   /** References to attributes in Profile.attribute_table. */
-  List<Integer> getAttributes();
+  List<Integer> getAttributeIndices();
 }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationMarshaler.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/LocationMarshaler.java
@@ -30,7 +30,7 @@ final class LocationMarshaler extends MarshalerWithSize {
         locationData.getAddress(),
         LineMarshaler.createRepeated(locationData.getLines()),
         locationData.isFolded(),
-        locationData.getAttributes());
+        locationData.getAttributeIndices());
   }
 
   static LocationMarshaler[] createRepeated(List<LocationData> items) {

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileData.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileData.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.exporter.otlp.profiles;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.internal.OtelEncodingUtils;
+import io.opentelemetry.exporter.internal.otlp.AttributeKeyValue;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.nio.ByteBuffer;
@@ -51,7 +51,7 @@ public interface ProfileData {
   List<FunctionData> getFunctionTable();
 
   /** Lookup table for attributes. */
-  Attributes getAttributeTable();
+  List<AttributeKeyValue<?>> getAttributeTable();
 
   /** Represents a mapping between Attribute Keys and Units. */
   List<AttributeUnitData> getAttributeUnits();

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileMarshaler.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileMarshaler.java
@@ -51,7 +51,7 @@ final class ProfileMarshaler extends MarshalerWithSize {
     FunctionMarshaler[] functionMarshalers =
         FunctionMarshaler.createRepeated(profileData.getFunctionTable());
     KeyValueMarshaler[] attributeTableMarshalers =
-        KeyValueMarshaler.createForAttributes(profileData.getAttributeTable());
+        KeyValueMarshaler.createRepeated(profileData.getAttributeTable());
     AttributeUnitMarshaler[] attributeUnitsMarshalers =
         AttributeUnitMarshaler.createRepeated(profileData.getAttributeUnits());
     LinkMarshaler[] linkMarshalers = LinkMarshaler.createRepeated(profileData.getLinkTable());

--- a/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/ProfilesRequestMarshalerTest.java
+++ b/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/ProfilesRequestMarshalerTest.java
@@ -151,7 +151,7 @@ public class ProfilesRequestMarshalerTest {
             Collections.emptyList(),
             listOf(1, 2),
             Collections.emptyList(),
-            Attributes.empty(),
+            Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),


### PR DESCRIPTION
Use List<AttributeKeyValue<?>> rather than Attributes, as the latter's map semantics are not appropriate for all use cases of the Profile.attribute_table field in the wire message.