### PR TITLE
6195: DelegatingMetricData.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,61 @@
 Comparing source compatibility of opentelemetry-sdk-metrics-1.49.0-SNAPSHOT.jar against opentelemetry-sdk-metrics-1.48.0.jar
-No changes.
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.metrics.data.DelegatingMetricData  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW INTERFACE: io.opentelemetry.sdk.metrics.data.MetricData
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) boolean equals(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.data.Data<?> getData()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getDescription()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.common.InstrumentationScopeInfo getInstrumentationScopeInfo()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getName()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.resources.Resource getResource()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.data.MetricDataType getType()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String getUnit()
+	+++  NEW METHOD: PUBLIC(+) int hashCode()
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.DoubleExemplarData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.DoubleExemplarData create(io.opentelemetry.api.common.Attributes, long, io.opentelemetry.api.trace.SpanContext, double)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.DoublePointData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.DoublePointData create(long, long, io.opentelemetry.api.common.Attributes, double)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets create(int, int, java.util.List<java.lang.Long>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.ExponentialHistogramData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.ExponentialHistogramData create(io.opentelemetry.sdk.metrics.data.AggregationTemporality, java.util.Collection<io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData create(int, double, long, boolean, double, boolean, double, io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets, io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets, long, long, io.opentelemetry.api.common.Attributes, java.util.List<io.opentelemetry.sdk.metrics.data.DoubleExemplarData>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.GaugeData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === T:io.opentelemetry.sdk.metrics.data.PointData
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.GaugeData<T> create(java.util.Collection<T>)
+		GENERIC TEMPLATES: +++ T:io.opentelemetry.sdk.metrics.data.PointData
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.HistogramData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.HistogramData create(io.opentelemetry.sdk.metrics.data.AggregationTemporality, java.util.Collection<io.opentelemetry.sdk.metrics.data.HistogramPointData>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.HistogramPointData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.HistogramPointData create(long, long, io.opentelemetry.api.common.Attributes, double, boolean, double, boolean, double, java.util.List<java.lang.Double>, java.util.List<java.lang.Long>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.LongExemplarData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.LongExemplarData create(io.opentelemetry.api.common.Attributes, long, io.opentelemetry.api.trace.SpanContext, long)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.LongPointData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.LongPointData create(long, long, io.opentelemetry.api.common.Attributes, long)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.SumData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === T:io.opentelemetry.sdk.metrics.data.PointData
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData<T> create(boolean, io.opentelemetry.sdk.metrics.data.AggregationTemporality, java.util.Collection<T>)
+		GENERIC TEMPLATES: +++ T:io.opentelemetry.sdk.metrics.data.PointData
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.SummaryData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.SummaryData create(java.util.Collection<io.opentelemetry.sdk.metrics.data.SummaryPointData>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.SummaryPointData  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.SummaryPointData create(long, long, io.opentelemetry.api.common.Attributes, long, double, java.util.List<io.opentelemetry.sdk.metrics.data.ValueAtQuantile>)
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.ValueAtQuantile  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.ValueAtQuantile create(double, double)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,18 @@
 Comparing source compatibility of opentelemetry-sdk-testing-1.49.0-SNAPSHOT.jar against opentelemetry-sdk-testing-1.48.0.jar
-No changes.
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) TestMetricData()
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder builder()
++++  NEW CLASS: PUBLIC(+) ABSTRACT(+) STATIC(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW CONSTRUCTOR: PUBLIC(+) TestMetricData$Builder()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.metrics.TestMetricData build()
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setData(io.opentelemetry.sdk.metrics.data.Data<?>)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setDescription(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setInstrumentationScopeInfo(io.opentelemetry.sdk.common.InstrumentationScopeInfo)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setName(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setResource(io.opentelemetry.sdk.resources.Resource)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setType(io.opentelemetry.sdk.metrics.data.MetricDataType)
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.testing.metrics.TestMetricData$Builder setUnit(java.lang.String)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+
+/**
+ * A {@link MetricData} which delegates all methods to another {@link MetricData}. Extend this class
+ * to modify the {@link MetricData} that will be exported, for example by creating a delegating
+ * {@link io.opentelemetry.sdk.metrics.export.MetricExporter} which wraps {@link MetricData} with a
+ * custom implementation.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // class MetricDataWithCustomDescription extends DelegatingMetricData {
+ * //
+ * //   private final String description;
+ * //
+ * //   MetricDataWithCustomDescription(MetricData delegate) {
+ * //     super(delegate);
+ * //     this.description = delegate.getDescription() + " (custom)";
+ * //   }
+ * //
+ * //   @Override
+ * //   public String getDescription() {
+ * //     return description;
+ * //   }
+ * // }
+ * }</pre>
+ *
+ * @since 1.28.0
+ */
+public abstract class DelegatingMetricData implements MetricData {
+
+  private final MetricData delegate;
+
+  protected DelegatingMetricData(MetricData delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  /**
+   * Returns the resource associated with this metric data.
+   *
+   * @return the {@link Resource} instance.
+   */
+  @Override
+  public Resource getResource() {
+    return delegate.getResource();
+  }
+
+  /**
+   * Returns the instrumentation library information associated with this metric data.
+   *
+   * @return the {@link InstrumentationScopeInfo} instance.
+   */
+  @Override
+  public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return delegate.getInstrumentationScopeInfo();
+  }
+
+  /**
+   * Returns the name of the metric.
+   *
+   * @return the name of the metric.
+   */
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  /**
+   * Returns the description of the metric.
+   *
+   * @return the description of the metric.
+   */
+  @Override
+  public String getDescription() {
+    return delegate.getDescription();
+  }
+
+  /**
+   * Returns the unit of the metric.
+   *
+   * @return the unit of the metric.
+   */
+  @Override
+  public String getUnit() {
+    return delegate.getUnit();
+  }
+
+  /**
+   * Returns the type of the metric.
+   *
+   * @return the type of the metric.
+   */
+  @Override
+  public MetricDataType getType() {
+    return delegate.getType();
+  }
+
+  /**
+   * Returns the data of the metric.
+   *
+   * @return the data of the metric.
+   */
+  @Override
+  public Data<?> getData() {
+    return delegate.getData();
+  }
+
+  /**
+   * Returns a boolean indicating whether the delegate {@link MetricData} is equal to this {@code
+   * MetricData}.
+   *
+   * @param o the object to compare to.
+   * @return a boolean indicating whether the delegate {@link MetricData} is equal to this {@code
+   *     MetricData}.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof MetricData) {
+      MetricData that = (MetricData) o;
+      return getResource().equals(that.getResource())
+          && getInstrumentationScopeInfo().equals(that.getInstrumentationScopeInfo())
+          && getName().equals(that.getName())
+          && getDescription().equals(that.getDescription())
+          && getUnit().equals(that.getUnit())
+          && getType().equals(that.getType())
+          && getData().equals(that.getData());
+    }
+    return false;
+  }
+
+  /**
+   * Returns a hash code value for the delegate {@link MetricData}.
+   *
+   * @return a hash code value for the delegate {@link MetricData}.
+   */
+  @Override
+  public int hashCode() {
+    int code = 1;
+    code *= 1000003;
+    code ^= getResource().hashCode();
+    code *= 1000003;
+    code ^= getInstrumentationScopeInfo().hashCode();
+    code *= 1000003;
+    code ^= getName().hashCode();
+    code *= 1000003;
+    code ^= getDescription().hashCode();
+    code *= 1000003;
+    code ^= getUnit().hashCode();
+    code *= 1000003;
+    code ^= getType().hashCode();
+    code *= 1000003;
+    code ^= getData().hashCode();
+    return code;
+  }
+
+  /** Returns a string representation of the delegate {@link MetricData}. */
+  @Override
+  public String toString() {
+    return "DelegatingMetricData{"
+        + "resource="
+        + getResource()
+        + ", instrumentationScopeInfo="
+        + getInstrumentationScopeInfo()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", unit="
+        + getUnit()
+        + ", type="
+        + getType()
+        + ", data="
+        + getData()
+        + "}";
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarData.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -14,6 +17,22 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface DoubleExemplarData extends ExemplarData {
+
+  /**
+   * Construct a new exemplar.
+   *
+   * @param filteredAttributes The set of {@link Attributes} not already associated with the {@link
+   *     PointData}.
+   * @param recordTimeNanos The time when the sample qas recorded in nanoseconds.
+   * @param spanContext The associated span context.
+   * @param value The value recorded.
+   */
+  static DoubleExemplarData create(
+      Attributes filteredAttributes, long recordTimeNanos, SpanContext spanContext, double value) {
+    return ImmutableDoubleExemplarData.create(
+        filteredAttributes, recordTimeNanos, spanContext, value);
+  }
+
   /** Numerical value of the measurement that was recorded. */
   double getValue();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoublePointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoublePointData.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -13,6 +16,23 @@ import java.util.List;
  * @since 1.14.0
  */
 public interface DoublePointData extends PointData {
+
+  /**
+   * Creates a {@link DoublePointData}.
+   *
+   * @param startEpochNanos The starting time for the period where this point was sampled. Note:
+   *     While start time is optional in OTLP, all SDKs should produce it for all their metrics, so
+   *     it is required here.
+   * @param epochNanos The ending time for the period when this value was sampled.
+   * @param attributes The set of attributes associated with this point.
+   * @param value The value that was sampled.
+   */
+  static DoublePointData create(
+      long startEpochNanos, long epochNanos, Attributes attributes, double value) {
+    return ImmutableDoublePointData.create(
+        startEpochNanos, epochNanos, attributes, value, Collections.emptyList());
+  }
+
   /** Returns the value of the data point. */
   double getValue();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramBuckets.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramBuckets.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramBuckets;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -24,6 +25,16 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface ExponentialHistogramBuckets {
+
+  /**
+   * Create a ExponentialHistogramBuckets.
+   *
+   * @return a ExponentialHistogramBuckets.
+   */
+  @SuppressWarnings("TooManyParameters")
+  static ExponentialHistogramBuckets create(int scale, int offset, List<Long> bucketCounts) {
+    return ImmutableExponentialHistogramBuckets.create(scale, offset, bucketCounts);
+  }
 
   /** The scale of the buckets. Must align with {@link ExponentialHistogramPointData#getScale()}. */
   int getScale();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramData.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramData;
 import java.util.Collection;
 import javax.annotation.concurrent.Immutable;
 
@@ -23,6 +24,12 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface ExponentialHistogramData extends Data<ExponentialHistogramPointData> {
+
+  /** Returns a new {@link ExponentialHistogramData}. */
+  static ExponentialHistogramData create(
+      AggregationTemporality temporality, Collection<ExponentialHistogramPointData> points) {
+    return ImmutableExponentialHistogramData.create(temporality, points);
+  }
 
   /**
    * Returns the {@code AggregationTemporality} of this metric.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramPointData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramPointData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -23,6 +25,43 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface ExponentialHistogramPointData extends PointData {
+
+  /**
+   * Create a ExponentialHistogramPointData.
+   *
+   * @return a ExponentialHistogramPointData.
+   */
+  @SuppressWarnings("TooManyParameters")
+  static ExponentialHistogramPointData create(
+      int scale,
+      double sum,
+      long zeroCount,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
+      ExponentialHistogramBuckets positiveBuckets,
+      ExponentialHistogramBuckets negativeBuckets,
+      long startEpochNanos,
+      long epochNanos,
+      Attributes attributes,
+      List<DoubleExemplarData> exemplars) {
+
+    return ImmutableExponentialHistogramPointData.create(
+        scale,
+        sum,
+        zeroCount,
+        hasMin,
+        min,
+        hasMax,
+        max,
+        positiveBuckets,
+        negativeBuckets,
+        startEpochNanos,
+        epochNanos,
+        attributes,
+        exemplars);
+  }
 
   /**
    * Scale characterises the resolution of the histogram, with larger values of scale offering

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/GaugeData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/GaugeData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
+import java.util.Collection;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -13,4 +15,16 @@ import javax.annotation.concurrent.Immutable;
  * @since 1.14.0
  */
 @Immutable
-public interface GaugeData<T extends PointData> extends Data<T> {}
+public interface GaugeData<T extends PointData> extends Data<T> {
+
+  /**
+   * Creates an instance of {@link GaugeData} with the given collection of points.
+   *
+   * @param <T> the type of the point data
+   * @param points the collection of points to be included in the gauge data
+   * @return an instance of {@link ImmutableGaugeData} containing the provided points
+   */
+  static <T extends PointData> GaugeData<T> create(Collection<T> points) {
+    return ImmutableGaugeData.create(points);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramData.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import java.util.Collection;
 import javax.annotation.concurrent.Immutable;
 
@@ -15,6 +16,19 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface HistogramData extends Data<HistogramPointData> {
+
+  /**
+   * Creates a new instance of {@link HistogramData}.
+   *
+   * @param temporality the aggregation temporality of the histogram data
+   * @param points the collection of histogram point data
+   * @return a new instance of {@link HistogramData}
+   */
+  static HistogramData create(
+      AggregationTemporality temporality, Collection<HistogramPointData> points) {
+    return ImmutableHistogramData.create(temporality, points);
+  }
+
   /** Returns the histogram {@link AggregationTemporality}. */
   AggregationTemporality getAggregationTemporality();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramPointData;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -15,6 +18,40 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface HistogramPointData extends PointData {
+
+  /**
+   * Creates a HistogramPointData. For a Histogram with N defined boundaries, there should be N+1
+   * counts.
+   *
+   * @return a HistogramPointData.
+   * @throws IllegalArgumentException if the given boundaries/counts were invalid
+   */
+  @SuppressWarnings("TooManyParameters")
+  static HistogramPointData create(
+      long startEpochNanos,
+      long epochNanos,
+      Attributes attributes,
+      double sum,
+      boolean hasMin,
+      double min,
+      boolean hasMax,
+      double max,
+      List<Double> boundaries,
+      List<Long> counts) {
+    return ImmutableHistogramPointData.create(
+        startEpochNanos,
+        epochNanos,
+        attributes,
+        sum,
+        hasMin,
+        min,
+        hasMax,
+        max,
+        boundaries,
+        counts,
+        Collections.emptyList());
+  }
+
   /**
    * The sum of all measurements recorded.
    *

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongExemplarData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongExemplarData.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongExemplarData;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -14,6 +17,22 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface LongExemplarData extends ExemplarData {
+
+  /**
+   * Construct a new exemplar.
+   *
+   * @param filteredAttributes The set of {@link Attributes} not already associated with the {@link
+   *     PointData}.
+   * @param recordTimeNanos The time when the sample qas recorded in nanoseconds.
+   * @param spanContext The associated span context.
+   * @param value The value recorded.
+   */
+  static LongExemplarData create(
+      Attributes filteredAttributes, long recordTimeNanos, SpanContext spanContext, long value) {
+    return ImmutableLongExemplarData.create(
+        filteredAttributes, recordTimeNanos, spanContext, value);
+  }
+
   /** Numerical value of the measurement that was recorded. */
   long getValue();
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongPointData.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -13,6 +16,23 @@ import java.util.List;
  * @since 1.14.0
  */
 public interface LongPointData extends PointData {
+
+  /**
+   * Creates a {@link LongPointData}.
+   *
+   * @param startEpochNanos The starting time for the period where this point was sampled. Note:
+   *     While start time is optional in OTLP, all SDKs should produce it for all their metrics, so
+   *     it is required here.
+   * @param epochNanos The ending time for the period when this value was sampled.
+   * @param attributes The set of attributes associated with this point.
+   * @param value The value that was sampled.
+   */
+  static LongPointData create(
+      long startEpochNanos, long epochNanos, Attributes attributes, long value) {
+    return ImmutableLongPointData.create(
+        startEpochNanos, epochNanos, attributes, value, Collections.emptyList());
+  }
+
   /** Returns the value of the data point. */
   long getValue();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SumData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SumData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
+import java.util.Collection;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -14,6 +16,20 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface SumData<T extends PointData> extends Data<T> {
+
+  /**
+   * Creates a new instance of {@link SumData}.
+   *
+   * @param isMonotonic {@code true} if the sum is monotonic.
+   * @param temporality the aggregation temporality of the sum data
+   * @param points the collection of sum point data
+   * @return a new instance of {@link SumData}
+   */
+  static <T extends PointData> ImmutableSumData<T> create(
+      boolean isMonotonic, AggregationTemporality temporality, Collection<T> points) {
+    return ImmutableSumData.create(isMonotonic, temporality, points);
+  }
+
   /** Returns "true" if the sum is monotonic. */
   boolean isMonotonic();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SummaryData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SummaryData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import java.util.Collection;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -13,4 +15,16 @@ import javax.annotation.concurrent.Immutable;
  * @since 1.14.0
  */
 @Immutable
-public interface SummaryData extends Data<SummaryPointData> {}
+public interface SummaryData extends Data<SummaryPointData> {
+
+  /**
+   * Creates a new instance of {@link SummaryData} with the given collection of {@link
+   * SummaryPointData}.
+   *
+   * @param points a collection of {@link SummaryPointData} to be included in the summary data
+   * @return a new instance of {@link SummaryData} containing the provided points
+   */
+  static SummaryData create(Collection<SummaryPointData> points) {
+    return ImmutableSummaryData.create(points);
+  }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SummaryPointData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SummaryPointData.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -15,6 +17,29 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface SummaryPointData extends PointData {
+
+  /**
+   * Creates a {@link SummaryPointData}.
+   *
+   * @param startEpochNanos (optional) The starting time for the period where this point was
+   *     sampled.
+   * @param epochNanos The ending time for the period when this value was sampled.
+   * @param attributes The set of attributes associated with this point.
+   * @param count The number of measurements being sumarized.
+   * @param sum The sum of measuremnts being sumarized.
+   * @param percentileValues Calculations of percentile values from measurements.
+   */
+  static SummaryPointData create(
+      long startEpochNanos,
+      long epochNanos,
+      Attributes attributes,
+      long count,
+      double sum,
+      List<ValueAtQuantile> percentileValues) {
+    return ImmutableSummaryPointData.create(
+        startEpochNanos, epochNanos, attributes, count, sum, percentileValues);
+  }
+
   /** Returns the count of measurements. */
   long getCount();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ValueAtQuantile.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/ValueAtQuantile.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.metrics.data;
 
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -14,6 +15,18 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public interface ValueAtQuantile {
+
+  /**
+   * Creates a new {@code ValueAtQuantile} instance with the specified quantile and value.
+   *
+   * @param quantile the quantile for which the value is being recorded
+   * @param value the value at the specified quantile
+   * @return a new {@code ValueAtQuantile} instance
+   */
+  static ValueAtQuantile create(double quantile, double value) {
+    return ImmutableValueAtQuantile.create(quantile, value);
+  }
+
   /** Returns the quantile of a distribution. Must be in the interval [0.0, 1.0]. */
   double getQuantile();
 

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.metrics.TestMetricData;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.junit.jupiter.api.Test;
+
+class DelegatingMetricDataTest {
+
+  @Test
+  void delegates() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+
+    assertThat(noOpWrapper)
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("delegate").build())
+        .isEqualTo(metricData);
+  }
+
+  @Test
+  void overrideDelegate() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData withCustomDescription = new MetricDataWithCustomDescription(metricData);
+
+    assertThat(withCustomDescription.getDescription()).isEqualTo("test");
+  }
+
+  @Test
+  void equals() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+    MetricData withCustomDescription = new MetricDataWithCustomDescription(metricData);
+
+    assertThat(noOpWrapper).isEqualTo(metricData);
+    assertThat(metricData).isNotEqualTo(withCustomDescription);
+  }
+
+  @Test
+  void equals_sameInstance() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+
+    assertThat(noOpWrapper.equals(noOpWrapper)).isTrue();
+  }
+
+  @Test
+  void equals_differentResource() {
+    MetricData metricData1 =
+        createBasicMetricBuilder()
+            .setResource(Resource.create(Attributes.builder().put("key", "value1").build()))
+            .build();
+    MetricData metricData2 =
+        createBasicMetricBuilder()
+            .setResource(Resource.create(Attributes.builder().put("key", "value2").build()))
+            .build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isNotEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_differentInstrumentationScopeInfo() {
+    MetricData metricData1 =
+        createBasicMetricBuilder()
+            .setInstrumentationScopeInfo(InstrumentationScopeInfo.create("scope1"))
+            .build();
+    MetricData metricData2 =
+        createBasicMetricBuilder()
+            .setInstrumentationScopeInfo(InstrumentationScopeInfo.create("scope2"))
+            .build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isNotEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_differentName() {
+    MetricData metricData1 = createBasicMetricBuilder().setName("name1").build();
+    MetricData metricData2 = createBasicMetricBuilder().setName("name2").build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isNotEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_differentUnit() {
+    MetricData metricData1 = createBasicMetricBuilder().setUnit("unit1").build();
+    MetricData metricData2 = createBasicMetricBuilder().setUnit("unit2").build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isNotEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_differentType() {
+    MetricData metricData1 = createBasicMetricBuilder().setType(MetricDataType.SUMMARY).build();
+    MetricData metricData2 = createBasicMetricBuilder().setType(MetricDataType.LONG_SUM).build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isNotEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_differentData() {
+    MetricData metricData1 =
+        createBasicMetricBuilder().setData(ImmutableSummaryData.empty()).build();
+    MetricData metricData2 =
+        createBasicMetricBuilder().setData(ImmutableSummaryData.empty()).build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1).isEqualTo(noOpWrapper2);
+  }
+
+  @Test
+  void equals_nonMetricDataObject_returnsFalse() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+
+    // Compare with a String object (non-MetricData)
+    Object nonMetricData = "not a metric data";
+
+    assertThat(noOpWrapper.equals(nonMetricData)).isFalse();
+  }
+
+  @Test
+  void testToString() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+
+    String expectedString =
+        "DelegatingMetricData{"
+            + "resource="
+            + metricData.getResource()
+            + ", instrumentationScopeInfo="
+            + metricData.getInstrumentationScopeInfo()
+            + ", name="
+            + metricData.getName()
+            + ", description="
+            + metricData.getDescription()
+            + ", unit="
+            + metricData.getUnit()
+            + ", type="
+            + metricData.getType()
+            + ", data="
+            + metricData.getData()
+            + "}";
+
+    assertThat(noOpWrapper.toString()).isEqualTo(expectedString);
+  }
+
+  @Test
+  void testHashCode() {
+    MetricData metricData1 = createBasicMetricBuilder().build();
+    MetricData metricData2 = createBasicMetricBuilder().build();
+    MetricData noOpWrapper1 = new NoOpDelegatingMetricData(metricData1);
+    MetricData noOpWrapper2 = new NoOpDelegatingMetricData(metricData2);
+
+    assertThat(noOpWrapper1.hashCode()).isEqualTo(metricData1.hashCode());
+    assertThat(noOpWrapper2.hashCode()).isEqualTo(metricData2.hashCode());
+    assertThat(noOpWrapper1.hashCode()).isEqualTo(noOpWrapper2.hashCode());
+  }
+
+  private static TestMetricData.Builder createBasicMetricBuilder() {
+    return TestMetricData.builder()
+        .setResource(Resource.empty())
+        .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
+        .setDescription("")
+        .setUnit("1")
+        .setName("name")
+        .setData(ImmutableSummaryData.empty())
+        .setType(MetricDataType.SUMMARY); // Not sure what type should be here
+  }
+
+  private static final class NoOpDelegatingMetricData extends DelegatingMetricData {
+    private NoOpDelegatingMetricData(MetricData delegate) {
+      super(delegate);
+    }
+  }
+
+  private static final class MetricDataWithCustomDescription extends DelegatingMetricData {
+    private final String description;
+
+    private MetricDataWithCustomDescription(MetricData delegate) {
+      super(delegate);
+      this.description = "test";
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DoubleExemplarDataTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.internal.ImmutableSpanContext;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import org.junit.jupiter.api.Test;
+
+public class DoubleExemplarDataTest {
+
+  private static final String TRACE_ID = "00000000000000000000000000000061";
+  private static final String SPAN_ID = "0000000000000061";
+
+  @Test
+  void create() {
+    SpanContext spanContext =
+        ImmutableSpanContext.create(
+            TRACE_ID,
+            SPAN_ID,
+            TraceFlags.getDefault(),
+            TraceState.getDefault(),
+            /* remote= */ false,
+            /* skipIdValidation= */ false);
+    DoubleExemplarData exemplarData =
+        DoubleExemplarData.create(
+            Attributes.builder().put("key", "value1").build(), // attributes
+            1, // epochNanos
+            /* spanContext= */ spanContext, // spanContext
+            /* value= */ 2.0);
+    assertThat(exemplarData.getValue()).isEqualTo(2.0);
+    assertThat(exemplarData.getEpochNanos()).isEqualTo(1);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DoublePointDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DoublePointDataTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+public class DoublePointDataTest {
+
+  @Test
+  void create() {
+    DoublePointData pointData =
+        DoublePointData.create(1, 2, Attributes.builder().put("key", "value1").build(), 3);
+    assertThat(pointData.getStartEpochNanos()).isEqualTo(1);
+    assertThat(pointData.getEpochNanos()).isEqualTo(2);
+    assertThat(pointData.getAttributes())
+        .isEqualTo(Attributes.builder().put("key", "value1").build());
+    assertThat(pointData.getValue()).isEqualTo(3);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramBucketsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramBucketsTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class ExponentialHistogramBucketsTest {
+
+  @Test
+  void create() {
+    ExponentialHistogramBuckets buckets =
+        ExponentialHistogramBuckets.create(1, 2, Arrays.asList(3L, 4L));
+    assertThat(buckets.getBucketCounts()).containsExactly(3L, 4L);
+    assertThat(buckets.getScale()).isEqualTo(1);
+    assertThat(buckets.getOffset()).isEqualTo(2);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramDataTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ExponentialHistogramDataTest {
+
+  @Test
+  void create() {
+    ExponentialHistogramData histogramData =
+        ExponentialHistogramData.create(AggregationTemporality.CUMULATIVE, Collections.emptyList());
+    assertThat(histogramData.getAggregationTemporality())
+        .isEqualTo(AggregationTemporality.CUMULATIVE);
+    assertThat(histogramData.getPoints()).isEmpty();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramPointDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ExponentialHistogramPointDataTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramBuckets;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ExponentialHistogramPointDataTest {
+
+  @Test
+  void create() {
+    DoubleExemplarData doubleExemplarOne =
+        ImmutableDoubleExemplarData.create(
+            Attributes.empty(),
+            0,
+            SpanContext.create(
+                "TraceId", "SpanId", TraceFlags.getDefault(), TraceState.getDefault()),
+            1.0);
+
+    DoubleExemplarData doubleExemplarTwo =
+        ImmutableDoubleExemplarData.create(
+            Attributes.empty(),
+            2,
+            SpanContext.create(
+                "TraceId", "SpanId", TraceFlags.getDefault(), TraceState.getDefault()),
+            2.0);
+    ExponentialHistogramPointData pointData =
+        ExponentialHistogramPointData.create(
+            1,
+            10.0,
+            1,
+            /* hasMin= */ true,
+            2.0,
+            /* hasMax= */ true,
+            4.0,
+            ImmutableExponentialHistogramBuckets.create(1, 10, Arrays.asList(1L, 2L)),
+            ImmutableExponentialHistogramBuckets.create(1, 0, Collections.emptyList()),
+            1,
+            2,
+            Attributes.empty(),
+            Arrays.asList(doubleExemplarOne, doubleExemplarTwo));
+    assertThat(pointData.getStartEpochNanos()).isEqualTo(1);
+    assertThat(pointData.getEpochNanos()).isEqualTo(2);
+    assertThat(pointData.getAttributes()).isEqualTo(Attributes.empty());
+    assertThat(pointData.getSum()).isEqualTo(10.0);
+    assertThat(pointData.getCount()).isEqualTo(4);
+    assertThat(pointData.hasMin()).isTrue();
+    assertThat(pointData.getMin()).isEqualTo(2.0);
+    assertThat(pointData.hasMax()).isTrue();
+    assertThat(pointData.getMax()).isEqualTo(4.0);
+    assertThat(pointData.getPositiveBuckets().getTotalCount()).isEqualTo(3);
+    assertThat(pointData.getNegativeBuckets().getTotalCount()).isEqualTo(0);
+    assertThat(pointData.getPositiveBuckets().getBucketCounts()).containsExactly(1L, 2L);
+    assertThat(pointData.getNegativeBuckets().getBucketCounts()).isEmpty();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/GaugeDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/GaugeDataTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class GaugeDataTest {
+
+  @Test
+  void create() {
+    GaugeData<LongPointData> gaugeData = GaugeData.create(Collections.emptyList());
+    assertThat(gaugeData.getPoints()).isEmpty();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/HistogramDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/HistogramDataTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class HistogramDataTest {
+
+  @Test
+  void create() {
+    HistogramData histogramData =
+        HistogramData.create(AggregationTemporality.CUMULATIVE, Collections.emptyList());
+    assertThat(histogramData.getAggregationTemporality())
+        .isEqualTo(AggregationTemporality.CUMULATIVE);
+    assertThat(histogramData.getPoints()).isEmpty();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/HistogramPointDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/HistogramPointDataTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import io.opentelemetry.api.common.Attributes;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class HistogramPointDataTest {
+
+  @Test
+  void create() {
+    HistogramPointData pointData =
+        HistogramPointData.create(
+            0,
+            0,
+            Attributes.empty(),
+            0.0,
+            /* hasMin= */ false,
+            0.0,
+            /* hasMax= */ false,
+            0.0,
+            new ArrayList<>(),
+            ImmutableList.of(0L));
+    assertThat(pointData.getStartEpochNanos()).isEqualTo(0);
+    assertThat(pointData.getEpochNanos()).isEqualTo(0);
+    assertThat(pointData.getAttributes()).isEqualTo(Attributes.empty());
+    assertThat(pointData.getSum()).isEqualTo(0.0);
+    assertThat(pointData.getCount()).isEqualTo(0);
+    assertThat(pointData.hasMin()).isFalse();
+    assertThat(pointData.getMin()).isEqualTo(0.0);
+    assertThat(pointData.hasMax()).isFalse();
+    assertThat(pointData.getMax()).isEqualTo(0.0);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/LongExemplarDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/LongExemplarDataTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import org.junit.jupiter.api.Test;
+
+public class LongExemplarDataTest {
+
+  @Test
+  void create() {
+    Attributes attributes = Attributes.builder().put("test", "value").build();
+    LongExemplarData exemplar =
+        LongExemplarData.create(
+            attributes,
+            2L,
+            SpanContext.create(
+                "00000000000000000000000000000001",
+                "0000000000000002",
+                TraceFlags.getDefault(),
+                TraceState.getDefault()),
+            1);
+    assertThat(exemplar.getFilteredAttributes()).isEqualTo(attributes);
+    assertThat(exemplar.getValue()).isEqualTo(1L);
+    assertThat(exemplar.getSpanContext()).isNotNull();
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/LongPointDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/LongPointDataTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+public class LongPointDataTest {
+
+  @Test
+  void create() {
+    LongPointData pointData = LongPointData.create(0, 0, Attributes.empty(), 0);
+    assertThat(pointData.getStartEpochNanos()).isEqualTo(0);
+    assertThat(pointData.getEpochNanos()).isEqualTo(0);
+    assertThat(pointData.getAttributes()).isEqualTo(Attributes.empty());
+    assertThat(pointData.getValue()).isEqualTo(0);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SumDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SumDataTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class SumDataTest {
+
+  @Test
+  void create() {
+    long startEpochNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+    long epochNanos = TimeUnit.MILLISECONDS.toNanos(2000);
+    long longValue = 10;
+    AttributeKey<String> key = AttributeKey.stringKey("key");
+    LongPointData longPoint =
+        LongPointData.create(startEpochNanos, epochNanos, Attributes.of(key, "value"), longValue);
+    SumData<LongPointData> sumData =
+        SumData.create(
+            /* isMonotonic= */ false,
+            AggregationTemporality.CUMULATIVE,
+            Collections.singletonList(longPoint));
+    assertThat(sumData.isMonotonic()).isFalse();
+    assertThat(sumData.getAggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SummaryDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SummaryDataTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class SummaryDataTest {
+
+  @Test
+  void create() {
+    List<ValueAtQuantile> percentileValues =
+        Arrays.asList(ImmutableValueAtQuantile.create(3.0, 4.0));
+    List<SummaryPointData> points =
+        Arrays.asList(
+            ImmutableSummaryPointData.create(
+                12345, 12346, Attributes.empty(), 1, 2.0, percentileValues));
+    SummaryData summary = ImmutableSummaryData.create(points);
+    assertThat(summary.getPoints()).isEqualTo(points);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SummaryPointDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/SummaryPointDataTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class SummaryPointDataTest {
+
+  @Test
+  void create() {
+    AttributeKey<String> kvAttr = AttributeKey.stringKey("key");
+    long startEpochNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+    long epochNanos = TimeUnit.MILLISECONDS.toNanos(2000);
+    double sum = 10.0;
+    long count = 5;
+    SummaryPointData summaryPoint =
+        SummaryPointData.create(
+            startEpochNanos,
+            epochNanos,
+            Attributes.of(kvAttr, "value"),
+            count,
+            sum,
+            Collections.emptyList());
+    assertThat(summaryPoint.getStartEpochNanos()).isEqualTo(startEpochNanos);
+    assertThat(summaryPoint.getEpochNanos()).isEqualTo(epochNanos);
+    assertThat(summaryPoint.getSum()).isEqualTo(sum);
+    assertThat(summaryPoint.getCount()).isEqualTo(count);
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ValueAtQuantileTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/ValueAtQuantileTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ValueAtQuantileTest {
+
+  @Test
+  void create() {
+    ValueAtQuantile valueAtQuantile = ValueAtQuantile.create(0.0, 1.1);
+    assertThat(valueAtQuantile.getQuantile()).isEqualTo(0.0);
+    assertThat(valueAtQuantile.getValue()).isEqualTo(1.1);
+  }
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.testing.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Immutable representation of all data collected by the {@link
+ * io.opentelemetry.sdk.metrics.data.MetricData} class.
+ */
+@Immutable
+@AutoValue
+public abstract class TestMetricData implements MetricData {
+  public static Builder builder() {
+    return new AutoValue_TestMetricData.Builder()
+        .setResource(Resource.empty())
+        .setName("name")
+        .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
+        .setDescription("description")
+        .setUnit("1");
+  }
+
+  /** A builder for {@link TestMetricData}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    abstract TestMetricData autoBuild();
+
+    /**
+     * Builds and returns a new {@link MetricData} instance from the data in {@code this}.
+     *
+     * @return a new {@link MetricData} instance.
+     */
+    public TestMetricData build() {
+      return autoBuild();
+    }
+
+    /**
+     * Sets the resource of the metric.
+     *
+     * @param resource the resource of the metric.
+     * @return this.
+     */
+    public abstract Builder setResource(Resource resource);
+
+    /**
+     * Sets the name of the metric.
+     *
+     * @param name the name of the metric.
+     * @return this.
+     */
+    public abstract Builder setName(String name);
+
+    /**
+     * Sets the description of the metric.
+     *
+     * @param description the description of the metric.
+     * @return this.
+     */
+    public abstract Builder setDescription(String description);
+
+    /**
+     * Sets the unit of the metric.
+     *
+     * @param unit the unit of the metric.
+     * @return this.
+     */
+    public abstract Builder setUnit(String unit);
+
+    /**
+     * Sets the type of the metric.
+     *
+     * @param type the type of the metric.
+     * @return this.
+     */
+    public abstract Builder setType(MetricDataType type);
+
+    /**
+     * Sets the data of the metric.
+     *
+     * @param data the data of the metric.
+     * @return this.
+     */
+    public abstract Builder setData(Data<?> data);
+
+    /**
+     * Sets the Instrumentation scope of the metric.
+     *
+     * @param instrumentationScopeInfo the instrumentation scope of the tracer which created this
+     *     metric.
+     * @return this.
+     */
+    public abstract Builder setInstrumentationScopeInfo(
+        InstrumentationScopeInfo instrumentationScopeInfo);
+  }
+}


### PR DESCRIPTION
## This Change

### Context
This PR tries to solve this [ticket](https://github.com/open-telemetry/opentelemetry-java/issues/6195). I preserved the original PR that was initially raised to add this class but I added a couple other enhancements that were mentioned in the PR. @jack-berg proposed two approaches for exposing other `PointData` interfaces:

1. Creating Delegating Classes
2. Adding Static Create Methods to Interfaces

I went with the second approach because it keeps the API simpler, consistent and avoids code duplication..

### Implementation Example
Finally I am thinking people might be using this class with Metric Exporter as below:

```
import io.opentelemetry.sdk.common.CompletableResultCode;
import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
import io.opentelemetry.sdk.metrics.data.Data;
import io.opentelemetry.sdk.metrics.data.DelegatingMetricData;
import io.opentelemetry.sdk.metrics.data.MetricData;
import io.opentelemetry.sdk.metrics.data.MetricDataType;
import io.opentelemetry.sdk.metrics.export.MetricExporter;
import io.opentelemetry.sdk.resources.Resource;

import java.util.ArrayList;
import java.util.Collection;
import java.util.function.Function;

/**
 * A MetricExporter that transforms metrics using a custom DelegatingMetricData implementation
 * before exporting them through a delegate exporter.
 */
public class TransformingMetricExporter implements MetricExporter {
    private final MetricExporter delegate;
    private final Function<MetricData, MetricData> transformer;

    /**
     * Creates a new TransformingMetricExporter.
     *
     * @param delegate The underlying exporter to send metrics to
     * @param namePrefix Prefix to add to all metric names
     * @param scaleFactor Factor to multiply all numeric values by (if applicable)
     */
    public TransformingMetricExporter(MetricExporter delegate, String namePrefix, double scaleFactor) {
        this.delegate = delegate;
        this.transformer = metric -> new CustomMetricData(metric, namePrefix, scaleFactor);
    }

    @Override
    public CompletableResultCode export(Collection<MetricData> metrics) {
        // Transform each metric before delegating to the wrapped exporter
        Collection<MetricData> transformedMetrics = new ArrayList<>(metrics.size());
        for (MetricData metric : metrics) {
            transformedMetrics.add(transformer.apply(metric));
        }
        return delegate.export(transformedMetrics);
    }

    @Override
    public CompletableResultCode flush() {
        return delegate.flush();
    }

    @Override
    public CompletableResultCode shutdown() {
        return delegate.shutdown();
    }

    /**
     * Custom implementation of DelegatingMetricData that modifies metric names and scales values.
     */
    private static class CustomMetricData extends DelegatingMetricData {
        private final String name;
        private final double scaleFactor;

        CustomMetricData(MetricData delegate, String namePrefix, double scaleFactor) {
            super(delegate);
            this.name = namePrefix + delegate.getName();
            this.scaleFactor = scaleFactor;
        }

        @Override
        public String getName() {
            return name;
        }

        @Override
        public Data<?> getData() {
            // Here you could implement value scaling logic based on the metric type
            // For example, you could create custom scaled versions of:
            // - LongSumData/DoubleSumData values
            // - HistogramData/ExponentialHistogramData values
            // - etc.
            
            return super.getData();
        }
        
        @Override
        public String toString() {
            return "CustomMetricData{name='" + name + "', scaled by " + scaleFactor + 
                   ", delegate=" + super.toString() + "}";
        }
    }
}
```