### PR TITLE
Always run gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,14 +1,14 @@
 name: Gradle wrapper validation
+
 on:
-  pull_request:
-    paths:
-      - '**/gradle/wrapper/**'
   push:
-    paths:
-      - '**/gradle/wrapper/**'
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  validation:
+  gradle-wrapper-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is why OSSF Scorecard Binary-Artifacts score is only 9/10.

Related to #7068