### PR TITLE
Simplify the sampler to use on ratio bounds

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/Sampler.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/Sampler.java
@@ -86,6 +86,12 @@ public interface Sampler {
    * @throws IllegalArgumentException if {@code ratio} is out of range
    */
   static Sampler traceIdRatioBased(double ratio) {
+    if(ratio == 0.0d){
+      return alwaysOff();
+    }
+    if(ratio == 1.0d){
+      return alwaysOn();
+    }
     return TraceIdRatioBasedSampler.create(ratio);
   }
 

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/Sampler.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/Sampler.java
@@ -86,10 +86,10 @@ public interface Sampler {
    * @throws IllegalArgumentException if {@code ratio} is out of range
    */
   static Sampler traceIdRatioBased(double ratio) {
-    if(ratio == 0.0d){
+    if (ratio == 0.0d) {
       return alwaysOff();
     }
-    if(ratio == 1.0d){
+    if (ratio == 1.0d) {
       return alwaysOn();
     }
     return TraceIdRatioBasedSampler.create(ratio);


### PR DESCRIPTION
This is a pretty minor simplification -- but in the extreme cases where a ratio of 0.0 or 1.0 are chosen, the `TraceIdRatioBasedSampler` still has to do work on every decision in order to extract the numeric part of the trace. I think that we should be able to just use 0.0 to mean `alwaysOff()` and 1.0 to mean `alwaysOn()` and avoid this work.