### PR TITLE
Disable owasp dependency check on :custom-checks

### DIFF
--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -80,3 +80,8 @@ configurations {
     }
   }
 }
+
+// Skip OWASP dependencyCheck task on test module
+dependencyCheck {
+  skip = true
+}


### PR DESCRIPTION
Resolves #7125.

See another example of where we disable `dependencyCheck` on test code: https://github.com/open-telemetry/opentelemetry-java/blob/main/integration-tests/otlp/build.gradle.kts#L46-L49