### PR TITLE
Fix graalvm compatibility

### DIFF
--- a/api/all/src/main/resources/META-INF/native-image/io.opentelemetry/opentelemetry-api/native-image.properties
+++ b/api/all/src/main/resources/META-INF/native-image/io.opentelemetry/opentelemetry-api/native-image.properties
@@ -1,0 +1,1 @@
+Args=--io.opentelemetry.api.common.AttributeType


### PR DESCRIPTION
This fix a graalvm compatibility with the logger api (only one I tested in my lib), this exports the graalvm config automatically for clients.

```java
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'io.opentelemetry.api.common.AttributeType' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.opentelemetry.api.common.AttributeType' are persisted in the image heap, add

    '--initialize-at-build-time=io.opentelemetry.api.common.AttributeType'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.opentelemetry.api.common.AttributeType' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=io.opentelemetry.api.common.AttributeType'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=io.opentelemetry.api.common.AttributeType' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.

The following detailed trace displays from which field in the code the object was reached.
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.checkImageHeapInstance(ClassInitializationFeature.java:206)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.lambda$notifyObjectReachable$12(AnalysisType.java:659)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.ConcurrentLightHashSet.forEach(ConcurrentLightHashSet.java:149)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisType.notifyObjectReachable(AnalysisType.java:659)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onObjectReachable(ImageHeapScanner.java:586)
        ... 11 more
```