### PR TITLE
Define optionalCompileOnly configuration

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -208,6 +208,30 @@ val dependencyManagement by configurations.creating {
   isVisible = false
 }
 
+// An optionalCompileOnly dependency is the same as a compileOnly dependency, except that it appears
+// in published pom.xml like the following, where compileOnly dependencies don't appear in pom.xml at all:
+// <dependency>
+//   <groupId>io.opentelemetry</groupId>
+//   <artifactId>opentelemetry-api-incubator</artifactId>
+//   <version>1.48.0-alpha-SNAPSHOT</version>
+//   <scope>runtime</scope>
+//   <optional>true</optional>
+// </dependency>
+val optionalCompileOnly by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = false
+  // In otel.publish-conventions.gradle.kts we indicate that optionalCompileOnly dependencies should
+  // be added to the publication with scope=runtime, optional=true. For some reason, this fails if
+  // the configuration doesn't have at least 1 attribute associated with it. It's not clear from the
+  // docs (https://docs.gradle.org/current/userguide/variant_attributes.html) what the attribute is used for.
+  attributes {
+    attribute(Attribute.of("unused", String::class.java), "unused")
+  }
+}
+configurations.named("compileOnly") {
+  extendsFrom(optionalCompileOnly)
+}
+
 dependencies {
   dependencyManagement(platform(project(":dependencyManagement")))
   afterEvaluate {

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -20,6 +20,12 @@ publishing {
       }
       plugins.withId("java-library") {
         from(components["java"])
+
+        val javaComponent = components.findByName("java") as AdhocComponentWithVariants
+        javaComponent.addVariantsFromConfiguration(configurations["optionalCompileOnly"]) {
+          mapToMavenScope("runtime")
+          mapToOptional()
+        }
       }
 
       versionMapping {

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   api(project(":api:all"))
   api(project(":sdk:common"))
 
-  compileOnly(project(":api:incubator"))
+  optionalCompileOnly(project(":api:incubator"))
   compileOnly(project(":sdk:trace-shaded-deps"))
 
   annotationProcessor("com.google.auto.value:auto-value")


### PR DESCRIPTION
An alternative to #7137 that allows us to specify that certain compileOnly dependencies should be added to `pom.xml` with `scope=runtime`, `optional=true`, without the complexity of [gradle feature variants](https://docs.gradle.org/current/userguide/feature_variants.html).