### PR TITLE
Avoid HTTP 429 errors

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -19,4 +19,6 @@ jobs:
             --include-fragments
             --exclude "^https://github.com/open-telemetry/opentelemetry-java/(issues|pull)/\\d+$"
             --max-retries 6
+            --retry-wait-time 10
+            --max-concurrency 1
             .


### PR DESCRIPTION
Fixes #7327 

* Add retry-wait-time to potentially help these errors too (10s backoff instead of 1s).
* Add max-concurrency 1 to follow what opentelemetry-java-instrumentation does to avoid these issues.