### PR TITLE
Add test that shows how context keys are special

### DIFF
--- a/context/src/test/java/io/opentelemetry/context/ContextTest.java
+++ b/context/src/test/java/io/opentelemetry/context/ContextTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -106,6 +107,12 @@ class ContextTest {
       assertThat(Context.current().get(ANIMAL)).isEqualTo("cat");
     }
     assertThat(Context.current().get(ANIMAL)).isNull();
+  }
+
+  @Test
+  void keyEqualityIsInstanceCheck() {
+    Context context = Context.current().with(ContextKey.named("animal"), "cat");
+    assertNull(context.get(ContextKey.named("animal"))); // yup
   }
 
   @Test


### PR DESCRIPTION
I hate this, but I think it serves to clarify the current state of the context implementation. [See also](https://github.com/open-telemetry/opentelemetry-java/pull/2191#discussion_r535400360)...