### PR TITLE
Lazily evaluate ExceptionEventData exception.* attributes

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/LazyExceptionEventData.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/internal/data/LazyExceptionEventData.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace.internal.data;
+
+import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.internal.AttributesMap;
+import io.opentelemetry.sdk.trace.SpanLimits;
+import io.opentelemetry.sdk.trace.data.ExceptionEventData;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * An {@link ExceptionEventData} implementation with {@link #getAttributes()} lazily evaluated,
+ * allowing the (relatively) expensive exception attribute rendering to take place off the hot path.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+@AutoValue
+@Immutable
+public abstract class LazyExceptionEventData implements ExceptionEventData {
+
+  private static final AttributeKey<String> EXCEPTION_TYPE =
+      AttributeKey.stringKey("exception.type");
+  private static final AttributeKey<String> EXCEPTION_MESSAGE =
+      AttributeKey.stringKey("exception.message");
+  private static final AttributeKey<String> EXCEPTION_STACKTRACE =
+      AttributeKey.stringKey("exception.stacktrace");
+  private static final String EXCEPTION_EVENT_NAME = "exception";
+
+  @Override
+  public final String getName() {
+    return EXCEPTION_EVENT_NAME;
+  }
+
+  /** TODO. */
+  public static ExceptionEventData create(
+      long epochNanos,
+      Throwable exception,
+      Attributes additionalAttributes,
+      SpanLimits spanLimits) {
+    return new AutoValue_LazyExceptionEventData(
+        epochNanos, exception, spanLimits, additionalAttributes);
+  }
+
+  abstract SpanLimits getSpanLimits();
+
+  public abstract Attributes getAdditionalAttributes();
+
+  @Override
+  @Memoized
+  public Attributes getAttributes() {
+    Throwable exception = getException();
+    SpanLimits spanLimits = getSpanLimits();
+    Attributes additionalAttributes = getAdditionalAttributes();
+
+    AttributesMap attributes =
+        AttributesMap.create(
+            spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
+    String exceptionName = exception.getClass().getCanonicalName();
+    String exceptionMessage = exception.getMessage();
+    StringWriter stringWriter = new StringWriter();
+    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+      exception.printStackTrace(printWriter);
+    }
+    String stackTrace = stringWriter.toString();
+
+    if (exceptionName != null) {
+      attributes.put(EXCEPTION_TYPE, exceptionName);
+    }
+    if (exceptionMessage != null) {
+      attributes.put(EXCEPTION_MESSAGE, exceptionMessage);
+    }
+    if (stackTrace != null) {
+      attributes.put(EXCEPTION_STACKTRACE, stackTrace);
+    }
+
+    additionalAttributes.forEach(attributes::put);
+
+    return attributes.immutableCopy();
+  }
+
+  @Override
+  public int getTotalAttributeCount() {
+    // getAttributes() lazily adds 3 attributes to getAdditionalAttributes():
+    // - exception.type
+    // - exception.message
+    // - exception.stacktrace
+    return getAdditionalAttributes().size() + 3;
+  }
+
+  LazyExceptionEventData() {}
+}


### PR DESCRIPTION
Currently, we compute `exception.*` span event attributes immediately when `recordException` is called.

With this PR, those attributes are computed lazily at the time of export. This should shift CPU / memory from hot path to export background threads.