### PR TITLE
fix bug: throttledRateLimiter is not once per minute, but five times

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ThrottlingLogger.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/ThrottlingLogger.java
@@ -41,7 +41,8 @@ public class ThrottlingLogger {
     this.fastRateLimiter =
         new RateLimiter(RATE_LIMIT / rateTimeUnit.toSeconds(1), RATE_LIMIT, clock);
     this.throttledRateLimiter =
-        new RateLimiter(RATE_LIMIT / rateTimeUnit.toSeconds(1), THROTTLED_RATE_LIMIT, clock);
+        new RateLimiter(
+            THROTTLED_RATE_LIMIT / rateTimeUnit.toSeconds(1), THROTTLED_RATE_LIMIT, clock);
   }
 
   /** Log a message at the given level. */


### PR DESCRIPTION
After I stopped the otel collector, the program injected with agnet logged errors. The error logs were printed very frequently. I saw that the source code had already limited the flow of printing logs, but it was not as expected once a minute, but still five times a minute. Then I checked the code and found that there was an error in the parameter assignment. After changing it, it ran OK.
Thanks for reviewing the PR! I appreciate your time and any feedback you can provide.
[application-log.txt](https://github.com/user-attachments/files/19006768/application-log.txt)
