### PR TITLE
Add logs sampler

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/logs/ConfigurableLogSamplerProvider.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/logs/ConfigurableLogSamplerProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.spi.logs;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.logs.samplers.LogSampler;
+
+public interface ConfigurableLogSamplerProvider {
+
+  /**
+   * Returns a {@link LogSampler} that can be registered to OpenTelemetry by providing the property
+   * value specified by {@link #getName()}.
+   */
+  LogSampler createSampler(ConfigProperties config);
+
+  /**
+   * Returns the name of this sampler, which can be specified with the {@code otel.logs.sampler}
+   * property to enable it. The name returned should NOT be the same as any other exporter name. If
+   * the name does conflict with another exporter name, the resulting behavior is undefined and it
+   * is explicitly unspecified which exporter will actually be used.
+   */
+  String getName();
+}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LoggerSharedState.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/LoggerSharedState.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.samplers.LogSampler;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -21,16 +22,19 @@ final class LoggerSharedState {
   private final Supplier<LogLimits> logLimitsSupplier;
   private final LogRecordProcessor logRecordProcessor;
   private final Clock clock;
+  private final LogSampler sampler;
   @Nullable private volatile CompletableResultCode shutdownResult = null;
 
   LoggerSharedState(
       Resource resource,
       Supplier<LogLimits> logLimitsSupplier,
       LogRecordProcessor logRecordProcessor,
+      LogSampler sampler,
       Clock clock) {
     this.resource = resource;
     this.logLimitsSupplier = logLimitsSupplier;
     this.logRecordProcessor = logRecordProcessor;
+    this.sampler = sampler;
     this.clock = clock;
   }
 
@@ -44,6 +48,10 @@ final class LoggerSharedState {
 
   LogRecordProcessor getLogRecordProcessor() {
     return logRecordProcessor;
+  }
+
+  LogSampler getSampler() {
+    return this.sampler;
   }
 
   Clock getClock() {

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
@@ -125,6 +125,11 @@ class SdkLogRecordBuilder implements LogRecordBuilder {
         this.observedTimestampEpochNanos == 0
             ? this.loggerSharedState.getClock().now()
             : this.observedTimestampEpochNanos;
+    boolean isShouldSample =
+        loggerSharedState.getSampler().shouldSample(context, this.severity, body, attributes);
+    if (!isShouldSample) {
+      return;
+    }
     loggerSharedState
         .getLogRecordProcessor()
         .onEmit(

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.ComponentRegistry;
 import io.opentelemetry.sdk.internal.ScopeConfigurator;
 import io.opentelemetry.sdk.logs.internal.LoggerConfig;
+import io.opentelemetry.sdk.logs.samplers.LogSampler;
 import io.opentelemetry.sdk.resources.Resource;
 import java.io.Closeable;
 import java.util.List;
@@ -52,11 +53,12 @@ public final class SdkLoggerProvider implements LoggerProvider, Closeable {
       Resource resource,
       Supplier<LogLimits> logLimitsSupplier,
       List<LogRecordProcessor> processors,
+      LogSampler sampler,
       Clock clock,
       ScopeConfigurator<LoggerConfig> loggerConfigurator) {
     LogRecordProcessor logRecordProcessor = LogRecordProcessor.composite(processors);
     this.sharedState =
-        new LoggerSharedState(resource, logLimitsSupplier, logRecordProcessor, clock);
+        new LoggerSharedState(resource, logLimitsSupplier, logRecordProcessor, sampler, clock);
     this.loggerComponentRegistry =
         new ComponentRegistry<>(
             instrumentationScopeInfo ->

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -17,6 +17,7 @@ import io.opentelemetry.sdk.internal.ScopeConfiguratorBuilder;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.internal.LoggerConfig;
 import io.opentelemetry.sdk.logs.internal.SdkLoggerProviderUtil;
+import io.opentelemetry.sdk.logs.samplers.LogSampler;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,8 @@ public final class SdkLoggerProviderBuilder {
   private Clock clock = Clock.getDefault();
   private ScopeConfiguratorBuilder<LoggerConfig> loggerConfiguratorBuilder =
       LoggerConfig.configuratorBuilder();
+
+  private LogSampler sampler = LogSampler.alwaysOnSampler();
 
   SdkLoggerProviderBuilder() {}
 
@@ -93,6 +96,18 @@ public final class SdkLoggerProviderBuilder {
   public SdkLoggerProviderBuilder addLogRecordProcessor(LogRecordProcessor processor) {
     requireNonNull(processor, "processor");
     logRecordProcessors.add(processor);
+    return this;
+  }
+
+  /**
+   * Set log sampler
+   *
+   * @param sampler the log sampler
+   * @return this
+   */
+  public SdkLoggerProviderBuilder setLogSampler(LogSampler sampler) {
+    requireNonNull(sampler, "sampler");
+    this.sampler = sampler;
     return this;
   }
 
@@ -156,6 +171,11 @@ public final class SdkLoggerProviderBuilder {
    */
   public SdkLoggerProvider build() {
     return new SdkLoggerProvider(
-        resource, logLimitsSupplier, logRecordProcessors, clock, loggerConfiguratorBuilder.build());
+        resource,
+        logLimitsSupplier,
+        logRecordProcessors,
+        sampler,
+        clock,
+        loggerConfiguratorBuilder.build());
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/samplers/LogSampler.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/samplers/LogSampler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs.samplers;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public interface LogSampler {
+
+  static LogSampler alwaysOnSampler() {
+    return (parentContext, severity, value, attributes) -> true;
+  }
+
+  static LogSampler parentBasedSampler() {
+    return (parentContext, severity, value, attributes) -> {
+      SpanContext spanContext = Span.fromContext(parentContext).getSpanContext();
+      return spanContext.isSampled();
+    };
+  }
+
+  boolean shouldSample(
+      Context parentContext,
+      Severity severity,
+      @Nullable Value<?> value,
+      @Nullable Attributes attributes);
+}


### PR DESCRIPTION
Sometimes we don't want to collect all the logs, we only need the logs associated with the call chain. The goal of this PR is to provide a mechanism for users to customize the log sampling rules to meet custom requirements.Add logs sampler