### PR TITLE
Update maven badge to new host

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,5 +304,5 @@ Made with [contrib.rocks](https://contrib.rocks).
 [codecov-image]: https://codecov.io/gh/open-telemetry/opentelemetry-java/branch/main/graph/badge.svg
 [codecov-url]: https://app.codecov.io/gh/open-telemetry/opentelemetry-java/branch/main/
 [dependencies-and-boms]: https://opentelemetry.io/docs/languages/java/intro/#dependencies-and-boms
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry/opentelemetry-api/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry/opentelemetry-api
+[maven-image]: https://maven-badges.sml.io/maven-central/io.opentelemetry/opentelemetry-api/badge.svg
+[maven-url]: https://maven-badges.sml.io/maven-central/io.opentelemetry/opentelemetry-api


### PR DESCRIPTION
Build link checking frequently fails on this link with a 403 ([example](https://github.com/open-telemetry/opentelemetry-java/actions/runs/14499462708/job/40675416367)). Hoping a change to the new host [documented here](https://github.com/softwaremill/maven-badges?tab=readme-ov-file#a-new-dns-address) resolves it.

Also considering: 
1. Removing the maven badge, but I like having a quick link to get to maven central
2. Excluding the link from build link checking