### PR TITLE
Expand OkHttp retry exception predicate

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
-import java.util.Locale;
+import java.net.UnknownHostException;
 import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -154,14 +154,15 @@ public final class RetryInterceptor implements Interceptor {
 
   // Visible for testing
   static boolean isRetryableException(IOException e) {
+    // Known retryable SocketTimeoutException messages: null, "connect timed out", "timeout"
+    // Known retryable ConnectTimeout messages: "Failed to connect to
+    // localhost/[0:0:0:0:0:0:0:1]:62611"
+    // Known retryable UnknownHostException messages: "xxxxxx.com"
     if (e instanceof SocketTimeoutException) {
-      String message = e.getMessage();
-      // Connect timeouts can produce SocketTimeoutExceptions with no message, or with "connect
-      // timed out"
-      return message == null || message.toLowerCase(Locale.ROOT).contains("connect timed out");
+      return true;
     } else if (e instanceof ConnectException) {
-      // Exceptions resemble: java.net.ConnectException: Failed to connect to
-      // localhost/[0:0:0:0:0:0:0:1]:62611
+      return true;
+    } else if (e instanceof UnknownHostException) {
       return true;
     }
     return false;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/RetryPolicy.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/RetryPolicy.java
@@ -70,8 +70,8 @@ public abstract class RetryPolicy {
   public abstract double getBackoffMultiplier();
 
   /**
-   * Returns the predicate used to determine if thrown exception is retryableor {@code null} if no
-   * predicate was set.
+   * Returns the predicate used to determine if an attempt which failed exceptionally should be
+   * retried, or {@code null} if the exporter specific default predicate should be used.
    */
   @Nullable
   public abstract Predicate<IOException> getRetryExceptionPredicate();
@@ -106,7 +106,10 @@ public abstract class RetryPolicy {
      */
     public abstract RetryPolicyBuilder setBackoffMultiplier(double backoffMultiplier);
 
-    /** Set the predicate to determine if retry should happen based on exception. */
+    /**
+     * Set the predicate used to determine if an attempt which failed exceptionally should be
+     * retried. By default, an exporter specific default predicate should be used.
+     */
     public abstract RetryPolicyBuilder setRetryExceptionPredicate(
         Predicate<IOException> retryExceptionPredicate);
 


### PR DESCRIPTION
Reflects discussion [here](https://github.com/open-telemetry/opentelemetry-java/pull/6991#issuecomment-2578647610).

- Expand to retry on all SocketTimeoutExceptions, instead of looking for specific messages.
- Expand to retry on UnknownHostException

This brings OkHttp more in line with JdkHttpSender, which retries [on any IOException except SSLException](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java#L306). 