### PR TITLE
Expand OkHttp default retry exception predicate with SocketException

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
@@ -10,6 +10,7 @@ import static java.util.stream.Collectors.joining;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.StringJoiner;
@@ -158,11 +159,14 @@ public final class RetryInterceptor implements Interceptor {
     // Known retryable ConnectTimeout messages: "Failed to connect to
     // localhost/[0:0:0:0:0:0:0:1]:62611"
     // Known retryable UnknownHostException messages: "xxxxxx.com"
+    // Known retryable SocketException: Socket closed
     if (e instanceof SocketTimeoutException) {
       return true;
     } else if (e instanceof ConnectException) {
       return true;
     } else if (e instanceof UnknownHostException) {
+      return true;
+    } else if (e instanceof SocketException) {
       return true;
     }
     return false;

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.HttpRetryException;
 import java.net.ServerSocket;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -237,6 +238,8 @@ class RetryInterceptorTest {
         Arguments.of(new SocketTimeoutException(), true),
         // Should retry on UnknownHostExceptions
         Arguments.of(new UnknownHostException("host"), true),
+        // Should retry on SocketException
+        Arguments.of(new SocketException("closed"), true),
         // Should retry on ConnectException
         Arguments.of(
             new ConnectException("Failed to connect to localhost/[0:0:0:0:0:0:0:1]:62611"), true),


### PR DESCRIPTION
Extended the default predicate as mentioned here https://github.com/open-telemetry/opentelemetry-java/pull/6991#issuecomment-2585209126