### PR TITLE
Update from ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           - 23
         # Collect coverage on latest LTS
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             test-java-version: 21
             coverage: true
             jmh-based-tests: true


### PR DESCRIPTION
[The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01](https://github.com/actions/runner-images/issues/11101)

