### PR TITLE
Fix context storage provider property name (#7318)

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -127,7 +127,8 @@ final class LazyStorage {
       deferredStorageFailure.set(
           new IllegalStateException(
               "Found multiple ContextStorageProvider. Set the "
-                  + "io.opentelemetry.context.ContextStorageProvider property to the fully "
+                  + CONTEXT_STORAGE_PROVIDER_PROPERTY
+                  + " property to the fully "
                   + "qualified class name of the provider to use. Falling back to default "
                   + "ContextStorage. Found providers: "
                   + providers));
@@ -142,7 +143,8 @@ final class LazyStorage {
 
     deferredStorageFailure.set(
         new IllegalStateException(
-            "io.opentelemetry.context.ContextStorageProvider property set but no matching class "
+            CONTEXT_STORAGE_PROVIDER_PROPERTY
+                + " property set but no matching class "
                 + "could be found, requested: "
                 + providerClassName
                 + " but found providers: "


### PR DESCRIPTION
This change makes error messages use the existing `CONTEXT_STORAGE_PROVIDER_PROPERTY` constant to fix the name of the system property being slightly different.
This solves issue #7318