### PR TITLE
Remove support for otel.experimental.exporter.otlp.retry.enabled

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -134,13 +134,6 @@ public final class OtlpConfigUtil {
     }
 
     Boolean retryDisabled = config.getBoolean("otel.java.exporter.otlp.retry.disabled");
-    if (retryDisabled == null) {
-      Boolean experimentalRetryEnabled =
-          config.getBoolean("otel.experimental.exporter.otlp.retry.enabled");
-      if (experimentalRetryEnabled != null) {
-        retryDisabled = !experimentalRetryEnabled;
-      }
-    }
     if (retryDisabled != null && retryDisabled) {
       setRetryPolicy.accept(null);
     }


### PR DESCRIPTION
The new property `otel.java.exporter.otlp.retry.disabled` was added in #6588 in 7/2024, so we're well past our ordinary timeline for supporting deprecated experimental properties, which is typically just 3 releases. 