### PR TITLE
Extract sender parameters to config carrier class

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -199,17 +199,18 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     GrpcSenderProvider grpcSenderProvider = resolveGrpcSenderProvider();
     GrpcSender<T> grpcSender =
         grpcSenderProvider.createSender(
-            endpoint,
-            grpcEndpointPath,
-            compressor,
-            timeoutNanos,
-            connectTimeoutNanos,
-            headerSupplier,
-            grpcChannel,
-            grpcStubFactory,
-            retryPolicy,
-            isPlainHttp ? null : tlsConfigHelper.getSslContext(),
-            isPlainHttp ? null : tlsConfigHelper.getTrustManager());
+            GrpcSenderConfig.create(
+                endpoint,
+                grpcEndpointPath,
+                compressor,
+                timeoutNanos,
+                connectTimeoutNanos,
+                headerSupplier,
+                grpcChannel,
+                grpcStubFactory,
+                retryPolicy,
+                isPlainHttp ? null : tlsConfigHelper.getSslContext(),
+                isPlainHttp ? null : tlsConfigHelper.getTrustManager()));
     LOGGER.log(Level.FINE, "Using GrpcSender: " + grpcSender.getClass().getName());
 
     return new GrpcExporter<>(exporterName, type, grpcSender, meterProviderSupplier);

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderConfig.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.grpc;
+
+import com.google.auto.value.AutoValue;
+import io.grpc.Channel;
+import io.opentelemetry.exporter.internal.compression.Compressor;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+@AutoValue
+@Immutable
+public abstract class GrpcSenderConfig<T extends Marshaler> {
+
+  @SuppressWarnings("TooManyParameters")
+  public static <T extends Marshaler> GrpcSenderConfig<T> create(
+      URI endpoint,
+      String endpointPath,
+      @Nullable Compressor compressor,
+      long timeoutNanos,
+      long connectTimeoutNanos,
+      Supplier<Map<String, List<String>>> headersSupplier,
+      @Nullable Object managedChannel,
+      Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
+      @Nullable RetryPolicy retryPolicy,
+      @Nullable SSLContext sslContext,
+      @Nullable X509TrustManager trustManager) {
+    return new AutoValue_GrpcSenderConfig<>(
+        endpoint,
+        endpointPath,
+        compressor,
+        timeoutNanos,
+        connectTimeoutNanos,
+        headersSupplier,
+        managedChannel,
+        stubFactory,
+        retryPolicy,
+        sslContext,
+        trustManager);
+  }
+
+  public abstract URI getEndpoint();
+
+  public abstract String getEndpointPath();
+
+  @Nullable
+  public abstract Compressor getCompressor();
+
+  public abstract long getTimeoutNanos();
+
+  public abstract long getConnectTimeoutNanos();
+
+  public abstract Supplier<Map<String, List<String>>> getHeadersSupplier();
+
+  @Nullable
+  public abstract Object getManagedChannel();
+
+  public abstract Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>>
+      getStubFactory();
+
+  @Nullable
+  public abstract RetryPolicy getRetryPolicy();
+
+  @Nullable
+  public abstract SSLContext getSslContext();
+
+  @Nullable
+  public abstract X509TrustManager getTrustManager();
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcSenderProvider.java
@@ -5,18 +5,7 @@
 
 package io.opentelemetry.exporter.internal.grpc;
 
-import io.grpc.Channel;
-import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * A service provider interface (SPI) for providing {@link GrpcSender}s backed by different client
@@ -27,18 +16,6 @@ import javax.net.ssl.X509TrustManager;
  */
 public interface GrpcSenderProvider {
 
-  /** Returns a {@link GrpcSender} configured with the provided parameters. */
-  @SuppressWarnings("TooManyParameters")
-  <T extends Marshaler> GrpcSender<T> createSender(
-      URI endpoint,
-      String endpointPath,
-      @Nullable Compressor compressor,
-      long timeoutNanos,
-      long connectTimeoutNanos,
-      Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable Object managedChannel,
-      Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager);
+  /** Returns a {@link GrpcSender} configured with the provided config. */
+  <T extends Marshaler> GrpcSender<T> createSender(GrpcSenderConfig<T> grpcSenderConfig);
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -181,17 +181,18 @@ public final class HttpExporterBuilder<T extends Marshaler> {
     HttpSenderProvider httpSenderProvider = resolveHttpSenderProvider();
     HttpSender httpSender =
         httpSenderProvider.createSender(
-            endpoint,
-            compressor,
-            exportAsJson,
-            exportAsJson ? "application/json" : "application/x-protobuf",
-            timeoutNanos,
-            connectTimeoutNanos,
-            headerSupplier,
-            proxyOptions,
-            retryPolicy,
-            isPlainHttp ? null : tlsConfigHelper.getSslContext(),
-            isPlainHttp ? null : tlsConfigHelper.getTrustManager());
+            HttpSenderConfig.create(
+                endpoint,
+                compressor,
+                exportAsJson,
+                exportAsJson ? "application/json" : "application/x-protobuf",
+                timeoutNanos,
+                connectTimeoutNanos,
+                headerSupplier,
+                proxyOptions,
+                retryPolicy,
+                isPlainHttp ? null : tlsConfigHelper.getSslContext(),
+                isPlainHttp ? null : tlsConfigHelper.getTrustManager()));
     LOGGER.log(Level.FINE, "Using HttpSender: " + httpSender.getClass().getName());
 
     return new HttpExporter<>(exporterName, type, httpSender, meterProviderSupplier, exportAsJson);

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpSenderConfig.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpSenderConfig.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal.http;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.exporter.internal.compression.Compressor;
+import io.opentelemetry.sdk.common.export.ProxyOptions;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+@AutoValue
+@Immutable
+public abstract class HttpSenderConfig {
+
+  @SuppressWarnings("TooManyParameters")
+  public static HttpSenderConfig create(
+      String endpoint,
+      @Nullable Compressor compressor,
+      boolean exportAsJson,
+      String contentType,
+      long timeoutNanos,
+      long connectTimeoutNanos,
+      Supplier<Map<String, List<String>>> headerSupplier,
+      @Nullable ProxyOptions proxyOptions,
+      @Nullable RetryPolicy retryPolicy,
+      @Nullable SSLContext sslContext,
+      @Nullable X509TrustManager trustManager) {
+    return new AutoValue_HttpSenderConfig(
+        endpoint,
+        compressor,
+        exportAsJson,
+        contentType,
+        timeoutNanos,
+        connectTimeoutNanos,
+        headerSupplier,
+        proxyOptions,
+        retryPolicy,
+        sslContext,
+        trustManager);
+  }
+
+  public abstract String getEndpoint();
+
+  @Nullable
+  public abstract Compressor getCompressor();
+
+  public abstract boolean getExportAsJson();
+
+  public abstract String getContentType();
+
+  public abstract long getTimeoutNanos();
+
+  public abstract long getConnectTimeoutNanos();
+
+  public abstract Supplier<Map<String, List<String>>> getHeadersSupplier();
+
+  @Nullable
+  public abstract ProxyOptions getProxyOptions();
+
+  @Nullable
+  public abstract RetryPolicy getRetryPolicy();
+
+  @Nullable
+  public abstract SSLContext getSslContext();
+
+  @Nullable
+  public abstract X509TrustManager getTrustManager();
+}

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpSenderProvider.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpSenderProvider.java
@@ -5,16 +5,6 @@
 
 package io.opentelemetry.exporter.internal.http;
 
-import io.opentelemetry.exporter.internal.compression.Compressor;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
-
 /**
  * A service provider interface (SPI) for providing {@link HttpSender}s backed by different HTTP
  * client libraries.
@@ -24,18 +14,6 @@ import javax.net.ssl.X509TrustManager;
  */
 public interface HttpSenderProvider {
 
-  /** Returns a {@link HttpSender} configured with the provided parameters. */
-  @SuppressWarnings("TooManyParameters")
-  HttpSender createSender(
-      String endpoint,
-      @Nullable Compressor compressor,
-      boolean exportAsJson,
-      String contentType,
-      long timeoutNanos,
-      long connectTimeout,
-      Supplier<Map<String, List<String>>> headerSupplier,
-      @Nullable ProxyOptions proxyOptions,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager);
+  /** Returns a {@link HttpSender} configured with the provided config. */
+  HttpSender createSender(HttpSenderConfig httpSenderConfig);
 }

--- a/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
+++ b/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
@@ -12,20 +12,15 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.grpc.GrpcSender;
+import io.opentelemetry.exporter.internal.grpc.GrpcSenderConfig;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
 import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * {@link GrpcSender} SPI implementation for {@link UpstreamGrpcSender}.
@@ -36,27 +31,17 @@ import javax.net.ssl.X509TrustManager;
 public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
 
   @Override
-  public <T extends Marshaler> GrpcSender<T> createSender(
-      URI endpoint,
-      String endpointPath,
-      @Nullable Compressor compressor,
-      long timeoutNanos,
-      long connectTimeoutNanos,
-      Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable Object managedChannel,
-      Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager) {
+  public <T extends Marshaler> GrpcSender<T> createSender(GrpcSenderConfig<T> grpcSenderConfig) {
     boolean shutdownChannel = false;
+    Object managedChannel = grpcSenderConfig.getManagedChannel();
     if (managedChannel == null) {
       // Shutdown the channel as part of the exporter shutdown sequence if
       shutdownChannel = true;
-      managedChannel = minimalFallbackManagedChannel(endpoint);
+      managedChannel = minimalFallbackManagedChannel(grpcSenderConfig.getEndpoint());
     }
 
     String authorityOverride = null;
-    Map<String, List<String>> headers = headersSupplier.get();
+    Map<String, List<String>> headers = grpcSenderConfig.getHeadersSupplier().get();
     if (headers != null) {
       for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
         if (entry.getKey().equals("host") && !entry.getValue().isEmpty()) {
@@ -66,6 +51,7 @@ public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
     }
 
     String compression = Codec.Identity.NONE.getMessageEncoding();
+    Compressor compressor = grpcSenderConfig.getCompressor();
     if (compressor != null) {
       CompressorRegistry.getDefaultInstance()
           .register(
@@ -84,12 +70,17 @@ public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
     }
 
     MarshalerServiceStub<T, ?, ?> stub =
-        stubFactory
+        grpcSenderConfig
+            .getStubFactory()
             .get()
             .apply((Channel) managedChannel, authorityOverride)
             .withCompression(compression);
 
-    return new UpstreamGrpcSender<>(stub, shutdownChannel, timeoutNanos, headersSupplier);
+    return new UpstreamGrpcSender<>(
+        stub,
+        shutdownChannel,
+        grpcSenderConfig.getTimeoutNanos(),
+        grpcSenderConfig.getHeadersSupplier());
   }
 
   /**

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderProvider.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderProvider.java
@@ -5,17 +5,9 @@
 
 package io.opentelemetry.exporter.sender.jdk.internal;
 
-import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.http.HttpSender;
+import io.opentelemetry.exporter.internal.http.HttpSenderConfig;
 import io.opentelemetry.exporter.internal.http.HttpSenderProvider;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * {@link HttpSender} SPI implementation for {@link JdkHttpSender}.
@@ -26,28 +18,17 @@ import javax.net.ssl.X509TrustManager;
 public final class JdkHttpSenderProvider implements HttpSenderProvider {
 
   @Override
-  public HttpSender createSender(
-      String endpoint,
-      @Nullable Compressor compressor,
-      boolean exportAsJson,
-      String contentType,
-      long timeoutNanos,
-      long connectTimeout,
-      Supplier<Map<String, List<String>>> headerSupplier,
-      @Nullable ProxyOptions proxyOptions,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager) {
+  public HttpSender createSender(HttpSenderConfig httpSenderConfig) {
     return new JdkHttpSender(
-        endpoint,
-        compressor,
-        exportAsJson,
-        contentType,
-        timeoutNanos,
-        connectTimeout,
-        headerSupplier,
-        retryPolicy,
-        proxyOptions,
-        sslContext);
+        httpSenderConfig.getEndpoint(),
+        httpSenderConfig.getCompressor(),
+        httpSenderConfig.getExportAsJson(),
+        httpSenderConfig.getContentType(),
+        httpSenderConfig.getTimeoutNanos(),
+        httpSenderConfig.getConnectTimeoutNanos(),
+        httpSenderConfig.getHeadersSupplier(),
+        httpSenderConfig.getRetryPolicy(),
+        httpSenderConfig.getProxyOptions(),
+        httpSenderConfig.getSslContext());
   }
 }

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderProvider.java
@@ -5,21 +5,10 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
-import io.grpc.Channel;
-import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.grpc.GrpcSender;
+import io.opentelemetry.exporter.internal.grpc.GrpcSenderConfig;
 import io.opentelemetry.exporter.internal.grpc.GrpcSenderProvider;
-import io.opentelemetry.exporter.internal.grpc.MarshalerServiceStub;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link GrpcSender} SPI implementation for {@link OkHttpGrpcSender}.
@@ -30,26 +19,15 @@ import org.jetbrains.annotations.Nullable;
 public class OkHttpGrpcSenderProvider implements GrpcSenderProvider {
 
   @Override
-  public <T extends Marshaler> GrpcSender<T> createSender(
-      URI endpoint,
-      String endpointPath,
-      @Nullable Compressor compressor,
-      long timeoutNanos,
-      long connectTimeoutNanos,
-      Supplier<Map<String, List<String>>> headersSupplier,
-      @Nullable Object managedChannel,
-      Supplier<BiFunction<Channel, String, MarshalerServiceStub<T, ?, ?>>> stubFactory,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager) {
+  public <T extends Marshaler> GrpcSender<T> createSender(GrpcSenderConfig<T> grpcSenderConfig) {
     return new OkHttpGrpcSender<>(
-        endpoint.resolve(endpointPath).toString(),
-        compressor,
-        timeoutNanos,
-        connectTimeoutNanos,
-        headersSupplier,
-        retryPolicy,
-        sslContext,
-        trustManager);
+        grpcSenderConfig.getEndpoint().resolve(grpcSenderConfig.getEndpointPath()).toString(),
+        grpcSenderConfig.getCompressor(),
+        grpcSenderConfig.getTimeoutNanos(),
+        grpcSenderConfig.getConnectTimeoutNanos(),
+        grpcSenderConfig.getHeadersSupplier(),
+        grpcSenderConfig.getRetryPolicy(),
+        grpcSenderConfig.getSslContext(),
+        grpcSenderConfig.getTrustManager());
   }
 }

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderProvider.java
@@ -5,17 +5,9 @@
 
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
-import io.opentelemetry.exporter.internal.compression.Compressor;
 import io.opentelemetry.exporter.internal.http.HttpSender;
+import io.opentelemetry.exporter.internal.http.HttpSenderConfig;
 import io.opentelemetry.exporter.internal.http.HttpSenderProvider;
-import io.opentelemetry.sdk.common.export.ProxyOptions;
-import io.opentelemetry.sdk.common.export.RetryPolicy;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.X509TrustManager;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link HttpSender} SPI implementation for {@link OkHttpHttpSender}.
@@ -26,29 +18,18 @@ import org.jetbrains.annotations.Nullable;
 public final class OkHttpHttpSenderProvider implements HttpSenderProvider {
 
   @Override
-  public HttpSender createSender(
-      String endpoint,
-      @Nullable Compressor compressor,
-      boolean exportAsJson,
-      String contentType,
-      long timeoutNanos,
-      long connectTimeout,
-      Supplier<Map<String, List<String>>> headerSupplier,
-      @Nullable ProxyOptions proxyOptions,
-      @Nullable RetryPolicy retryPolicy,
-      @Nullable SSLContext sslContext,
-      @Nullable X509TrustManager trustManager) {
+  public HttpSender createSender(HttpSenderConfig httpSenderConfig) {
     return new OkHttpHttpSender(
-        endpoint,
-        compressor,
-        exportAsJson,
-        contentType,
-        timeoutNanos,
-        connectTimeout,
-        headerSupplier,
-        proxyOptions,
-        retryPolicy,
-        sslContext,
-        trustManager);
+        httpSenderConfig.getEndpoint(),
+        httpSenderConfig.getCompressor(),
+        httpSenderConfig.getExportAsJson(),
+        httpSenderConfig.getContentType(),
+        httpSenderConfig.getTimeoutNanos(),
+        httpSenderConfig.getConnectTimeoutNanos(),
+        httpSenderConfig.getHeadersSupplier(),
+        httpSenderConfig.getProxyOptions(),
+        httpSenderConfig.getRetryPolicy(),
+        httpSenderConfig.getSslContext(),
+        httpSenderConfig.getTrustManager());
   }
 }


### PR DESCRIPTION
Related to #6718.

Reduces churn of the GrpcSenderProvider, HttpSenderProvider interfaces by extracting all config parameters into a carrier class, which can be extended with default implementations when new options are added.

#7152 would need to churn the API contract in order to accommodate the new `ExecutorService` parameter. Instead, because its built off of this PR, it can be done as a non-breaking change.

This will be important if we want to promote sender API to public as discussed in #6781.