### PR TITLE
Add custom stacktrace renderer which is length limit aware

### DIFF
--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
   id("otel.animalsniffer-conventions")
+  id("otel.jmh-conventions")
 }
 apply<OtelVersionClassPlugin>()
 

--- a/sdk/common/src/jmh/java/io/opentelemetry/sdk/internal/StacktraceRenderBenchmark.java
+++ b/sdk/common/src/jmh/java/io/opentelemetry/sdk/internal/StacktraceRenderBenchmark.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * This benchmark compares the performance of {@link StackTraceRenderer}, the custom length limit
+ * aware exception render, to the built-in JDK stacktrace renderer {@link
+ * Throwable#printStackTrace(PrintStream)}.
+ */
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+public class StacktraceRenderBenchmark {
+
+  private static final Exception simple = new Exception("error");
+  private static final Exception complex =
+      new Exception("error", new Exception("cause1", new Exception("cause2")));
+
+  static {
+    complex.addSuppressed(new Exception("suppressed1"));
+    complex.addSuppressed(new Exception("suppressed2", new Exception("cause")));
+  }
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+
+    @Param Renderer renderer;
+    @Param ExceptionParam exceptionParam;
+
+    @Param({"10", "1000", "100000"})
+    int lengthLimit;
+  }
+
+  @SuppressWarnings("ImmutableEnumChecker")
+  public enum Renderer {
+    JDK(
+        (throwable, limit) -> {
+          StringWriter stringWriter = new StringWriter();
+          try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            throwable.printStackTrace(printWriter);
+          }
+          String stacktrace = stringWriter.toString();
+          return stacktrace.substring(0, Math.min(stacktrace.length(), limit));
+        }),
+    CUSTOM((throwable, limit) -> new StackTraceRenderer(throwable, limit).render());
+
+    private final BiFunction<Throwable, Integer, String> renderer;
+
+    Renderer(BiFunction<Throwable, Integer, String> renderer) {
+      this.renderer = renderer;
+    }
+
+    BiFunction<Throwable, Integer, String> renderer() {
+      return renderer;
+    }
+  }
+
+  @SuppressWarnings("ImmutableEnumChecker")
+  public enum ExceptionParam {
+    SIMPLE(simple),
+    COMPLEX(complex);
+
+    private final Throwable throwable;
+
+    ExceptionParam(Throwable throwable) {
+      this.throwable = throwable;
+    }
+
+    Throwable throwable() {
+      return throwable;
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  @SuppressWarnings("ReturnValueIgnored")
+  public void render(BenchmarkState benchmarkState) {
+    BiFunction<Throwable, Integer, String> renderer = benchmarkState.renderer.renderer();
+    Throwable throwable = benchmarkState.exceptionParam.throwable();
+    int limit = benchmarkState.lengthLimit;
+
+    renderer.apply(throwable, limit);
+  }
+}

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeUtil.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/AttributeUtil.java
@@ -8,8 +8,6 @@ package io.opentelemetry.sdk.internal;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +105,9 @@ public final class AttributeUtil {
   }
 
   public static void addExceptionAttributes(
-      Throwable exception, BiConsumer<AttributeKey<String>, String> attributeConsumer) {
+      Throwable exception,
+      BiConsumer<AttributeKey<String>, String> attributeConsumer,
+      int lengthLimit) {
     String exceptionType = exception.getClass().getCanonicalName();
     if (exceptionType != null) {
       attributeConsumer.accept(EXCEPTION_TYPE, exceptionType);
@@ -118,11 +118,7 @@ public final class AttributeUtil {
       attributeConsumer.accept(EXCEPTION_MESSAGE, exceptionMessage);
     }
 
-    StringWriter stringWriter = new StringWriter();
-    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
-      exception.printStackTrace(printWriter);
-    }
-    String stackTrace = stringWriter.toString();
+    String stackTrace = new StackTraceRenderer(exception, lengthLimit).render();
     if (stackTrace != null) {
       attributeConsumer.accept(EXCEPTION_STACKTRACE, stackTrace);
     }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/StackTraceRenderer.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/StackTraceRenderer.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * An alternative to exception stacktrace renderer that replicates the behavior of {@link
+ * Throwable#printStackTrace(PrintStream)}, but which is aware of a maximum stacktrace length limit,
+ * and exits early when the lenght limit has been exceeded to avoid unnecessary computation.
+ *
+ * <p>Instances should only be used once.
+ */
+class StackTraceRenderer {
+
+  private static final String CAUSED_BY = "Caused by: ";
+  private static final String SUPPRESSED = "Suppressed: ";
+
+  private final Throwable throwable;
+  private final int lengthLimit;
+  private final StringBuilder builder = new StringBuilder();
+
+  StackTraceRenderer(Throwable throwable, int lengthLimit) {
+    this.throwable = throwable;
+    this.lengthLimit = lengthLimit;
+  }
+
+  String render() {
+    if (builder.length() == 0) {
+      appendStackTrace();
+    }
+
+    return builder.substring(0, Math.min(builder.length(), lengthLimit));
+  }
+
+  private void appendStackTrace() {
+    if (appendLine(throwable.toString())) {
+      return;
+    }
+
+    StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+    for (StackTraceElement stackTraceElement : stackTraceElements) {
+      if (appendLine("\tat " + stackTraceElement)) {
+        return;
+      }
+    }
+
+    Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+    seen.add(throwable);
+
+    for (Throwable suppressed : throwable.getSuppressed()) {
+      appendInnerStacktrace(stackTraceElements, suppressed, "\t", SUPPRESSED, seen);
+    }
+
+    Throwable cause = throwable.getCause();
+    if (cause != null) {
+      appendInnerStacktrace(stackTraceElements, cause, "", CAUSED_BY, seen);
+    }
+  }
+
+  /**
+   * Append the {@code innerThrowable} to the {@link #builder}, returning {@code true} if the
+   * builder now exceeds the length limit.
+   */
+  private boolean appendInnerStacktrace(
+      StackTraceElement[] parentElements,
+      Throwable innerThrowable,
+      String prefix,
+      String caption,
+      Set<Throwable> seen) {
+    if (seen.contains(innerThrowable)) {
+      appendLine(prefix + caption + "[CIRCULAR REFERENCE: " + innerThrowable + "]");
+      return true;
+    }
+    seen.add(innerThrowable);
+
+    // Iterating back to front, compute the lastSharedFrameIndex, which tracks the point at which
+    // this exception's stacktrace elements start repeating the parent's elements
+    StackTraceElement[] currentElements = innerThrowable.getStackTrace();
+    int parentIndex = parentElements.length - 1;
+    int lastSharedFrameIndex = currentElements.length - 1;
+    while (true) {
+      if (parentIndex < 0 || lastSharedFrameIndex < 0) {
+        break;
+      }
+      if (!parentElements[parentIndex].equals(currentElements[lastSharedFrameIndex])) {
+        break;
+      }
+      parentIndex--;
+      lastSharedFrameIndex--;
+    }
+
+    if (appendLine(prefix + caption + innerThrowable)) {
+      return true;
+    }
+
+    for (int i = 0; i <= lastSharedFrameIndex; i++) {
+      StackTraceElement stackTraceElement = currentElements[i];
+      if (appendLine(prefix + "\tat " + stackTraceElement)) {
+        return true;
+      }
+    }
+
+    int duplicateFrames = currentElements.length - 1 - lastSharedFrameIndex;
+    if (duplicateFrames != 0) {
+      if (appendLine(prefix + "\t... " + duplicateFrames + " more")) {
+        return true;
+      }
+    }
+
+    for (Throwable suppressed : innerThrowable.getSuppressed()) {
+      if (appendInnerStacktrace(currentElements, suppressed, prefix + "\t", SUPPRESSED, seen)) {
+        return true;
+      }
+    }
+
+    Throwable cause = innerThrowable.getCause();
+    if (cause != null) {
+      return appendInnerStacktrace(currentElements, cause, prefix, CAUSED_BY, seen);
+    }
+
+    return false;
+  }
+
+  /**
+   * Append the string as a new line on {@link #builder}, returning {@code true} if the builder now
+   * exceeds the length limit.
+   */
+  private boolean appendLine(String s) {
+    builder.append(s).append(System.lineSeparator());
+    return builder.length() >= lengthLimit;
+  }
+}

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/internal/StackTraceRendererTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/internal/StackTraceRendererTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class StackTraceRendererTest {
+
+  @ParameterizedTest
+  @MethodSource("renderStacktraceArgs")
+  void renderStacktrace(Throwable throwable) {
+    assertThat(new StackTraceRenderer(throwable, 10).render())
+        .isEqualTo(jdkStackTrace(throwable, 10));
+    assertThat(new StackTraceRenderer(throwable, 100).render())
+        .isEqualTo(jdkStackTrace(throwable, 100));
+    assertThat(new StackTraceRenderer(throwable, 1000).render())
+        .isEqualTo(jdkStackTrace(throwable, 1000));
+    assertThat(new StackTraceRenderer(throwable, Integer.MAX_VALUE).render())
+        .isEqualTo(jdkStackTrace(throwable, Integer.MAX_VALUE));
+  }
+
+  private static Stream<Arguments> renderStacktraceArgs() {
+    Exception withCycle = new Exception("error1");
+    Exception withCycleInner = new Exception("error2", withCycle);
+    withCycle.initCause(withCycleInner);
+
+    Exception withSuppressed = new Exception("error");
+    withSuppressed.addSuppressed(new Exception("suppressed"));
+
+    Exception withMultipleSuppressed = new Exception("error");
+    withMultipleSuppressed.addSuppressed(new Exception("suppressed1"));
+    withMultipleSuppressed.addSuppressed(new Exception("suppressed2"));
+
+    Exception withNestedSuppressed = new Exception("error");
+    withNestedSuppressed.addSuppressed(withSuppressed);
+    withNestedSuppressed.addSuppressed(withMultipleSuppressed);
+
+    Exception withKitchenSink = new Exception("kitchenSink", withCycle);
+    withKitchenSink.addSuppressed(withMultipleSuppressed);
+    withKitchenSink.addSuppressed(withNestedSuppressed);
+
+    return Stream.of(
+        // simple
+        Arguments.of(new Exception()),
+        Arguments.of(new Exception("error")),
+        // with cause
+        Arguments.of(new Exception(new Exception("cause"))),
+        Arguments.of(new Exception("error", new Exception("cause"))),
+        // with nested causes
+        Arguments.of(
+            new Exception(
+                "error",
+                new Exception(
+                    "cause1",
+                    new Exception(
+                        "cause2",
+                        new Exception(
+                            "cause3", new Exception("cause4", new Exception("cause5"))))))),
+        // with cause with circular reference
+        Arguments.of(withCycle),
+        // with suppressed
+        Arguments.of(withSuppressed),
+        Arguments.of(withMultipleSuppressed),
+        Arguments.of(withNestedSuppressed),
+        // with cause, cycle, and suppressed!
+        Arguments.of(withKitchenSink));
+  }
+
+  private static String jdkStackTrace(Throwable exception, int limit) {
+    StringWriter stringWriter = new StringWriter();
+    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+      exception.printStackTrace(printWriter);
+    }
+    String stacktrace = stringWriter.toString();
+    return stacktrace.substring(0, Math.min(stacktrace.length(), limit));
+  }
+}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogRecordBuilder.java
@@ -43,7 +43,8 @@ final class ExtendedSdkLogRecordBuilder extends SdkLogRecordBuilder
       return this;
     }
 
-    AttributeUtil.addExceptionAttributes(throwable, this::setAttribute);
+    AttributeUtil.addExceptionAttributes(
+        throwable, this::setAttribute, logLimits.getMaxAttributeValueLength());
 
     return this;
   }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -469,7 +469,8 @@ final class SdkSpan implements ReadWriteSpan {
         AttributesMap.create(
             spanLimits.getMaxNumberOfAttributes(), spanLimits.getMaxAttributeValueLength());
 
-    AttributeUtil.addExceptionAttributes(exception, attributes::put);
+    AttributeUtil.addExceptionAttributes(
+        exception, attributes::put, spanLimits.getMaxAttributeValueLength());
 
     additionalAttributes.forEach(attributes::put);
 


### PR DESCRIPTION
Replace `Throwable#printStackTrace(PrintStream)` exception stacktrace rendering with a custom implementation which is aware of attribute length limits, and exits early to avoid unnecessary work. The result is significantly improved memory and cpu, with gains proportional to the difference between the total stack trace length and the attribute length limit. I.e. if you have a really long stack trace (i.e. 100k+ chars) and relatively small length limit (i.e. 1k chars), you'll have more to gain with this improvement.

Benchmark results:

```
Benchmark                                            (exceptionParam)  (lengthLimit)  (renderer)  Mode  Cnt      Score      Error   Units
StacktraceRenderBenchmark.render                               SIMPLE             10         JDK  avgt    5   3341.372 ± 2897.392   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE             10         JDK  avgt    5   5650.153 ± 4700.598  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE             10         JDK  avgt    5  19064.017 ±    0.016    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE             10         JDK  avgt    5      3.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE             10         JDK  avgt    5     22.000                 ms
StacktraceRenderBenchmark.render                               SIMPLE             10      CUSTOM  avgt    5     52.803 ±   30.464   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE             10      CUSTOM  avgt    5   4349.904 ± 2077.709  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE             10      CUSTOM  avgt    5    240.000 ±    0.001    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE             10      CUSTOM  avgt    5      2.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE             10      CUSTOM  avgt    5      3.000                 ms
StacktraceRenderBenchmark.render                               SIMPLE           1000         JDK  avgt    5   2789.526 ± 1620.749   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE           1000         JDK  avgt    5   6961.280 ± 3623.628  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE           1000         JDK  avgt    5  20064.015 ±    0.008    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE           1000         JDK  avgt    5      3.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE           1000         JDK  avgt    5      4.000                 ms
StacktraceRenderBenchmark.render                               SIMPLE           1000      CUSTOM  avgt    5    915.035 ±  482.433   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE           1000      CUSTOM  avgt    5  11918.989 ± 5471.749  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE           1000      CUSTOM  avgt    5  11312.005 ±    0.002    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE           1000      CUSTOM  avgt    5      5.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE           1000      CUSTOM  avgt    5      7.000                 ms
StacktraceRenderBenchmark.render                               SIMPLE         100000         JDK  avgt    5   2483.485 ±  417.582   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE         100000         JDK  avgt    5   7305.934 ± 1181.639  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE         100000         JDK  avgt    5  19024.013 ±    0.004    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE         100000         JDK  avgt    5      3.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE         100000         JDK  avgt    5      5.000                 ms
StacktraceRenderBenchmark.render                               SIMPLE         100000      CUSTOM  avgt    5   1585.589 ±  958.212   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                 SIMPLE         100000      CUSTOM  avgt    5  11593.570 ± 5794.885  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm            SIMPLE         100000      CUSTOM  avgt    5  18992.008 ±    0.004    B/op
StacktraceRenderBenchmark.render:gc.count                      SIMPLE         100000      CUSTOM  avgt    5      5.000             counts
StacktraceRenderBenchmark.render:gc.time                       SIMPLE         100000      CUSTOM  avgt    5      8.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX             10         JDK  avgt    5   4291.839 ± 1596.569   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX             10         JDK  avgt    5   5042.169 ± 1731.599  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX             10         JDK  avgt    5  22568.023 ±    0.008    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX             10         JDK  avgt    5      4.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX             10         JDK  avgt    5      6.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX             10      CUSTOM  avgt    5     51.515 ±   24.906   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX             10      CUSTOM  avgt    5   4487.824 ± 1996.520  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX             10      CUSTOM  avgt    5    240.000 ±    0.001    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX             10      CUSTOM  avgt    5      2.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX             10      CUSTOM  avgt    5      3.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX           1000         JDK  avgt    5   3942.046 ±  556.053   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX           1000         JDK  avgt    5   5703.369 ±  793.320  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX           1000         JDK  avgt    5  23592.021 ±    0.004    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX           1000         JDK  avgt    5      4.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX           1000         JDK  avgt    5      7.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX           1000      CUSTOM  avgt    5    928.634 ±   79.862   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX           1000      CUSTOM  avgt    5  11624.281 ± 1010.560  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX           1000      CUSTOM  avgt    5  11336.005 ±    0.001    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX           1000      CUSTOM  avgt    5      6.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX           1000      CUSTOM  avgt    5     10.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX         100000         JDK  avgt    5   4793.245 ± 2833.184   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX         100000         JDK  avgt    5   4556.893 ± 2409.667  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX         100000         JDK  avgt    5  22552.025 ±    0.010    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX         100000         JDK  avgt    5      3.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX         100000         JDK  avgt    5     11.000                 ms
StacktraceRenderBenchmark.render                              COMPLEX         100000      CUSTOM  avgt    5   2532.993 ±  638.702   ns/op
StacktraceRenderBenchmark.render:gc.alloc.rate                COMPLEX         100000      CUSTOM  avgt    5   8701.358 ± 2035.307  MB/sec
StacktraceRenderBenchmark.render:gc.alloc.rate.norm           COMPLEX         100000      CUSTOM  avgt    5  23088.013 ±    0.003    B/op
StacktraceRenderBenchmark.render:gc.count                     COMPLEX         100000      CUSTOM  avgt    5      4.000             counts
StacktraceRenderBenchmark.render:gc.time                      COMPLEX         100000      CUSTOM  avgt    5      6.000                 ms
```