### PR TITLE
Add context and severity params to ExtendedLogger#isEnabled

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLogger.java
@@ -27,6 +27,11 @@ class ExtendedDefaultLogger implements ExtendedLogger {
   }
 
   @Override
+  public boolean isEnabled(Severity severity, Context context) {
+    return false;
+  }
+
+  @Override
   public ExtendedLogRecordBuilder logRecordBuilder() {
     return NOOP_LOG_RECORD_BUILDER;
   }

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedLogger.java
@@ -6,19 +6,39 @@
 package io.opentelemetry.api.incubator.logs;
 
 import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
 
 /** Extended {@link Logger} with experimental APIs. */
 public interface ExtendedLogger extends Logger {
 
   /**
-   * Returns {@code true} if the logger is enabled.
+   * Returns {@code true} if the logger is enabled for the given {@code context} and {@code
+   * severity}.
    *
    * <p>This allows callers to avoid unnecessary compute when nothing is consuming the data. Because
    * the response is subject to change over the application, callers should call this before each
    * call to {@link #logRecordBuilder()}.
    */
-  default boolean isEnabled() {
+  default boolean isEnabled(Severity severity, Context context) {
     return true;
+  }
+
+  /** Overload of {@link #isEnabled(Severity, Context)} assuming {@link Context#current()}. */
+  default boolean isEnabled(Severity severity) {
+    return isEnabled(severity, Context.current());
+  }
+
+  /**
+   * Overload of {@link #isEnabled(Severity, Context)} assuming {@link
+   * Severity#UNDEFINED_SEVERITY_NUMBER} and {@link Context#current()}.
+   *
+   * @deprecated for removal after 1.52.0. Use {@link #isEnabled(Severity, Context)} or {@link
+   *     #isEnabled(Severity)} instead.
+   */
+  @Deprecated
+  default boolean isEnabled() {
+    return isEnabled(Severity.UNDEFINED_SEVERITY_NUMBER);
   }
 
   @Override

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeter.java
@@ -95,6 +95,11 @@ class ExtendedDefaultMeter implements Meter {
 
   private static class NoopLongCounter implements ExtendedLongCounter {
     @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
+    @Override
     public void add(long value, Attributes attributes, Context context) {}
 
     @Override
@@ -105,6 +110,11 @@ class ExtendedDefaultMeter implements Meter {
   }
 
   private static class NoopDoubleCounter implements ExtendedDoubleCounter {
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
     @Override
     public void add(double value, Attributes attributes, Context context) {}
 
@@ -187,6 +197,11 @@ class ExtendedDefaultMeter implements Meter {
 
   private static class NoopLongUpDownCounter implements ExtendedLongUpDownCounter {
     @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
+    @Override
     public void add(long value, Attributes attributes, Context context) {}
 
     @Override
@@ -197,6 +212,11 @@ class ExtendedDefaultMeter implements Meter {
   }
 
   private static class NoopDoubleUpDownCounter implements ExtendedDoubleUpDownCounter {
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
     @Override
     public void add(double value, Attributes attributes, Context context) {}
 
@@ -282,6 +302,11 @@ class ExtendedDefaultMeter implements Meter {
 
   private static class NoopDoubleHistogram implements ExtendedDoubleHistogram {
     @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
+    @Override
     public void record(double value, Attributes attributes, Context context) {}
 
     @Override
@@ -292,6 +317,11 @@ class ExtendedDefaultMeter implements Meter {
   }
 
   private static class NoopLongHistogram implements ExtendedLongHistogram {
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
     @Override
     public void record(long value, Attributes attributes, Context context) {}
 
@@ -386,6 +416,11 @@ class ExtendedDefaultMeter implements Meter {
 
   private static class NoopDoubleGauge implements ExtendedDoubleGauge {
     @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
+    @Override
     public void set(double value) {}
 
     @Override
@@ -426,6 +461,11 @@ class ExtendedDefaultMeter implements Meter {
   }
 
   private static class NoopLongGauge implements ExtendedLongGauge {
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
     @Override
     public void set(long value) {}
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracer.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracer.java
@@ -32,6 +32,11 @@ final class ExtendedDefaultTracer implements ExtendedTracer {
   }
 
   @Override
+  public boolean isEnabled() {
+    return false;
+  }
+
+  @Override
   public ExtendedSpanBuilder spanBuilder(String spanName) {
     return NoopSpanBuilder.create();
   }

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLoggerTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLoggerTest.java
@@ -10,7 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.testing.internal.AbstractDefaultLoggerTest;
+import io.opentelemetry.context.Context;
 import org.junit.jupiter.api.Test;
 
 class ExtendedDefaultLoggerTest extends AbstractDefaultLoggerTest {
@@ -26,10 +28,18 @@ class ExtendedDefaultLoggerTest extends AbstractDefaultLoggerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // testing deprecated code
   void incubatingApiIsLoaded() {
     Logger logger = LoggerProvider.noop().get("test");
 
-    assertThat(logger).isInstanceOf(ExtendedLogger.class);
+    assertThat(logger)
+        .isInstanceOfSatisfying(
+            ExtendedLogger.class,
+            extendedLogger -> {
+              assertThat(extendedLogger.isEnabled(Severity.ERROR, Context.current())).isFalse();
+              assertThat(extendedLogger.isEnabled(Severity.ERROR)).isFalse();
+              assertThat(extendedLogger.isEnabled()).isFalse();
+            });
     ExtendedLogRecordBuilder builder = (ExtendedLogRecordBuilder) logger.logRecordBuilder();
     assertThat(builder).isInstanceOf(ExtendedLogRecordBuilder.class);
     assertThat(builder.setBody(Value.of(0))).isSameAs(builder);

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedLogsBridgeApiUsageTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/logs/ExtendedLogsBridgeApiUsageTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.logs.internal.LoggerConfig.disabled;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
@@ -42,24 +43,26 @@ class ExtendedLogsBridgeApiUsageTest {
     ExtendedLogger loggerB = (ExtendedLogger) loggerProvider.get("loggerB");
 
     // Check if logger is enabled before emitting log and avoid unnecessary computation
-    if (loggerA.isEnabled()) {
+    if (loggerA.isEnabled(Severity.INFO)) {
       loggerA
           .logRecordBuilder()
+          .setSeverity(Severity.INFO)
           .setBody("hello world!")
           .setAllAttributes(Attributes.builder().put("result", flipCoin()).build())
           .emit();
     }
-    if (loggerB.isEnabled()) {
+    if (loggerB.isEnabled(Severity.INFO)) {
       loggerB
           .logRecordBuilder()
+          .setSeverity(Severity.INFO)
           .setBody("hello world!")
           .setAllAttributes(Attributes.builder().put("result", flipCoin()).build())
           .emit();
     }
 
     // loggerA is enabled, loggerB is disabled
-    assertThat(loggerA.isEnabled()).isTrue();
-    assertThat(loggerB.isEnabled()).isFalse();
+    assertThat(loggerA.isEnabled(Severity.INFO)).isTrue();
+    assertThat(loggerB.isEnabled(Severity.INFO)).isFalse();
 
     // Collected data only consists of logs from loggerA. Note, loggerB's logs would be
     // omitted from the results even if logs were emitted. The check if enabled simply avoids

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeterTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/metrics/ExtendedDefaultMeterTest.java
@@ -11,7 +11,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.testing.internal.AbstractDefaultMeterTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ExtendedDefaultMeterTest extends AbstractDefaultMeterTest {
@@ -27,44 +26,53 @@ class ExtendedDefaultMeterTest extends AbstractDefaultMeterTest {
   }
 
   @Test
-  public void incubatingApiIsLoaded() {
+  void incubatingApiIsLoaded() {
     Meter meter = MeterProvider.noop().get("test");
     assertThat(meter).isSameAs(OpenTelemetry.noop().getMeter("test"));
 
-    Assertions.assertThat(meter.gaugeBuilder("test").ofLongs())
-        .isInstanceOf(ExtendedLongGaugeBuilder.class);
-    Assertions.assertThat(meter.gaugeBuilder("test").ofLongs().build())
-        .isInstanceOf(ExtendedLongGauge.class);
-    Assertions.assertThat(meter.gaugeBuilder("test"))
-        .isInstanceOf(ExtendedDoubleGaugeBuilder.class);
-    Assertions.assertThat(meter.gaugeBuilder("test").build())
-        .isInstanceOf(ExtendedDoubleGauge.class);
+    assertThat(meter.gaugeBuilder("test").ofLongs()).isInstanceOf(ExtendedLongGaugeBuilder.class);
+    assertThat(meter.gaugeBuilder("test").ofLongs().build())
+        .isInstanceOfSatisfying(
+            ExtendedLongGauge.class, instrument -> assertThat(instrument.isEnabled()).isFalse());
+    assertThat(meter.gaugeBuilder("test")).isInstanceOf(ExtendedDoubleGaugeBuilder.class);
+    assertThat(meter.gaugeBuilder("test").build())
+        .isInstanceOfSatisfying(
+            ExtendedDoubleGauge.class, instrument -> assertThat(instrument.isEnabled()).isFalse());
 
-    Assertions.assertThat(meter.histogramBuilder("test").ofLongs())
+    assertThat(meter.histogramBuilder("test").ofLongs())
         .isInstanceOf(ExtendedLongHistogramBuilder.class);
-    Assertions.assertThat(meter.histogramBuilder("test").ofLongs().build())
-        .isInstanceOf(ExtendedLongHistogram.class);
-    Assertions.assertThat(meter.histogramBuilder("test"))
-        .isInstanceOf(ExtendedDoubleHistogramBuilder.class);
-    Assertions.assertThat(meter.histogramBuilder("test").build())
-        .isInstanceOf(ExtendedDoubleHistogram.class);
+    assertThat(meter.histogramBuilder("test").ofLongs().build())
+        .isInstanceOfSatisfying(
+            ExtendedLongHistogram.class,
+            instrument -> assertThat(instrument.isEnabled()).isFalse());
+    assertThat(meter.histogramBuilder("test")).isInstanceOf(ExtendedDoubleHistogramBuilder.class);
+    assertThat(meter.histogramBuilder("test").build())
+        .isInstanceOfSatisfying(
+            ExtendedDoubleHistogram.class,
+            instrument -> assertThat(instrument.isEnabled()).isFalse());
 
-    Assertions.assertThat(meter.counterBuilder("test"))
-        .isInstanceOf(ExtendedLongCounterBuilder.class);
-    Assertions.assertThat(meter.counterBuilder("test").build())
-        .isInstanceOf(ExtendedLongCounter.class);
-    Assertions.assertThat(meter.counterBuilder("test").ofDoubles())
+    assertThat(meter.counterBuilder("test")).isInstanceOf(ExtendedLongCounterBuilder.class);
+    assertThat(meter.counterBuilder("test").build())
+        .isInstanceOfSatisfying(
+            ExtendedLongCounter.class, instrument -> assertThat(instrument.isEnabled()).isFalse());
+    assertThat(meter.counterBuilder("test").ofDoubles())
         .isInstanceOf(ExtendedDoubleCounterBuilder.class);
-    Assertions.assertThat(meter.counterBuilder("test").ofDoubles().build())
-        .isInstanceOf(ExtendedDoubleCounter.class);
+    assertThat(meter.counterBuilder("test").ofDoubles().build())
+        .isInstanceOfSatisfying(
+            ExtendedDoubleCounter.class,
+            instrument -> assertThat(instrument.isEnabled()).isFalse());
 
-    Assertions.assertThat(meter.upDownCounterBuilder("test"))
+    assertThat(meter.upDownCounterBuilder("test"))
         .isInstanceOf(ExtendedLongUpDownCounterBuilder.class);
-    Assertions.assertThat(meter.upDownCounterBuilder("test").build())
-        .isInstanceOf(ExtendedLongUpDownCounter.class);
-    Assertions.assertThat(meter.upDownCounterBuilder("test").ofDoubles())
+    assertThat(meter.upDownCounterBuilder("test").build())
+        .isInstanceOfSatisfying(
+            ExtendedLongUpDownCounter.class,
+            instrument -> assertThat(instrument.isEnabled()).isFalse());
+    assertThat(meter.upDownCounterBuilder("test").ofDoubles())
         .isInstanceOf(ExtendedDoubleUpDownCounterBuilder.class);
-    Assertions.assertThat(meter.upDownCounterBuilder("test").ofDoubles().build())
-        .isInstanceOf(ExtendedDoubleUpDownCounter.class);
+    assertThat(meter.upDownCounterBuilder("test").ofDoubles().build())
+        .isInstanceOfSatisfying(
+            ExtendedDoubleUpDownCounter.class,
+            instrument -> assertThat(instrument.isEnabled()).isFalse());
   }
 }

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracerTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/trace/ExtendedDefaultTracerTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.api.incubator.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.testing.internal.AbstractDefaultTracerTest;
@@ -27,17 +29,20 @@ class ExtendedDefaultTracerTest extends AbstractDefaultTracerTest {
   }
 
   @Test
-  public void incubatingApiIsLoaded() {
+  void incubatingApiIsLoaded() {
     Tracer tracer = TracerProvider.noop().get("test");
     assertThat(tracer).isSameAs(OpenTelemetry.noop().getTracer("test"));
 
-    assertThat(tracer).isInstanceOf(ExtendedTracer.class);
+    assertThat(tracer)
+        .isInstanceOfSatisfying(
+            ExtendedTracer.class,
+            extendedTracer -> assertThat(extendedTracer.isEnabled()).isFalse());
     assertThat(tracer.spanBuilder("test")).isInstanceOf(ExtendedSpanBuilder.class);
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void incubatingApi() {
+  void incubatingApi() {
     ExtendedSpanBuilder spanBuilder =
         (ExtendedSpanBuilder) ExtendedDefaultTracer.getNoop().spanBuilder("test");
     assertThat(spanBuilder.setParentFrom(null, null)).isSameAs(spanBuilder);
@@ -45,21 +50,21 @@ class ExtendedDefaultTracerTest extends AbstractDefaultTracerTest {
     SpanRunnable<RuntimeException> spanRunnable = Mockito.mock(SpanRunnable.class);
 
     spanBuilder.startAndRun(spanRunnable);
-    Mockito.verify(spanRunnable).runInSpan();
-    Mockito.reset(spanRunnable);
+    verify(spanRunnable).runInSpan();
+    reset(spanRunnable);
 
     spanBuilder.startAndRun(spanRunnable, null);
-    Mockito.verify(spanRunnable).runInSpan();
-    Mockito.reset(spanRunnable);
+    verify(spanRunnable).runInSpan();
+    reset(spanRunnable);
 
     SpanCallable<String, RuntimeException> spanCallable = Mockito.mock(SpanCallable.class);
 
     spanBuilder.startAndCall(spanCallable);
-    Mockito.verify(spanCallable).callInSpan();
-    Mockito.reset(spanCallable);
+    verify(spanCallable).callInSpan();
+    reset(spanCallable);
 
     spanBuilder.startAndCall(spanCallable, null);
-    Mockito.verify(spanCallable).callInSpan();
-    Mockito.reset(spanCallable);
+    verify(spanCallable).callInSpan();
+    reset(spanCallable);
   }
 }

--- a/integration-tests/graal-incubating/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingApiTests.java
+++ b/integration-tests/graal-incubating/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingApiTests.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.incubator.metrics.ExtendedLongHistogram;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounter;
 import io.opentelemetry.api.incubator.trace.ExtendedTracer;
 import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.trace.TracerProvider;
@@ -50,8 +51,8 @@ class IncubatingApiTests {
             .build();
 
     ExtendedLogger logger = (ExtendedLogger) loggerProvider.get("logger");
-    logger.isEnabled();
-    logger.logRecordBuilder().setBody("message").emit();
+    logger.isEnabled(Severity.INFO);
+    logger.logRecordBuilder().setSeverity(Severity.INFO).setBody("message").emit();
   }
 
   @Test

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogger.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogger.java
@@ -7,6 +7,8 @@ package io.opentelemetry.sdk.logs;
 
 import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
 import io.opentelemetry.api.incubator.logs.ExtendedLogger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.internal.LoggerConfig;
 
@@ -24,7 +26,7 @@ final class ExtendedSdkLogger extends SdkLogger implements ExtendedLogger {
   }
 
   @Override
-  public boolean isEnabled() {
+  public boolean isEnabled(Severity severity, Context context) {
     return loggerEnabled;
   }
 

--- a/sdk/logs/src/testIncubating/java/io/opentelemetry/sdk/logs/LoggerConfigTest.java
+++ b/sdk/logs/src/testIncubating/java/io/opentelemetry/sdk/logs/LoggerConfigTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 
 import io.opentelemetry.api.incubator.logs.ExtendedLogger;
 import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.internal.ScopeConfigurator;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -61,9 +62,9 @@ class LoggerConfigTest {
               assertThat(logsByScope.get(InstrumentationScopeInfo.create("loggerC"))).hasSize(1);
             });
     // loggerA and loggerC are enabled, loggerB is disabled.
-    assertThat(((ExtendedLogger) loggerA).isEnabled()).isTrue();
-    assertThat(((ExtendedLogger) loggerB).isEnabled()).isFalse();
-    assertThat(((ExtendedLogger) loggerC).isEnabled()).isTrue();
+    assertThat(((ExtendedLogger) loggerA).isEnabled(Severity.INFO)).isTrue();
+    assertThat(((ExtendedLogger) loggerB).isEnabled(Severity.INFO)).isFalse();
+    assertThat(((ExtendedLogger) loggerC).isEnabled(Severity.INFO)).isTrue();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Resolves #7242.

Also noticed that the noop implementations of isEnabled for traces, metrics, and logs were all returning true instead of false, so fixed that as well. 