### PR TITLE
Add DeclarativeConfigContext

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactory.java
@@ -6,12 +6,10 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Base2ExponentialBucketHistogramAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExplicitBucketHistogramAggregationModel;
 import io.opentelemetry.sdk.metrics.Aggregation;
-import java.io.Closeable;
 import java.util.List;
 
 final class AggregationFactory implements Factory<AggregationModel, Aggregation> {
@@ -25,8 +23,7 @@ final class AggregationFactory implements Factory<AggregationModel, Aggregation>
   }
 
   @Override
-  public Aggregation create(
-      AggregationModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public Aggregation create(AggregationModel model, DeclarativeConfigContext context) {
     if (model.getDrop() != null) {
       return Aggregation.drop();
     }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributeListFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributeListFactory.java
@@ -11,9 +11,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeNameValueModel;
-import java.io.Closeable;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -28,8 +26,7 @@ final class AttributeListFactory implements Factory<List<AttributeNameValueModel
   }
 
   @Override
-  public Attributes create(
-      List<AttributeNameValueModel> model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public Attributes create(List<AttributeNameValueModel> model, DeclarativeConfigContext context) {
     AttributesBuilder builder = Attributes.builder();
 
     for (AttributeNameValueModel nameValueModel : model) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/CardinalityLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/CardinalityLimitsFactory.java
@@ -5,12 +5,9 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.CardinalityLimitsModel;
 import io.opentelemetry.sdk.metrics.export.CardinalityLimitSelector;
 import io.opentelemetry.sdk.metrics.internal.state.MetricStorage;
-import java.io.Closeable;
-import java.util.List;
 import javax.annotation.Nullable;
 
 final class CardinalityLimitsFactory
@@ -26,7 +23,7 @@ final class CardinalityLimitsFactory
 
   @Override
   public CardinalityLimitSelector create(
-      CardinalityLimitsModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+      CardinalityLimitsModel model, DeclarativeConfigContext context) {
     int defaultLimit = getOrDefault(model.getDefault(), MetricStorage.DEFAULT_MAX_CARDINALITY);
     int counterLimit = getOrDefault(model.getCounter(), defaultLimit);
     int gaugeLimit = getOrDefault(model.getGauge(), defaultLimit);

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
@@ -40,7 +40,7 @@ class DeclarativeConfigContext {
   }
 
   /**
-   * Find a registered {@link ComponentProvider} which {@link ComponentProvider#getType()} matching
+   * Find a registered {@link ComponentProvider} with {@link ComponentProvider#getType()} matching
    * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link
    * ComponentProvider#create(DeclarativeConfigProperties)} with the given {@code model}.
    *

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Declarative configuration context and state carrier. */
+class DeclarativeConfigContext {
+
+  private final SpiHelper spiHelper;
+  private final List<Closeable> closeables = new ArrayList<>();
+
+  DeclarativeConfigContext(SpiHelper spiHelper) {
+    this.spiHelper = spiHelper;
+  }
+
+  /**
+   * Add the {@code closeable} to the list of closeables to clean up if configuration fails
+   * exceptionally, and return it.
+   */
+  <T extends Closeable> T addCloseable(T closeable) {
+    closeables.add(closeable);
+    return closeable;
+  }
+
+  List<Closeable> getCloseables() {
+    return Collections.unmodifiableList(closeables);
+  }
+
+  /**
+   * Find a registered {@link ComponentProvider} which {@link ComponentProvider#getType()} matching
+   * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link
+   * ComponentProvider#create(DeclarativeConfigProperties)} with the given {@code model}.
+   *
+   * @throws DeclarativeConfigException if no matching providers are found, or if multiple are found
+   *     (i.e. conflict), or if {@link ComponentProvider#create(DeclarativeConfigProperties)} throws
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  <T> T loadComponent(Class<T> type, String name, Object model) {
+    DeclarativeConfigProperties config =
+        DeclarativeConfiguration.toConfigProperties(model, spiHelper.getComponentLoader());
+
+    // TODO(jack-berg): cache loaded component providers
+    List<ComponentProvider> componentProviders = spiHelper.load(ComponentProvider.class);
+    List<ComponentProvider<?>> matchedProviders =
+        componentProviders.stream()
+            .map(
+                (Function<ComponentProvider, ComponentProvider<?>>)
+                    componentProvider -> componentProvider)
+            .filter(
+                componentProvider ->
+                    componentProvider.getType() == type && name.equals(componentProvider.getName()))
+            .collect(Collectors.toList());
+    if (matchedProviders.isEmpty()) {
+      throw new DeclarativeConfigException(
+          "No component provider detected for " + type.getName() + " with name \"" + name + "\".");
+    }
+    if (matchedProviders.size() > 1) {
+      throw new DeclarativeConfigException(
+          "Component provider conflict. Multiple providers detected for "
+              + type.getName()
+              + " with name \""
+              + name
+              + "\": "
+              + componentProviders.stream()
+                  .map(provider -> provider.getClass().getName())
+                  .collect(Collectors.joining(",", "[", "]")));
+    }
+    // Exactly one matching component provider
+    ComponentProvider<T> provider = (ComponentProvider<T>) matchedProviders.get(0);
+
+    try {
+      return provider.create(config);
+    } catch (Throwable throwable) {
+      throw new DeclarativeConfigException(
+          "Error configuring " + type.getName() + " with name \"" + name + "\"", throwable);
+    }
+  }
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfiguration.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfiguration.java
@@ -21,7 +21,6 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -221,12 +220,12 @@ public final class DeclarativeConfiguration {
   }
 
   static <M, R> R createAndMaybeCleanup(Factory<M, R> factory, SpiHelper spiHelper, M model) {
-    List<Closeable> closeables = new ArrayList<>();
+    DeclarativeConfigContext context = new DeclarativeConfigContext(spiHelper);
     try {
-      return factory.create(model, spiHelper, closeables);
+      return factory.create(model, context);
     } catch (RuntimeException e) {
       logger.info("Error encountered interpreting model. Closing partially configured components.");
-      for (Closeable closeable : closeables) {
+      for (Closeable closeable : context.getCloseables()) {
         try {
           logger.fine("Closing " + closeable.getClass().getName());
           closeable.close();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/Factory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/Factory.java
@@ -5,19 +5,14 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
-import java.io.Closeable;
-import java.util.List;
-
 interface Factory<ModelT, ResultT> {
 
   /**
    * Interpret the model and create {@link ResultT} with corresponding configuration.
    *
    * @param model the configuration model
-   * @param spiHelper the service loader helper
-   * @param closeables mutable list of closeables created
+   * @param context the configuration context
    * @return the {@link ResultT}
    */
-  ResultT create(ModelT model, SpiHelper spiHelper, List<Closeable> closeables);
+  ResultT create(ModelT model, DeclarativeConfigContext context);
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigUtil.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/FileConfigUtil.java
@@ -8,27 +8,12 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static java.util.stream.Collectors.joining;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
-import java.io.Closeable;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 final class FileConfigUtil {
 
   private FileConfigUtil() {}
-
-  /** Add the {@code closeable} to the {@code closeables} and return it. */
-  static <T> T addAndReturn(List<Closeable> closeables, T closeable) {
-    if (closeable instanceof Closeable) {
-      closeables.add((Closeable) closeable);
-    }
-    return closeable;
-  }
 
   static <T> T assertNotNull(@Nullable T object, String description) {
     if (object == null) {
@@ -42,69 +27,6 @@ final class FileConfigUtil {
       throw new DeclarativeConfigException(description + " is required but is null");
     }
     return object;
-  }
-
-  /**
-   * Find a registered {@link ComponentProvider} which {@link ComponentProvider#getType()} matching
-   * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link
-   * ComponentProvider#create(DeclarativeConfigProperties)} with the given {@code model}.
-   *
-   * @throws DeclarativeConfigException if no matching providers are found, or if multiple are found
-   *     (i.e. conflict), or if {@link ComponentProvider#create(DeclarativeConfigProperties)} throws
-   */
-  static <T> T loadComponent(SpiHelper spiHelper, Class<T> type, String name, Object model) {
-    // Map model to generic structured config properties
-    DeclarativeConfigProperties config =
-        DeclarativeConfiguration.toConfigProperties(model, spiHelper.getComponentLoader());
-    return loadComponentHelper(spiHelper, type, name, config);
-  }
-
-  /**
-   * Find a registered {@link ComponentProvider} with {@link ComponentProvider#getType()} matching
-   * {@code type}, {@link ComponentProvider#getName()} matching {@code name}, and call {@link
-   * ComponentProvider#create(DeclarativeConfigProperties)} with the given {@code config}.
-   *
-   * @throws DeclarativeConfigException if no matching providers are found, or if multiple are found
-   *     (i.e. conflict), or if {@link ComponentProvider#create(DeclarativeConfigProperties)} throws
-   */
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  private static <T> T loadComponentHelper(
-      SpiHelper spiHelper, Class<T> type, String name, DeclarativeConfigProperties config) {
-    // TODO(jack-berg): cache loaded component providers
-    List<ComponentProvider> componentProviders = spiHelper.load(ComponentProvider.class);
-    List<ComponentProvider<?>> matchedProviders =
-        componentProviders.stream()
-            .map(
-                (Function<ComponentProvider, ComponentProvider<?>>)
-                    componentProvider -> componentProvider)
-            .filter(
-                componentProvider ->
-                    componentProvider.getType() == type && name.equals(componentProvider.getName()))
-            .collect(Collectors.toList());
-    if (matchedProviders.isEmpty()) {
-      throw new DeclarativeConfigException(
-          "No component provider detected for " + type.getName() + " with name \"" + name + "\".");
-    }
-    if (matchedProviders.size() > 1) {
-      throw new DeclarativeConfigException(
-          "Component provider conflict. Multiple providers detected for "
-              + type.getName()
-              + " with name \""
-              + name
-              + "\": "
-              + componentProviders.stream()
-                  .map(provider -> provider.getClass().getName())
-                  .collect(Collectors.joining(",", "[", "]")));
-    }
-    // Exactly one matching component provider
-    ComponentProvider<T> provider = (ComponentProvider<T>) matchedProviders.get(0);
-
-    try {
-      return provider.create(config);
-    } catch (Throwable throwable) {
-      throw new DeclarativeConfigException(
-          "Error configuring " + type.getName() + " with name \"" + name + "\"", throwable);
-    }
   }
 
   static Map.Entry<String, Object> getSingletonMapEntry(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactory.java
@@ -6,13 +6,10 @@
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ViewSelectorModel;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentSelectorBuilder;
 import io.opentelemetry.sdk.metrics.InstrumentType;
-import java.io.Closeable;
-import java.util.List;
 
 final class InstrumentSelectorFactory implements Factory<ViewSelectorModel, InstrumentSelector> {
 
@@ -25,8 +22,7 @@ final class InstrumentSelectorFactory implements Factory<ViewSelectorModel, Inst
   }
 
   @Override
-  public InstrumentSelector create(
-      ViewSelectorModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public InstrumentSelector create(ViewSelectorModel model, DeclarativeConfigContext context) {
     InstrumentSelectorBuilder builder = InstrumentSelector.builder();
     if (model.getInstrumentName() != null) {
       builder.setName(model.getInstrumentName());

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactory.java
@@ -5,13 +5,10 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimitsModel;
 import io.opentelemetry.sdk.logs.LogLimits;
 import io.opentelemetry.sdk.logs.LogLimitsBuilder;
-import java.io.Closeable;
-import java.util.List;
 
 final class LogLimitsFactory implements Factory<LogRecordLimitsAndAttributeLimits, LogLimits> {
 
@@ -25,7 +22,7 @@ final class LogLimitsFactory implements Factory<LogRecordLimitsAndAttributeLimit
 
   @Override
   public LogLimits create(
-      LogRecordLimitsAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
+      LogRecordLimitsAndAttributeLimits model, DeclarativeConfigContext context) {
     LogLimitsBuilder builder = LogLimits.builder();
 
     AttributeLimitsModel attributeLimitsModel = model.getAttributeLimits();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactory.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
-import java.io.Closeable;
-import java.util.List;
 import java.util.Map;
 
 final class LogRecordExporterFactory implements Factory<LogRecordExporterModel, LogRecordExporter> {
@@ -23,8 +20,7 @@ final class LogRecordExporterFactory implements Factory<LogRecordExporterModel, 
   }
 
   @Override
-  public LogRecordExporter create(
-      LogRecordExporterModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public LogRecordExporter create(LogRecordExporterModel model, DeclarativeConfigContext context) {
 
     model.getAdditionalProperties().compute("otlp_http", (k, v) -> model.getOtlpHttp());
     model.getAdditionalProperties().compute("otlp_grpc", (k, v) -> model.getOtlpGrpc());
@@ -36,8 +32,7 @@ final class LogRecordExporterFactory implements Factory<LogRecordExporterModel, 
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(model.getAdditionalProperties(), "log record exporter");
     LogRecordExporter logRecordExporter =
-        FileConfigUtil.loadComponent(
-            spiHelper, LogRecordExporter.class, keyValue.getKey(), keyValue.getValue());
-    return FileConfigUtil.addAndReturn(closeables, logRecordExporter);
+        context.loadComponent(LogRecordExporter.class, keyValue.getKey(), keyValue.getValue());
+    return context.addCloseable(logRecordExporter);
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactory.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordProcessorModel;
@@ -15,9 +14,7 @@ import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessorBuilder;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
-import java.io.Closeable;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 
 final class LogRecordProcessorFactory
@@ -33,7 +30,7 @@ final class LogRecordProcessorFactory
 
   @Override
   public LogRecordProcessor create(
-      LogRecordProcessorModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+      LogRecordProcessorModel model, DeclarativeConfigContext context) {
     BatchLogRecordProcessorModel batchModel = model.getBatch();
     if (batchModel != null) {
       LogRecordExporterModel exporterModel =
@@ -41,7 +38,7 @@ final class LogRecordProcessorFactory
               batchModel.getExporter(), "batch log record processor exporter");
 
       LogRecordExporter logRecordExporter =
-          LogRecordExporterFactory.getInstance().create(exporterModel, spiHelper, closeables);
+          LogRecordExporterFactory.getInstance().create(exporterModel, context);
       BatchLogRecordProcessorBuilder builder = BatchLogRecordProcessor.builder(logRecordExporter);
       if (batchModel.getExportTimeout() != null) {
         builder.setExporterTimeout(Duration.ofMillis(batchModel.getExportTimeout()));
@@ -55,7 +52,8 @@ final class LogRecordProcessorFactory
       if (batchModel.getScheduleDelay() != null) {
         builder.setScheduleDelay(Duration.ofMillis(batchModel.getScheduleDelay()));
       }
-      return FileConfigUtil.addAndReturn(closeables, builder.build());
+
+      return context.addCloseable(builder.build());
     }
 
     SimpleLogRecordProcessorModel simpleModel = model.getSimple();
@@ -64,17 +62,15 @@ final class LogRecordProcessorFactory
           FileConfigUtil.requireNonNull(
               simpleModel.getExporter(), "simple log record processor exporter");
       LogRecordExporter logRecordExporter =
-          LogRecordExporterFactory.getInstance().create(exporterModel, spiHelper, closeables);
-      return FileConfigUtil.addAndReturn(
-          closeables, SimpleLogRecordProcessor.create(logRecordExporter));
+          LogRecordExporterFactory.getInstance().create(exporterModel, context);
+      return context.addCloseable(SimpleLogRecordProcessor.create(logRecordExporter));
     }
 
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(
             model.getAdditionalProperties(), "log record processor");
     LogRecordProcessor logRecordProcessor =
-        FileConfigUtil.loadComponent(
-            spiHelper, LogRecordProcessor.class, keyValue.getKey(), keyValue.getValue());
-    return FileConfigUtil.addAndReturn(closeables, logRecordProcessor);
+        context.loadComponent(LogRecordProcessor.class, keyValue.getKey(), keyValue.getValue());
+    return context.addCloseable(logRecordProcessor);
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactory.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PushMetricExporterModel;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import java.io.Closeable;
-import java.util.List;
 import java.util.Map;
 
 final class MetricExporterFactory implements Factory<PushMetricExporterModel, MetricExporter> {
@@ -23,8 +20,7 @@ final class MetricExporterFactory implements Factory<PushMetricExporterModel, Me
   }
 
   @Override
-  public MetricExporter create(
-      PushMetricExporterModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public MetricExporter create(PushMetricExporterModel model, DeclarativeConfigContext context) {
 
     model.getAdditionalProperties().compute("otlp_http", (k, v) -> model.getOtlpHttp());
     model.getAdditionalProperties().compute("otlp_grpc", (k, v) -> model.getOtlpGrpc());
@@ -36,8 +32,7 @@ final class MetricExporterFactory implements Factory<PushMetricExporterModel, Me
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(model.getAdditionalProperties(), "metric exporter");
     MetricExporter metricExporter =
-        FileConfigUtil.loadComponent(
-            spiHelper, MetricExporter.class, keyValue.getKey(), keyValue.getValue());
-    return FileConfigUtil.addAndReturn(closeables, metricExporter);
+        context.loadComponent(MetricExporter.class, keyValue.getKey(), keyValue.getValue());
+    return context.addCloseable(metricExporter);
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactory.java
@@ -7,10 +7,8 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PropagatorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TextMapPropagatorModel;
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -29,8 +27,7 @@ final class PropagatorFactory implements Factory<PropagatorModel, ContextPropaga
   }
 
   @Override
-  public ContextPropagators create(
-      PropagatorModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public ContextPropagators create(PropagatorModel model, DeclarativeConfigContext context) {
     List<TextMapPropagatorModel> textMapPropagatorModels = model.getComposite();
     Set<String> propagatorNames = new HashSet<>();
     List<TextMapPropagator> textMapPropagators = new ArrayList<>();
@@ -38,8 +35,7 @@ final class PropagatorFactory implements Factory<PropagatorModel, ContextPropaga
       textMapPropagatorModels.forEach(
           textMapPropagatorModel -> {
             TextMapPropagatorAndName propagatorAndName =
-                TextMapPropagatorFactory.getInstance()
-                    .create(textMapPropagatorModel, spiHelper, closeables);
+                TextMapPropagatorFactory.getInstance().create(textMapPropagatorModel, context);
             textMapPropagators.add(propagatorAndName.getTextMapPropagator());
             propagatorNames.add(propagatorAndName.getName());
           });
@@ -59,7 +55,7 @@ final class PropagatorFactory implements Factory<PropagatorModel, ContextPropaga
         // Only add entries which weren't already previously added
         if (propagatorNames.add(propagatorName)) {
           textMapPropagators.add(
-              TextMapPropagatorFactory.getPropagator(spiHelper, propagatorName)
+              TextMapPropagatorFactory.getPropagator(context, propagatorName)
                   .getTextMapPropagator());
         }
       }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceDetectorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceDetectorFactory.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
 import io.opentelemetry.sdk.resources.Resource;
-import java.io.Closeable;
-import java.util.List;
 import java.util.Map;
 
 final class ResourceDetectorFactory
@@ -25,10 +22,9 @@ final class ResourceDetectorFactory
 
   @Override
   public Resource create(
-      ExperimentalResourceDetectorModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+      ExperimentalResourceDetectorModel model, DeclarativeConfigContext context) {
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(model.getAdditionalProperties(), "resource detector");
-    return FileConfigUtil.loadComponent(
-        spiHelper, Resource.class, keyValue.getKey(), keyValue.getValue());
+    return context.loadComponent(Resource.class, keyValue.getKey(), keyValue.getValue());
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactory.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.sdk.internal.GlobUtil.createGlobPatternPredicate;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.ResourceConfiguration;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeNameValueModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
@@ -18,7 +17,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Includ
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ResourceModel;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
-import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -35,7 +33,7 @@ final class ResourceFactory implements Factory<ResourceModel, Resource> {
   }
 
   @Override
-  public Resource create(ResourceModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public Resource create(ResourceModel model, DeclarativeConfigContext context) {
     ResourceBuilder builder = Resource.getDefault().toBuilder();
 
     ExperimentalResourceDetectionModel detectionModel = model.getDetectionDevelopment();
@@ -46,7 +44,7 @@ final class ResourceFactory implements Factory<ResourceModel, Resource> {
       if (detectorModels != null) {
         for (ExperimentalResourceDetectorModel detectorModel : detectorModels) {
           detectedResourceBuilder.putAll(
-              ResourceDetectorFactory.getInstance().create(detectorModel, spiHelper, closeables));
+              ResourceDetectorFactory.getInstance().create(detectorModel, context));
         }
       }
 
@@ -71,9 +69,7 @@ final class ResourceFactory implements Factory<ResourceModel, Resource> {
     List<AttributeNameValueModel> attributeNameValueModel = model.getAttributes();
     if (attributeNameValueModel != null) {
       builder
-          .putAll(
-              AttributeListFactory.getInstance()
-                  .create(attributeNameValueModel, spiHelper, closeables))
+          .putAll(AttributeListFactory.getInstance().create(attributeNameValueModel, context))
           .build();
     }
 

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactory.java
@@ -5,11 +5,8 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.io.Closeable;
-import java.util.List;
 import java.util.Map;
 
 final class SpanExporterFactory implements Factory<SpanExporterModel, SpanExporter> {
@@ -23,8 +20,7 @@ final class SpanExporterFactory implements Factory<SpanExporterModel, SpanExport
   }
 
   @Override
-  public SpanExporter create(
-      SpanExporterModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public SpanExporter create(SpanExporterModel model, DeclarativeConfigContext context) {
 
     model.getAdditionalProperties().compute("otlp_http", (k, v) -> model.getOtlpHttp());
     model.getAdditionalProperties().compute("otlp_grpc", (k, v) -> model.getOtlpGrpc());
@@ -36,9 +32,8 @@ final class SpanExporterFactory implements Factory<SpanExporterModel, SpanExport
 
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(model.getAdditionalProperties(), "span exporter");
-    SpanExporter metricExporter =
-        FileConfigUtil.loadComponent(
-            spiHelper, SpanExporter.class, keyValue.getKey(), keyValue.getValue());
-    return FileConfigUtil.addAndReturn(closeables, metricExporter);
+    SpanExporter spanExporter =
+        context.loadComponent(SpanExporter.class, keyValue.getKey(), keyValue.getValue());
+    return context.addCloseable(spanExporter);
   }
 }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactory.java
@@ -5,13 +5,10 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLimitsModel;
 import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.SpanLimitsBuilder;
-import java.io.Closeable;
-import java.util.List;
 
 final class SpanLimitsFactory implements Factory<SpanLimitsAndAttributeLimits, SpanLimits> {
 
@@ -24,8 +21,7 @@ final class SpanLimitsFactory implements Factory<SpanLimitsAndAttributeLimits, S
   }
 
   @Override
-  public SpanLimits create(
-      SpanLimitsAndAttributeLimits model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public SpanLimits create(SpanLimitsAndAttributeLimits model, DeclarativeConfigContext context) {
     SpanLimitsBuilder builder = SpanLimits.builder();
 
     AttributeLimitsModel attributeLimitsModel = model.getAttributeLimits();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TextMapPropagatorFactory.java
@@ -8,11 +8,8 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TextMapPropagatorModel;
-import java.io.Closeable;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 final class TextMapPropagatorFactory
@@ -28,35 +25,34 @@ final class TextMapPropagatorFactory
 
   @Override
   public TextMapPropagatorAndName create(
-      TextMapPropagatorModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+      TextMapPropagatorModel model, DeclarativeConfigContext context) {
     if (model.getTracecontext() != null) {
-      return getPropagator(spiHelper, "tracecontext");
+      return getPropagator(context, "tracecontext");
     }
     if (model.getBaggage() != null) {
-      return getPropagator(spiHelper, "baggage");
+      return getPropagator(context, "baggage");
     }
     if (model.getB3() != null) {
-      return getPropagator(spiHelper, "b3");
+      return getPropagator(context, "b3");
     }
     if (model.getB3multi() != null) {
-      return getPropagator(spiHelper, "b3multi");
+      return getPropagator(context, "b3multi");
     }
     if (model.getJaeger() != null) {
-      return getPropagator(spiHelper, "jaeger");
+      return getPropagator(context, "jaeger");
     }
     if (model.getOttrace() != null) {
-      return getPropagator(spiHelper, "ottrace");
+      return getPropagator(context, "ottrace");
     }
 
     Map.Entry<String, Object> keyValue =
         FileConfigUtil.getSingletonMapEntry(model.getAdditionalProperties(), "propagator");
     TextMapPropagator propagator =
-        FileConfigUtil.loadComponent(
-            spiHelper, TextMapPropagator.class, keyValue.getKey(), keyValue.getValue());
+        context.loadComponent(TextMapPropagator.class, keyValue.getKey(), keyValue.getValue());
     return TextMapPropagatorAndName.create(propagator, keyValue.getKey());
   }
 
-  static TextMapPropagatorAndName getPropagator(SpiHelper spiHelper, String name) {
+  static TextMapPropagatorAndName getPropagator(DeclarativeConfigContext context, String name) {
     TextMapPropagator textMapPropagator;
     if (name.equals("tracecontext")) {
       textMapPropagator = W3CTraceContextPropagator.getInstance();
@@ -64,8 +60,7 @@ final class TextMapPropagatorFactory
       textMapPropagator = W3CBaggagePropagator.getInstance();
     } else {
       textMapPropagator =
-          FileConfigUtil.loadComponent(
-              spiHelper, TextMapPropagator.class, name, Collections.emptyMap());
+          context.loadComponent(TextMapPropagator.class, name, Collections.emptyMap());
     }
     return TextMapPropagatorAndName.create(textMapPropagator, name);
   }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactory.java
@@ -5,12 +5,10 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.IncludeExcludeModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ViewStreamModel;
 import io.opentelemetry.sdk.metrics.View;
 import io.opentelemetry.sdk.metrics.ViewBuilder;
-import java.io.Closeable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -27,7 +25,7 @@ final class ViewFactory implements Factory<ViewStreamModel, View> {
   }
 
   @Override
-  public View create(ViewStreamModel model, SpiHelper spiHelper, List<Closeable> closeables) {
+  public View create(ViewStreamModel model, DeclarativeConfigContext context) {
     ViewBuilder builder = View.builder();
     if (model.getName() != null) {
       builder.setName(model.getName());
@@ -41,7 +39,7 @@ final class ViewFactory implements Factory<ViewStreamModel, View> {
     }
     if (model.getAggregation() != null) {
       builder.setAggregation(
-          AggregationFactory.getInstance().create(model.getAggregation(), spiHelper, closeables));
+          AggregationFactory.getInstance().create(model.getAggregation(), context));
     }
     if (model.getAggregationCardinalityLimit() != null) {
       builder.setCardinalityLimit(model.getAggregationCardinalityLimit());

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AggregationFactoryTest.java
@@ -8,14 +8,12 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Base2ExponentialBucketHistogramAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.DropAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExplicitBucketHistogramAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LastValueAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SumAggregationModel;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,7 +26,7 @@ class AggregationFactoryTest {
   @MethodSource("createTestCases")
   void create(AggregationModel model, io.opentelemetry.sdk.metrics.Aggregation expectedResult) {
     io.opentelemetry.sdk.metrics.Aggregation aggregation =
-        AggregationFactory.getInstance().create(model, mock(SpiHelper.class), new ArrayList<>());
+        AggregationFactory.getInstance().create(model, mock(DeclarativeConfigContext.class));
     assertThat(aggregation.toString()).isEqualTo(expectedResult.toString());
   }
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributeListFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/AttributeListFactoryTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeNameValueModel;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,7 +29,7 @@ class AttributeListFactoryTest {
     assertThatThrownBy(
             () ->
                 AttributeListFactory.getInstance()
-                    .create(model, mock(SpiHelper.class), Collections.emptyList()))
+                    .create(model, mock(DeclarativeConfigContext.class)))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessageContaining(expectedMessage);
   }
@@ -133,8 +132,7 @@ class AttributeListFactoryTest {
                             .withName("boolArrKey")
                             .withValue(Arrays.asList(true, false))
                             .withType(AttributeNameValueModel.AttributeType.BOOL_ARRAY)),
-                    mock(SpiHelper.class),
-                    Collections.emptyList()))
+                    mock(DeclarativeConfigContext.class)))
         .isEqualTo(expectedAttributes);
   }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/CardinalityLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/CardinalityLimitsFactoryTest.java
@@ -8,11 +8,9 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.CardinalityLimitsModel;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.CardinalityLimitSelector;
-import java.util.ArrayList;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,8 +22,7 @@ class CardinalityLimitsFactoryTest {
   @MethodSource("createTestCases")
   void create(CardinalityLimitsModel model, CardinalityLimitSelector expectedResult) {
     CardinalityLimitSelector cardinalityLimitSelector =
-        CardinalityLimitsFactory.getInstance()
-            .create(model, mock(SpiHelper.class), new ArrayList<>());
+        CardinalityLimitsFactory.getInstance().create(model, mock(DeclarativeConfigContext.class));
 
     for (InstrumentType instrumentType : InstrumentType.values()) {
       assertThat(cardinalityLimitSelector.getCardinalityLimit(instrumentType))

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/InstrumentSelectorFactoryTest.java
@@ -10,11 +10,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ViewSelectorModel;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.InstrumentType;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class InstrumentSelectorFactoryTest {
@@ -24,8 +22,7 @@ class InstrumentSelectorFactoryTest {
     assertThatThrownBy(
             () ->
                 InstrumentSelectorFactory.getInstance()
-                    .create(
-                        new ViewSelectorModel(), mock(SpiHelper.class), Collections.emptyList()))
+                    .create(new ViewSelectorModel(), mock(DeclarativeConfigContext.class)))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage("Invalid selector");
   }
@@ -41,8 +38,7 @@ class InstrumentSelectorFactoryTest {
                         .withMeterName("meter-name")
                         .withMeterSchemaUrl("https://opentelemetry.io/schemas/1.16.0")
                         .withMeterVersion("1.0.0"),
-                    mock(SpiHelper.class),
-                    Collections.emptyList()))
+                    mock(DeclarativeConfigContext.class)))
         .isEqualTo(
             InstrumentSelector.builder()
                 .setName("instrument-name")

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogLimitsFactoryTest.java
@@ -8,11 +8,9 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordLimitsModel;
 import io.opentelemetry.sdk.logs.LogLimits;
-import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,9 +21,7 @@ class LogLimitsFactoryTest {
   @ParameterizedTest
   @MethodSource("createArguments")
   void create(LogRecordLimitsAndAttributeLimits model, LogLimits expectedLogLimits) {
-    assertThat(
-            LogLimitsFactory.getInstance()
-                .create(model, mock(SpiHelper.class), Collections.emptyList()))
+    assertThat(LogLimitsFactory.getInstance().create(model, mock(DeclarativeConfigContext.class)))
         .isEqualTo(expectedLogLimits);
   }
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordExporterFactoryTest.java
@@ -64,6 +64,7 @@ class LogRecordExporterFactoryTest {
 
   private final SpiHelper spiHelper =
       spy(SpiHelper.create(SpanExporterFactoryTest.class.getClassLoader()));
+  private final DeclarativeConfigContext context = new DeclarativeConfigContext(spiHelper);
   private List<ComponentProvider<?>> loadedComponentProviders = Collections.emptyList();
 
   @BeforeEach
@@ -99,9 +100,7 @@ class LogRecordExporterFactoryTest {
     LogRecordExporter exporter =
         LogRecordExporterFactory.getInstance()
             .create(
-                new LogRecordExporterModel().withOtlpHttp(new OtlpHttpExporterModel()),
-                spiHelper,
-                closeables);
+                new LogRecordExporterModel().withOtlpHttp(new OtlpHttpExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -169,8 +168,7 @@ class LogRecordExporterFactoryTest {
                             .withCertificateFile(certificatePath)
                             .withClientKeyFile(clientKeyPath)
                             .withClientCertificateFile(clientCertificatePath)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -212,9 +210,7 @@ class LogRecordExporterFactoryTest {
     LogRecordExporter exporter =
         LogRecordExporterFactory.getInstance()
             .create(
-                new LogRecordExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()),
-                spiHelper,
-                closeables);
+                new LogRecordExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -281,8 +277,7 @@ class LogRecordExporterFactoryTest {
                             .withCertificateFile(certificatePath)
                             .withClientKeyFile(clientKeyPath)
                             .withClientCertificateFile(clientCertificatePath)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -326,8 +321,7 @@ class LogRecordExporterFactoryTest {
             .create(
                 new LogRecordExporterModel()
                     .withOtlpFileDevelopment(new ExperimentalOtlpFileExporterModel()),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -351,8 +345,7 @@ class LogRecordExporterFactoryTest {
                         new LogRecordExporterModel()
                             .withAdditionalProperty(
                                 "unknown_key", ImmutableMap.of("key1", "value1")),
-                        spiHelper,
-                        new ArrayList<>()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.sdk.logs.export.LogRecordExporter with name \"unknown_key\".");
@@ -366,8 +359,7 @@ class LogRecordExporterFactoryTest {
             .create(
                 new LogRecordExporterModel()
                     .withAdditionalProperty("test", ImmutableMap.of("key1", "value1")),
-                spiHelper,
-                new ArrayList<>());
+                context);
     assertThat(logRecordExporter)
         .isInstanceOf(LogRecordExporterComponentProvider.TestLogRecordExporter.class);
     assertThat(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LogRecordProcessorFactoryTest.java
@@ -22,7 +22,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Simple
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,8 +31,9 @@ class LogRecordProcessorFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(LogRecordProcessorFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(
+          SpiHelper.create(LogRecordProcessorFactoryTest.class.getClassLoader()));
 
   @Test
   void create_BatchNullExporter() {
@@ -42,8 +42,7 @@ class LogRecordProcessorFactoryTest {
                 LogRecordProcessorFactory.getInstance()
                     .create(
                         new LogRecordProcessorModel().withBatch(new BatchLogRecordProcessorModel()),
-                        spiHelper,
-                        Collections.emptyList()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage("batch log record processor exporter is required but is null");
   }
@@ -66,8 +65,7 @@ class LogRecordProcessorFactoryTest {
                             .withExporter(
                                 new LogRecordExporterModel()
                                     .withOtlpHttp(new OtlpHttpExporterModel()))),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(processor);
     cleanup.addCloseables(closeables);
 
@@ -98,8 +96,7 @@ class LogRecordProcessorFactoryTest {
                             .withScheduleDelay(1)
                             .withMaxExportBatchSize(2)
                             .withExportTimeout(3)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(processor);
     cleanup.addCloseables(closeables);
 
@@ -114,8 +111,7 @@ class LogRecordProcessorFactoryTest {
                     .create(
                         new LogRecordProcessorModel()
                             .withSimple(new SimpleLogRecordProcessorModel()),
-                        spiHelper,
-                        Collections.emptyList()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage("simple log record processor exporter is required but is null");
   }
@@ -137,8 +133,7 @@ class LogRecordProcessorFactoryTest {
                             .withExporter(
                                 new LogRecordExporterModel()
                                     .withOtlpHttp(new OtlpHttpExporterModel()))),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(processor);
     cleanup.addCloseables(closeables);
 
@@ -154,8 +149,7 @@ class LogRecordProcessorFactoryTest {
                         new LogRecordProcessorModel()
                             .withAdditionalProperty(
                                 "unknown_key", ImmutableMap.of("key1", "value1")),
-                        spiHelper,
-                        new ArrayList<>()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.sdk.logs.LogRecordProcessor with name \"unknown_key\".");
@@ -168,8 +162,7 @@ class LogRecordProcessorFactoryTest {
             .create(
                 new LogRecordProcessorModel()
                     .withAdditionalProperty("test", ImmutableMap.of("key1", "value1")),
-                spiHelper,
-                new ArrayList<>());
+                context);
     assertThat(logRecordProcessor)
         .isInstanceOf(LogRecordProcessorComponentProvider.TestLogRecordProcessor.class);
     Assertions.assertThat(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/LoggerProviderFactoryTest.java
@@ -40,8 +40,9 @@ class LoggerProviderFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(LoggerProviderFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(
+          SpiHelper.create(LoggerProviderFactoryTest.class.getClassLoader()));
 
   @ParameterizedTest
   @MethodSource("createArguments")
@@ -49,8 +50,7 @@ class LoggerProviderFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     cleanup.addCloseable(expectedProvider);
 
-    SdkLoggerProvider provider =
-        LoggerProviderFactory.getInstance().create(model, spiHelper, closeables).build();
+    SdkLoggerProvider provider = LoggerProviderFactory.getInstance().create(model, context).build();
     cleanup.addCloseable(provider);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MeterProviderFactoryTest.java
@@ -43,8 +43,9 @@ class MeterProviderFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(MeterProviderFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(
+          SpiHelper.create(MeterProviderFactoryTest.class.getClassLoader()));
 
   @ParameterizedTest
   @MethodSource("createArguments")
@@ -52,8 +53,7 @@ class MeterProviderFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     cleanup.addCloseable(expectedProvider);
 
-    SdkMeterProvider provider =
-        MeterProviderFactory.getInstance().create(model, spiHelper, closeables).build();
+    SdkMeterProvider provider = MeterProviderFactory.getInstance().create(model, context).build();
     cleanup.addCloseable(provider);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/MetricExporterFactoryTest.java
@@ -70,6 +70,7 @@ class MetricExporterFactoryTest {
 
   private final SpiHelper spiHelper =
       spy(SpiHelper.create(SpanExporterFactoryTest.class.getClassLoader()));
+  private final DeclarativeConfigContext context = new DeclarativeConfigContext(spiHelper);
   private List<ComponentProvider<?>> loadedComponentProviders = Collections.emptyList();
 
   @BeforeEach
@@ -106,8 +107,7 @@ class MetricExporterFactoryTest {
         MetricExporterFactory.getInstance()
             .create(
                 new PushMetricExporterModel().withOtlpHttp(new OtlpHttpMetricExporterModel()),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -184,8 +184,7 @@ class MetricExporterFactoryTest {
                             .withDefaultHistogramAggregation(
                                 OtlpHttpMetricExporterModel.ExporterDefaultHistogramAggregation
                                     .BASE_2_EXPONENTIAL_BUCKET_HISTOGRAM)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -231,8 +230,7 @@ class MetricExporterFactoryTest {
         MetricExporterFactory.getInstance()
             .create(
                 new PushMetricExporterModel().withOtlpGrpc(new OtlpGrpcMetricExporterModel()),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -308,8 +306,7 @@ class MetricExporterFactoryTest {
                             .withDefaultHistogramAggregation(
                                 OtlpHttpMetricExporterModel.ExporterDefaultHistogramAggregation
                                     .BASE_2_EXPONENTIAL_BUCKET_HISTOGRAM)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -353,10 +350,7 @@ class MetricExporterFactoryTest {
 
     io.opentelemetry.sdk.metrics.export.MetricExporter exporter =
         MetricExporterFactory.getInstance()
-            .create(
-                new PushMetricExporterModel().withConsole(new ConsoleExporterModel()),
-                spiHelper,
-                closeables);
+            .create(new PushMetricExporterModel().withConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -374,8 +368,7 @@ class MetricExporterFactoryTest {
             .create(
                 new PushMetricExporterModel()
                     .withOtlpFileDevelopment(new ExperimentalOtlpFileMetricExporterModel()),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -397,8 +390,7 @@ class MetricExporterFactoryTest {
                         new PushMetricExporterModel()
                             .withAdditionalProperty(
                                 "unknown_key", ImmutableMap.of("key1", "value1")),
-                        spiHelper,
-                        new ArrayList<>()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.sdk.metrics.export.MetricExporter with name \"unknown_key\".");
@@ -411,8 +403,7 @@ class MetricExporterFactoryTest {
             .create(
                 new PushMetricExporterModel()
                     .withAdditionalProperty("test", ImmutableMap.of("key1", "value1")),
-                spiHelper,
-                new ArrayList<>());
+                context);
     assertThat(metricExporter)
         .isInstanceOf(MetricExporterComponentProvider.TestMetricExporter.class);
     assertThat(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -70,8 +70,9 @@ class OpenTelemetryConfigurationFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(OpenTelemetryConfigurationFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(
+          SpiHelper.create(OpenTelemetryConfigurationFactoryTest.class.getClassLoader()));
 
   @Test
   void create_InvalidFileFormat() {
@@ -83,9 +84,7 @@ class OpenTelemetryConfigurationFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     for (OpenTelemetryConfigurationModel testCase : testCases) {
       assertThatThrownBy(
-              () ->
-                  OpenTelemetryConfigurationFactory.getInstance()
-                      .create(testCase, spiHelper, closeables))
+              () -> OpenTelemetryConfigurationFactory.getInstance().create(testCase, context))
           .isInstanceOf(DeclarativeConfigException.class)
           .hasMessage("Unsupported file format. Supported formats include: 0.4");
       cleanup.addCloseables(closeables);
@@ -100,8 +99,7 @@ class OpenTelemetryConfigurationFactoryTest {
 
     OpenTelemetrySdk sdk =
         OpenTelemetryConfigurationFactory.getInstance()
-            .create(
-                new OpenTelemetryConfigurationModel().withFileFormat("0.4"), spiHelper, closeables);
+            .create(new OpenTelemetryConfigurationModel().withFileFormat("0.4"), context);
     cleanup.addCloseable(sdk);
     cleanup.addCloseables(closeables);
 
@@ -132,8 +130,7 @@ class OpenTelemetryConfigurationFactoryTest {
                                                     new LogRecordExporterModel()
                                                         .withOtlpHttp(
                                                             new OtlpHttpExporterModel())))))),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(sdk);
     cleanup.addCloseables(closeables);
 
@@ -294,8 +291,7 @@ class OpenTelemetryConfigurationFactoryTest {
                                             new ViewStreamModel()
                                                 .withName("stream-name")
                                                 .withAttributeKeys(null))))),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(sdk);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/PropagatorFactoryTest.java
@@ -37,14 +37,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PropagatorFactoryTest {
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(PropagatorFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(SpiHelper.create(PropagatorFactoryTest.class.getClassLoader()));
 
   @ParameterizedTest
   @MethodSource("createArguments")
   void create(PropagatorModel model, ContextPropagators expectedPropagators) {
-    ContextPropagators propagators =
-        PropagatorFactory.getInstance().create(model, spiHelper, Collections.emptyList());
+    ContextPropagators propagators = PropagatorFactory.getInstance().create(model, context);
 
     assertThat(propagators.toString()).isEqualTo(expectedPropagators.toString());
   }
@@ -140,10 +139,7 @@ class PropagatorFactoryTest {
     assertThatThrownBy(
             () ->
                 PropagatorFactory.getInstance()
-                    .create(
-                        new PropagatorModel().withCompositeList("foo"),
-                        spiHelper,
-                        Collections.emptyList()))
+                    .create(new PropagatorModel().withCompositeList("foo"), context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.context.propagation.TextMapPropagator with name \"foo\".");

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ResourceFactoryTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.spy;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
@@ -29,11 +28,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceFactoryTest {
 
-  private SpiHelper spiHelper = SpiHelper.create(ResourceFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(SpiHelper.create(ResourceFactoryTest.class.getClassLoader()));
 
   @Test
   void create() {
-    spiHelper = spy(spiHelper);
     assertThat(
             ResourceFactory.getInstance()
                 .create(
@@ -47,8 +46,7 @@ class ResourceFactoryTest {
                                 new AttributeNameValueModel()
                                     .withName("shape")
                                     .withValue("circle"))),
-                    spiHelper,
-                    Collections.emptyList()))
+                    context))
         .isEqualTo(
             Resource.getDefault().toBuilder()
                 .put("shape", "circle")
@@ -75,8 +73,7 @@ class ResourceFactoryTest {
                                 .withAdditionalProperty("shape_color", null)))
                     .withAttributes(
                         new IncludeExcludeModel().withIncluded(included).withExcluded(excluded)));
-    Resource resource =
-        ResourceFactory.getInstance().create(resourceModel, spiHelper, Collections.emptyList());
+    Resource resource = ResourceFactory.getInstance().create(resourceModel, context);
     assertThat(resource).isEqualTo(expectedResource);
   }
 
@@ -148,8 +145,7 @@ class ResourceFactoryTest {
   @ParameterizedTest
   @MethodSource("createInvalidDetectorsArgs")
   void createWithDetectors_Invalid(ResourceModel model, String expectedMessage) {
-    assertThatThrownBy(
-            () -> ResourceFactory.getInstance().create(model, spiHelper, Collections.emptyList()))
+    assertThatThrownBy(() -> ResourceFactory.getInstance().create(model, context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(expectedMessage);
   }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
@@ -40,7 +40,8 @@ class SamplerFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper = SpiHelper.create(SamplerFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(SpiHelper.create(SamplerFactoryTest.class.getClassLoader()));
 
   @ParameterizedTest
   @MethodSource("createArguments")
@@ -53,7 +54,7 @@ class SamplerFactoryTest {
 
     List<Closeable> closeables = new ArrayList<>();
     io.opentelemetry.sdk.trace.samplers.Sampler sampler =
-        SamplerFactory.getInstance().create(model, spiHelper, closeables);
+        SamplerFactory.getInstance().create(model, context);
     cleanup.addCloseables(closeables);
 
     assertThat(sampler.toString()).isEqualTo(expectedSampler.toString());
@@ -139,8 +140,7 @@ class SamplerFactoryTest {
                         new SamplerModel()
                             .withAdditionalProperty(
                                 "unknown_key", ImmutableMap.of("key1", "value1")),
-                        spiHelper,
-                        new ArrayList<>()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.sdk.trace.samplers.Sampler with name \"unknown_key\".");
@@ -154,8 +154,7 @@ class SamplerFactoryTest {
             .create(
                 new SamplerModel()
                     .withAdditionalProperty("test", ImmutableMap.of("key1", "value1")),
-                spiHelper,
-                new ArrayList<>());
+                context);
     assertThat(sampler).isInstanceOf(SamplerComponentProvider.TestSampler.class);
     assertThat(((SamplerComponentProvider.TestSampler) sampler).config.getString("key1"))
         .isEqualTo("value1");

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanExporterFactoryTest.java
@@ -68,6 +68,7 @@ class SpanExporterFactoryTest {
 
   private final SpiHelper spiHelper =
       spy(SpiHelper.create(SpanExporterFactoryTest.class.getClassLoader()));
+  private final DeclarativeConfigContext context = new DeclarativeConfigContext(spiHelper);
   private List<ComponentProvider<?>> loadedComponentProviders = Collections.emptyList();
 
   @BeforeEach
@@ -102,10 +103,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter exporter =
         SpanExporterFactory.getInstance()
-            .create(
-                new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()),
-                spiHelper,
-                closeables);
+            .create(new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -170,8 +168,7 @@ class SpanExporterFactoryTest {
                             .withCertificateFile(certificatePath)
                             .withClientKeyFile(clientKeyPath)
                             .withClientCertificateFile(clientCertificatePath)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -211,10 +208,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter exporter =
         SpanExporterFactory.getInstance()
-            .create(
-                new SpanExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()),
-                spiHelper,
-                closeables);
+            .create(new SpanExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -278,8 +272,7 @@ class SpanExporterFactoryTest {
                             .withCertificateFile(certificatePath)
                             .withClientKeyFile(clientKeyPath)
                             .withClientCertificateFile(clientCertificatePath)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -319,10 +312,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter exporter =
         SpanExporterFactory.getInstance()
-            .create(
-                new SpanExporterModel().withConsole(new ConsoleExporterModel()),
-                spiHelper,
-                closeables);
+            .create(new SpanExporterModel().withConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -338,10 +328,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter exporter =
         SpanExporterFactory.getInstance()
-            .create(
-                new SpanExporterModel().withZipkin(new ZipkinSpanExporterModel()),
-                spiHelper,
-                closeables);
+            .create(new SpanExporterModel().withZipkin(new ZipkinSpanExporterModel()), context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -374,8 +361,7 @@ class SpanExporterFactoryTest {
                         new ZipkinSpanExporterModel()
                             .withEndpoint("http://zipkin:9411/v1/v2/spans")
                             .withTimeout(15_000)),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -401,8 +387,7 @@ class SpanExporterFactoryTest {
             .create(
                 new SpanExporterModel()
                     .withOtlpFileDevelopment(new ExperimentalOtlpFileExporterModel()),
-                spiHelper,
-                closeables);
+                context);
     cleanup.addCloseable(exporter);
     cleanup.addCloseables(closeables);
 
@@ -426,8 +411,7 @@ class SpanExporterFactoryTest {
                         new SpanExporterModel()
                             .withAdditionalProperty(
                                 "unknown_key", ImmutableMap.of("key1", "value1")),
-                        spiHelper,
-                        new ArrayList<>()))
+                        context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.sdk.trace.export.SpanExporter with name \"unknown_key\".");
@@ -441,8 +425,7 @@ class SpanExporterFactoryTest {
             .create(
                 new SpanExporterModel()
                     .withAdditionalProperty("test", ImmutableMap.of("key1", "value1")),
-                spiHelper,
-                new ArrayList<>());
+                context);
     assertThat(spanExporter).isInstanceOf(SpanExporterComponentProvider.TestSpanExporter.class);
     assertThat(
             ((SpanExporterComponentProvider.TestSpanExporter) spanExporter)

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SpanLimitsFactoryTest.java
@@ -8,10 +8,9 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AttributeLimitsModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanLimitsModel;
-import java.util.Collections;
+import io.opentelemetry.sdk.trace.SpanLimits;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -21,33 +20,24 @@ class SpanLimitsFactoryTest {
 
   @ParameterizedTest
   @MethodSource("createArguments")
-  void create(
-      SpanLimitsAndAttributeLimits model,
-      io.opentelemetry.sdk.trace.SpanLimits expectedSpanLimits) {
-    assertThat(
-            SpanLimitsFactory.getInstance()
-                .create(model, mock(SpiHelper.class), Collections.emptyList()))
+  void create(SpanLimitsAndAttributeLimits model, SpanLimits expectedSpanLimits) {
+    assertThat(SpanLimitsFactory.getInstance().create(model, mock(DeclarativeConfigContext.class)))
         .isEqualTo(expectedSpanLimits);
   }
 
   private static Stream<Arguments> createArguments() {
     return Stream.of(
-        Arguments.of(
-            SpanLimitsAndAttributeLimits.create(null, null),
-            io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
+        Arguments.of(SpanLimitsAndAttributeLimits.create(null, null), SpanLimits.getDefault()),
         Arguments.of(
             SpanLimitsAndAttributeLimits.create(new AttributeLimitsModel(), new SpanLimitsModel()),
-            io.opentelemetry.sdk.trace.SpanLimits.getDefault()),
+            SpanLimits.getDefault()),
         Arguments.of(
             SpanLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
                     .withAttributeCountLimit(1)
                     .withAttributeValueLengthLimit(2),
                 new SpanLimitsModel()),
-            io.opentelemetry.sdk.trace.SpanLimits.builder()
-                .setMaxNumberOfAttributes(1)
-                .setMaxAttributeValueLength(2)
-                .build()),
+            SpanLimits.builder().setMaxNumberOfAttributes(1).setMaxAttributeValueLength(2).build()),
         Arguments.of(
             SpanLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
@@ -60,7 +50,7 @@ class SpanLimitsFactoryTest {
                     .withLinkCountLimit(6)
                     .withEventAttributeCountLimit(7)
                     .withLinkAttributeCountLimit(8)),
-            io.opentelemetry.sdk.trace.SpanLimits.builder()
+            SpanLimits.builder()
                 .setMaxNumberOfAttributes(3)
                 .setMaxAttributeValueLength(4)
                 .setMaxNumberOfEvents(5)

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/TracerProviderFactoryTest.java
@@ -44,8 +44,9 @@ class TracerProviderFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();
 
-  private final SpiHelper spiHelper =
-      SpiHelper.create(TracerProviderFactoryTest.class.getClassLoader());
+  private final DeclarativeConfigContext context =
+      new DeclarativeConfigContext(
+          SpiHelper.create(TracerProviderFactoryTest.class.getClassLoader()));
 
   @ParameterizedTest
   @MethodSource("createArguments")
@@ -53,8 +54,7 @@ class TracerProviderFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     cleanup.addCloseable(expectedProvider);
 
-    SdkTracerProvider provider =
-        TracerProviderFactory.getInstance().create(model, spiHelper, closeables).build();
+    SdkTracerProvider provider = TracerProviderFactory.getInstance().create(model, context).build();
     cleanup.addCloseable(provider);
     cleanup.addCloseables(closeables);
 

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ViewFactoryTest.java
@@ -8,14 +8,12 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExplicitBucketHistogramAggregationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.IncludeExcludeModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ViewStreamModel;
 import io.opentelemetry.sdk.metrics.View;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
@@ -29,8 +27,7 @@ class ViewFactoryTest {
         ViewFactory.getInstance()
             .create(
                 new ViewStreamModel().withAttributeKeys(null),
-                mock(SpiHelper.class),
-                Collections.emptyList());
+                mock(DeclarativeConfigContext.class));
 
     assertThat(view.toString()).isEqualTo(expectedView.toString());
   }
@@ -60,8 +57,7 @@ class ViewFactoryTest {
                             .withExplicitBucketHistogram(
                                 new ExplicitBucketHistogramAggregationModel()
                                     .withBoundaries(Arrays.asList(1.0, 2.0)))),
-                mock(SpiHelper.class),
-                Collections.emptyList());
+                mock(DeclarativeConfigContext.class));
 
     assertThat(view.toString()).isEqualTo(expectedView.toString());
   }


### PR DESCRIPTION
Refactor declarative config to encapsulate config context and state into a new carrier object, DeclarativeConfigContext.

Benefits:
- Cleans up Factory interface by reducing number of arguments
- Makes it easier to test because SPI loading and closeables tracking is encapsulated in an instance which can be mocked and spied. Previously these were managed via static helper methods.
- Abstracts SPI loading to a single place, making #7292 easier
- ~200 fewer lines of code