### PR TITLE
Update cralwer to crawl all io.opentelemetry.* groups

### DIFF
--- a/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/Artifact.java
+++ b/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/Artifact.java
@@ -6,12 +6,18 @@
 package io.opentelemetry.javadocs;
 
 public class Artifact {
+  private final String group;
   private final String name;
   private final String version;
 
-  public Artifact(String name, String version) {
+  public Artifact(String group, String name, String version) {
+    this.group = group;
     this.name = name;
     this.version = version;
+  }
+
+  public String getGroup() {
+    return group;
   }
 
   public String getName() {
@@ -20,5 +26,10 @@ public class Artifact {
 
   public String getVersion() {
     return version;
+  }
+
+  @Override
+  public String toString() {
+    return group + ":" + name + ":" + version;
   }
 }


### PR DESCRIPTION
Expanding on @jaydeluca's javadoc crawler work from #7300 to crawl all groups we publish artifacts to:

- io.opentelemetry
- io.opentelemetry.instrumentation
- io.opentelemetry.contrib
- io.opentelemetry.semconv
- io.opentelemetry.proto