### PR TITLE
Remove guava dependency from buildSrc/build.gradle.kts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -54,8 +54,6 @@ dependencies {
   implementation("com.google.auto.value:auto-value-annotations:1.11.0")
   // When updating, update above in plugins too
   implementation("com.diffplug.spotless:spotless-plugin-gradle:7.0.2")
-  // Needed for japicmp but not automatically brought in for some reason.
-  implementation("com.google.guava:guava:33.4.6-jre")
   implementation("com.gradle.develocity:com.gradle.develocity.gradle.plugin:3.19.2")
   implementation("com.squareup:javapoet:1.13.0")
   implementation("com.squareup.wire:wire-compiler")


### PR DESCRIPTION
I believe this dependency is no longer needed. Maybe already brought in by japicmp now. Either way, removing reduces renovate noise. 