### PR TITLE
Allow frameworks to add instrumentation scope conditions

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -9,4 +9,5 @@ Comparing source compatibility of opentelemetry-sdk-logs-1.50.0-SNAPSHOT.jar aga
 		+++  NEW ANNOTATION: javax.annotation.Nullable
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED METHOD: PUBLIC (<- PACKAGE_PROTECTED) io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder addLoggerConfiguratorCondition(java.util.function.Predicate<io.opentelemetry.sdk.common.InstrumentationScopeInfo><io.opentelemetry.sdk.common.InstrumentationScopeInfo>, io.opentelemetry.sdk.logs.internal.LoggerConfig)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder addLogRecordProcessorFirst(io.opentelemetry.sdk.logs.LogRecordProcessor)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -59,3 +59,6 @@ Comparing source compatibility of opentelemetry-sdk-metrics-1.50.0-SNAPSHOT.jar 
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.metrics.data.ValueAtQuantile  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.data.ValueAtQuantile create(double, double)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	***  MODIFIED METHOD: PUBLIC (<- PACKAGE_PROTECTED) io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder addMeterConfiguratorCondition(java.util.function.Predicate<io.opentelemetry.sdk.common.InstrumentationScopeInfo><io.opentelemetry.sdk.common.InstrumentationScopeInfo>, io.opentelemetry.sdk.metrics.internal.MeterConfig)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -2,3 +2,4 @@ Comparing source compatibility of opentelemetry-sdk-trace-1.50.0-SNAPSHOT.jar ag
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.SdkTracerProviderBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.trace.SdkTracerProviderBuilder addSpanProcessorFirst(io.opentelemetry.sdk.trace.SpanProcessor)
+	***  MODIFIED METHOD: PUBLIC (<- PACKAGE_PROTECTED) io.opentelemetry.sdk.trace.SdkTracerProviderBuilder addTracerConfiguratorCondition(java.util.function.Predicate<io.opentelemetry.sdk.common.InstrumentationScopeInfo><io.opentelemetry.sdk.common.InstrumentationScopeInfo>, io.opentelemetry.sdk.trace.internal.TracerConfig)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -161,7 +161,7 @@ public final class SdkLoggerProviderBuilder {
    * @see ScopeConfiguratorBuilder#nameEquals(String)
    * @see ScopeConfiguratorBuilder#nameMatchesGlob(String)
    */
-  SdkLoggerProviderBuilder addLoggerConfiguratorCondition(
+  public SdkLoggerProviderBuilder addLoggerConfiguratorCondition(
       Predicate<InstrumentationScopeInfo> scopeMatcher, LoggerConfig loggerConfig) {
     this.loggerConfiguratorBuilder.addCondition(scopeMatcher, loggerConfig);
     return this;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkMeterProviderBuilder.java
@@ -192,7 +192,7 @@ public final class SdkMeterProviderBuilder {
    * @see ScopeConfiguratorBuilder#nameEquals(String)
    * @see ScopeConfiguratorBuilder#nameMatchesGlob(String)
    */
-  SdkMeterProviderBuilder addMeterConfiguratorCondition(
+  public SdkMeterProviderBuilder addMeterConfiguratorCondition(
       Predicate<InstrumentationScopeInfo> scopeMatcher, MeterConfig meterConfig) {
     this.meterConfiguratorBuilder.addCondition(scopeMatcher, meterConfig);
     return this;

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java
@@ -207,7 +207,7 @@ public final class SdkTracerProviderBuilder {
    * @see ScopeConfiguratorBuilder#nameEquals(String)
    * @see ScopeConfiguratorBuilder#nameMatchesGlob(String)
    */
-  SdkTracerProviderBuilder addTracerConfiguratorCondition(
+  public SdkTracerProviderBuilder addTracerConfiguratorCondition(
       Predicate<InstrumentationScopeInfo> scopeMatcher, TracerConfig tracerConfig) {
     this.tracerConfiguratorBuilder.addCondition(scopeMatcher, tracerConfig);
     return this;


### PR DESCRIPTION
I know the feature is internal, but it's there for 1y now and should be mature enough to be used.