### PR TITLE
Remove obsolete SdkMeterProviderUtil#setCardinalitylimit API

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/SdkMeterProviderUtil.java
@@ -120,21 +120,6 @@ public final class SdkMeterProviderUtil {
     }
   }
 
-  /**
-   * Reflectively set the {@code cardinalityLimit} on the {@link ViewBuilder}.
-   *
-   * @param viewBuilder the builder
-   */
-  public static void setCardinalityLimit(ViewBuilder viewBuilder, int cardinalityLimit) {
-    try {
-      Method method = ViewBuilder.class.getDeclaredMethod("setCardinalityLimit", int.class);
-      method.setAccessible(true);
-      method.invoke(viewBuilder, cardinalityLimit);
-    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-      throw new IllegalStateException("Error setting cardinalityLimit on ViewBuilder", e);
-    }
-  }
-
   /** Reflectively reset the {@link SdkMeterProvider}, clearing all registered instruments. */
   public static void resetForTest(SdkMeterProvider sdkMeterProvider) {
     try {


### PR DESCRIPTION
This API was promoted to the stable API in 1.44.0 but I forgot to remove the experimental method for setting: https://github.com/open-telemetry/opentelemetry-java/blob/3c71b798a5dc50d87e00698acfafc8d88f9e14fd/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java#L110-L125