### PR TITLE
Remove support for otel.java.experimental.exporter.memory_mode

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterBuilderUtil.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 /**
  * Utilities for exporter builders.
@@ -30,8 +29,6 @@ import java.util.logging.Logger;
  * at any time.
  */
 public final class ExporterBuilderUtil {
-
-  private static final Logger logger = Logger.getLogger(ExporterBuilderUtil.class.getName());
 
   /** Validate OTLP endpoint. */
   public static URI validateEndpoint(String endpoint) {
@@ -54,13 +51,6 @@ public final class ExporterBuilderUtil {
   public static void configureExporterMemoryMode(
       ConfigProperties config, Consumer<MemoryMode> memoryModeConsumer) {
     String memoryModeStr = config.getString("otel.java.exporter.memory_mode");
-    if (memoryModeStr == null) {
-      memoryModeStr = config.getString("otel.java.experimental.exporter.memory_mode");
-      if (memoryModeStr != null) {
-        logger.warning(
-            "otel.java.experimental.exporter.memory_mode was set but has been replaced with otel.java.exporter.memory_mode and will be removed in a future release");
-      }
-    }
     if (memoryModeStr == null) {
       return;
     }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
@@ -293,13 +293,13 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
     assertThat(
             exporterFromProvider(
                 DefaultConfigProperties.createFromMap(
-                    singletonMap("otel.java.experimental.exporter.memory_mode", "immutable_data"))))
+                    singletonMap("otel.java.exporter.memory_mode", "immutable_data"))))
         .extracting("memoryMode")
         .isEqualTo(MemoryMode.IMMUTABLE_DATA);
     assertThat(
             exporterFromProvider(
                 DefaultConfigProperties.createFromMap(
-                    singletonMap("otel.java.experimental.exporter.memory_mode", "reusable_data"))))
+                    singletonMap("otel.java.exporter.memory_mode", "reusable_data"))))
         .extracting("memoryMode")
         .isEqualTo(MemoryMode.REUSABLE_DATA);
   }


### PR DESCRIPTION
The new `otel.java.exporter.memory_mode` has been available sine 1.44.0, and there have been 3 minor releases since.