### PR TITLE
Fix Otlp*MetricExporterBuilderTests

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterMetrics.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/ExporterMetrics.java
@@ -87,9 +87,11 @@ public class ExporterMetrics {
   }
 
   private Meter meter() {
-    return meterProviderSupplier
-        .get()
-        .get("io.opentelemetry.exporters." + exporterName + "-" + transportName);
+    MeterProvider meterProvider = meterProviderSupplier.get();
+    if (meterProvider == null) {
+      meterProvider = MeterProvider.noop();
+    }
+    return meterProvider.get("io.opentelemetry.exporters." + exporterName + "-" + transportName);
   }
 
   private static boolean isNoop(LongCounter counter) {

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 
   testImplementation(project(":exporters:otlp:testing-internal"))
   testImplementation("com.linecorp.armeria:armeria-junit5")
+  implementation("com.linecorp.armeria:armeria-grpc")
   testImplementation("io.grpc:grpc-stub")
 
   jmhImplementation(project(":sdk:testing"))

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
   testImplementation(project(":exporters:otlp:testing-internal"))
   testImplementation("com.linecorp.armeria:armeria-junit5")
-  implementation("com.linecorp.armeria:armeria-grpc")
+  testImplementation("com.linecorp.armeria:armeria-grpc-protocol")
   testImplementation("io.grpc:grpc-stub")
 
   jmhImplementation(project(":sdk:testing"))


### PR DESCRIPTION
I ran the build locally for the first time after merging #7255 and noticed a variety of issues:

- Instances where GlobalOpenTelemetry is not reset
- Tests export real data via OTLP without setting up an OTLP receiver, causing error logs
- Test mocks don't account for all the code paths, causing NPEs

Fixing things up here. 