### PR TITLE
Don't initialize DeclarativeConfiguration in incubator available test

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -64,7 +64,10 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
   static {
     boolean incubatorAvailable = false;
     try {
-      Class.forName("io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration");
+      Class.forName(
+          "io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration",
+          false,
+          AutoConfiguredOpenTelemetrySdkBuilder.class.getClassLoader());
       incubatorAvailable = true;
     } catch (ClassNotFoundException e) {
       // Not available


### PR DESCRIPTION
Static initializer of `DeclarativeConfiguration` only needs to run when declarative configuration is used we can skip running it for the incubator available test.