### PR TITLE
Refine delay jitter for exponential backoff

### DIFF
--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -213,9 +213,11 @@ public final class JdkHttpSender implements HttpSender {
     do {
       if (attempt > 0) {
         // Compute and sleep for backoff
-        long upperBoundNanos = Math.min(nextBackoffNanos, retryPolicy.getMaxBackoff().toNanos());
-        long backoffNanos = ThreadLocalRandom.current().nextLong(upperBoundNanos);
-        nextBackoffNanos = (long) (nextBackoffNanos * retryPolicy.getBackoffMultiplier());
+        long currentBackoffNanos =
+            Math.min(nextBackoffNanos, retryPolicy.getMaxBackoff().toNanos());
+        long backoffNanos =
+            (long) (ThreadLocalRandom.current().nextDouble(0.8d, 1.2d) * currentBackoffNanos);
+        nextBackoffNanos = (long) (currentBackoffNanos * retryPolicy.getBackoffMultiplier());
         try {
           TimeUnit.NANOSECONDS.sleep(backoffNanos);
         } catch (InterruptedException e) {
@@ -227,16 +229,11 @@ public final class JdkHttpSender implements HttpSender {
           break;
         }
       }
-
-      attempt++;
+      httpResponse = null;
+      exception = null;
       requestBuilder.timeout(Duration.ofNanos(timeoutNanos - (System.nanoTime() - startTimeNanos)));
       try {
         httpResponse = sendRequest(requestBuilder, byteBufferPool);
-      } catch (IOException e) {
-        exception = e;
-      }
-
-      if (httpResponse != null) {
         boolean retryable = retryableStatusCodes.contains(httpResponse.statusCode());
         if (logger.isLoggable(Level.FINER)) {
           logger.log(
@@ -251,8 +248,8 @@ public final class JdkHttpSender implements HttpSender {
         if (!retryable) {
           return httpResponse;
         }
-      }
-      if (exception != null) {
+      } catch (IOException e) {
+        exception = e;
         boolean retryable = retryExceptionPredicate.test(exception);
         if (logger.isLoggable(Level.FINER)) {
           logger.log(
@@ -265,10 +262,10 @@ public final class JdkHttpSender implements HttpSender {
               exception);
         }
         if (!retryable) {
-          throw exception;
+          throw e;
         }
       }
-    } while (attempt < retryPolicy.getMaxAttempts());
+    } while (++attempt < retryPolicy.getMaxAttempts());
 
     if (httpResponse != null) {
       return httpResponse;

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -262,7 +262,7 @@ public final class JdkHttpSender implements HttpSender {
               exception);
         }
         if (!retryable) {
-          throw e;
+          throw exception;
         }
       }
     } while (++attempt < retryPolicy.getMaxAttempts());

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptor.java
@@ -110,7 +110,7 @@ public final class RetryInterceptor implements Interceptor {
             return response;
           }
         } else {
-          throw new NullPointerException("Response cannot be null.");
+          throw new NullPointerException("response cannot be null.");
         }
       } catch (IOException e) {
         exception = e;

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/RetryInterceptorTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -32,6 +32,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -47,7 +48,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class RetryInterceptorTest {
@@ -55,7 +58,7 @@ class RetryInterceptorTest {
   @RegisterExtension static final MockWebServerExtension server = new MockWebServerExtension();
 
   @Mock private RetryInterceptor.Sleeper sleeper;
-  @Mock private RetryInterceptor.BoundedLongGenerator random;
+  @Mock private Supplier<Double> random;
   private Predicate<IOException> retryExceptionPredicate;
 
   private RetryInterceptor retrier;
@@ -109,17 +112,8 @@ class RetryInterceptorTest {
   @ValueSource(ints = {5, 6})
   void backsOff(int attempts) throws Exception {
     succeedOnAttempt(attempts);
-
-    // Will backoff 4 times
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
-    // Capped
-    when(random.get(TimeUnit.SECONDS.toNanos(2))).thenReturn(500L).thenReturn(510L);
-
-    doNothing().when(sleeper).sleep(100);
-    doNothing().when(sleeper).sleep(50);
-    doNothing().when(sleeper).sleep(500);
-    doNothing().when(sleeper).sleep(510);
+    when(random.get()).thenReturn(1.0d);
+    doNothing().when(sleeper).sleep(anyLong());
 
     try (Response response = sendRequest()) {
       if (attempts <= 5) {
@@ -139,16 +133,26 @@ class RetryInterceptorTest {
     succeedOnAttempt(5);
 
     // Backs off twice, second is interrupted
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 0)))).thenReturn(100L);
-    when(random.get((long) (TimeUnit.SECONDS.toNanos(1) * Math.pow(1.6, 1)))).thenReturn(50L);
+    when(random.get()).thenReturn(1.0d).thenReturn(1.0d);
+    doAnswer(
+            new Answer<Void>() {
+              int counter = 0;
 
-    doNothing().when(sleeper).sleep(100);
-    doThrow(new InterruptedException()).when(sleeper).sleep(50);
+              @Override
+              public Void answer(InvocationOnMock invocation) throws Throwable {
+                if (counter++ == 1) {
+                  throw new InterruptedException();
+                }
+                return null;
+              }
+            })
+        .when(sleeper)
+        .sleep(anyLong());
 
     try (Response response = sendRequest()) {
       assertThat(response.isSuccessful()).isFalse();
     }
-
+    verify(sleeper, times(2)).sleep(anyLong());
     for (int i = 0; i < 2; i++) {
       server.takeRequest(0, TimeUnit.NANOSECONDS);
     }
@@ -157,7 +161,7 @@ class RetryInterceptorTest {
   @Test
   void connectTimeout() throws Exception {
     client = connectTimeoutClient();
-    when(random.get(anyLong())).thenReturn(1L);
+    when(random.get()).thenReturn(1.0d);
     doNothing().when(sleeper).sleep(anyLong());
 
     // Connecting to a non-routable IP address to trigger connection error
@@ -174,7 +178,7 @@ class RetryInterceptorTest {
   @Test
   void connectException() throws Exception {
     client = connectTimeoutClient();
-    when(random.get(anyLong())).thenReturn(1L);
+    when(random.get()).thenReturn(1.0d);
     doNothing().when(sleeper).sleep(anyLong());
 
     // Connecting to localhost on an unused port address to trigger java.net.ConnectException


### PR DESCRIPTION
Adjusted the jitter calculation to improve the randomness and distribution of delays in the exponential backoff logic.

current implementation is not based on exponential backoff but more uses randomly generated numbers in range **(0, upperBound)** and only **upperBound** exponentially grows, so in some cases we generate relatively low delays for retries 
Also there was an existing link 
![image](https://github.com/user-attachments/assets/7d9ba835-e43a-46d5-abc0-1b791209a339)

https://github.com/grpc/proposal/blob/master/A6-client-retries.md#exponential-backoff in code to implementation of exponential backoff but actual source code was different