### PR TITLE
Adds option to SpanLimits to exclude exception.stacktrace attribute

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of opentelemetry-sdk-trace-1.48.0-SNAPSHOT.jar against opentelemetry-sdk-trace-1.47.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.sdk.trace.SpanLimits  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) boolean isExcludeExceptionStackTrace()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SpanLimitsBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.SpanLimitsBuilder setExcludeExceptionStackTrace(boolean)

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -413,7 +413,7 @@ class OpenTelemetrySdkTest {
                 + "clock=SystemClock{}, "
                 + "idGenerator=RandomIdGenerator{}, "
                 + "resource=Resource{schemaUrl=null, attributes={service.name=\"otel-test\"}}, "
-                + "spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, "
+                + "spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647, excludeExceptionStackTrace=false}, "
                 + "sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, "
                 + "spanProcessor=SimpleSpanProcessor{spanExporter=MultiSpanExporter{spanExporters=[MockSpanExporter{}, MockSpanExporter{}]}, exportUnsampledSpans=false}"
                 + "}, "

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -479,11 +479,14 @@ final class SdkSpan implements ReadWriteSpan {
             spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
     String exceptionName = exception.getClass().getCanonicalName();
     String exceptionMessage = exception.getMessage();
-    StringWriter stringWriter = new StringWriter();
-    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
-      exception.printStackTrace(printWriter);
+    String stackTrace = null;
+    if (!spanLimits.isExcludeExceptionStackTrace()) {
+      StringWriter stringWriter = new StringWriter();
+      try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+        exception.printStackTrace(printWriter);
+      }
+      stackTrace = stringWriter.toString();
     }
-    String stackTrace = stringWriter.toString();
 
     if (exceptionName != null) {
       attributes.put(EXCEPTION_TYPE, exceptionName);

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimits.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimits.java
@@ -39,14 +39,16 @@ public abstract class SpanLimits {
       int maxNumLinks,
       int maxNumAttributesPerEvent,
       int maxNumAttributesPerLink,
-      int maxAttributeLength) {
+      int maxAttributeLength,
+      boolean excludeExceptionStackTrace) {
     return new AutoValue_SpanLimits_SpanLimitsValue(
         maxNumAttributes,
         maxNumEvents,
         maxNumLinks,
         maxNumAttributesPerEvent,
         maxNumAttributesPerLink,
-        maxAttributeLength);
+        maxAttributeLength,
+        excludeExceptionStackTrace);
   }
 
   /**
@@ -103,6 +105,15 @@ public abstract class SpanLimits {
   }
 
   /**
+   * Returns whether exception stack trace should be excluded from exception event attributes.
+   *
+   * @return whether exception stack trace should be excluded from exception event attributes.
+   */
+  public boolean isExcludeExceptionStackTrace() {
+    return false;
+  }
+
+  /**
    * Returns a {@link SpanLimitsBuilder} initialized to the same property values as the current
    * instance.
    *
@@ -116,7 +127,8 @@ public abstract class SpanLimits {
         .setMaxNumberOfLinks(getMaxNumberOfLinks())
         .setMaxNumberOfAttributesPerEvent(getMaxNumberOfAttributesPerEvent())
         .setMaxNumberOfAttributesPerLink(getMaxNumberOfAttributesPerLink())
-        .setMaxAttributeValueLength(getMaxAttributeValueLength());
+        .setMaxAttributeValueLength(getMaxAttributeValueLength())
+        .setExcludeExceptionStackTrace(isExcludeExceptionStackTrace());
   }
 
   @AutoValue
@@ -129,5 +141,12 @@ public abstract class SpanLimits {
      */
     @Override
     public abstract int getMaxAttributeValueLength();
+
+    /**
+     * Override {@link SpanLimits#isExcludeExceptionStackTrace()} to be abstract so autovalue can
+     * implement it.
+     */
+    @Override
+    public abstract boolean isExcludeExceptionStackTrace();
   }
 }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
@@ -23,6 +23,7 @@ public final class SpanLimitsBuilder {
   private int maxNumAttributesPerEvent = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_EVENT;
   private int maxNumAttributesPerLink = DEFAULT_SPAN_MAX_NUM_ATTRIBUTES_PER_LINK;
   private int maxAttributeValueLength = SpanLimits.DEFAULT_SPAN_MAX_ATTRIBUTE_LENGTH;
+  private boolean excludeExceptionStackTrace = false;
 
   SpanLimitsBuilder() {}
 
@@ -109,6 +110,18 @@ public final class SpanLimitsBuilder {
     return this;
   }
 
+  /**
+   * Sets whether exception stacktraces should be excluded from exception event attributes.
+   *
+   * @param excludeExceptionStackTrace whether exception stacktraces should be excluded from
+   *     exception event attributes.
+   * @return this.
+   */
+  public SpanLimitsBuilder setExcludeExceptionStackTrace(boolean excludeExceptionStackTrace) {
+    this.excludeExceptionStackTrace = excludeExceptionStackTrace;
+    return this;
+  }
+
   /** Builds and returns a {@link SpanLimits} with the values of this builder. */
   public SpanLimits build() {
     return SpanLimits.create(
@@ -117,6 +130,7 @@ public final class SpanLimitsBuilder {
         maxNumLinks,
         maxNumAttributesPerEvent,
         maxNumAttributesPerLink,
-        maxAttributeValueLength);
+        maxAttributeValueLength,
+        excludeExceptionStackTrace);
   }
 }


### PR DESCRIPTION
Adds an option on `SpanLimits` which specifies that the `exception.stacktrace` attribute should not be emitted on exception events recorded to a span.