### PR TITLE
Renovate best practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,12 @@
   ],
   "packageRules": [
     {
+      // this is to reduce the number of renovate PRs by consolidating them into a weekly batch
+      "matchManagers": ["github-actions"],
+      "extends": ["schedule:weekly"],
+      "groupName": "github actions",
+    },
+    {
       "matchPackageNames": [
         "io.opentelemetry.proto:opentelemetry-proto",
         "io.opentelemetry.semconv:opentelemetry-semconv-incubating"


### PR DESCRIPTION
After this, Renovate should send a PR to start pinning github actions and docker images.

Because of the resulting increase in Renovate PRs for ever github action minor version, I followed the instrumentation repo where we group the updates and limit them to once a week.

Related to https://github.com/open-telemetry/opentelemetry-java/issues/7068

Marked as draft for now because it's better to merge #7074 first.