### PR TITLE
Restore skipping japicmp diff for otelbot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,10 @@ jobs:
           RUN_JMH_BASED_TESTS: ${{ matrix.jmh-based-tests }}
 
       - name: Check for diff
-        # The jApiCmp diff compares current to latest, which isn't appropriate for release branches
+        # The jApiCmp diff compares current to latest, which isn't appropriate for release branches, or for bot-generated PRs
         # this fails on windows because of the bash-specific if/then/else syntax, but that's ok
         # because we only need to run this validation once (on any platform)
-        if: ${{ matrix.os != 'windows-latest' && !startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/') }}
+        if: ${{ matrix.os != 'windows-latest' && !startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/') && (github.actor != 'opentelemetrybot') }}
         run: |
           # need to "git add" in case any generated files did not already exist
           git add docs/apidiffs


### PR DESCRIPTION
Revert portion of #7273 which is causing this failure in the release workflow: https://github.com/open-telemetry/opentelemetry-java/pull/7338