### PR TITLE
prom exporter: exclude shaded protobuf

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -34,7 +34,6 @@ val jmhVersion = "1.37"
 val mockitoVersion = "4.11.0"
 val slf4jVersion = "2.0.17"
 val opencensusVersion = "0.31.1"
-val prometheusClientVersion = "0.16.0"
 val prometheusServerVersion = "1.3.7"
 val armeriaVersion = "1.32.5"
 val junitVersion = "5.12.2"
@@ -65,12 +64,8 @@ val DEPENDENCIES = listOf(
   "org.mockito:mockito-junit-jupiter:${mockitoVersion}",
   "org.slf4j:slf4j-simple:${slf4jVersion}",
   "org.slf4j:jul-to-slf4j:${slf4jVersion}",
-  "io.prometheus:prometheus-metrics-shaded-protobuf:1.3.1",
   "io.prometheus:prometheus-metrics-exporter-httpserver:${prometheusServerVersion}",
-  "io.prometheus:prometheus-metrics-exposition-formats:${prometheusServerVersion}",
-  "io.prometheus:simpleclient:${prometheusClientVersion}",
-  "io.prometheus:simpleclient_common:${prometheusClientVersion}",
-  "io.prometheus:simpleclient_httpserver:${prometheusClientVersion}",
+  "io.prometheus:prometheus-metrics-exposition-formats-no-protobuf:${prometheusServerVersion}",
   "javax.annotation:javax.annotation-api:1.3.2",
   "com.github.stefanbirkner:system-rules:1.19.0",
   "com.google.api.grpc:proto-google-common-protos:2.57.0",

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -12,7 +12,10 @@ dependencies {
   compileOnly(project(":api:incubator"))
   implementation(project(":exporters:common"))
   implementation(project(":sdk-extensions:autoconfigure-spi"))
-  implementation("io.prometheus:prometheus-metrics-exporter-httpserver")
+  implementation("io.prometheus:prometheus-metrics-exporter-httpserver") {
+    exclude(group = "io.prometheus", module = "prometheus-metrics-exposition-formats")
+  }
+  implementation("io.prometheus:prometheus-metrics-exposition-formats-no-protobuf")
 
   compileOnly("com.google.auto.value:auto-value-annotations")
 
@@ -20,8 +23,6 @@ dependencies {
 
   testImplementation(project(":sdk:testing"))
   testImplementation("io.opentelemetry.proto:opentelemetry-proto")
-  testImplementation("io.prometheus:prometheus-metrics-shaded-protobuf")
-  testImplementation("io.prometheus:prometheus-metrics-exposition-formats")
   testImplementation("com.sun.net.httpserver:http")
   testImplementation("com.google.guava:guava")
   testImplementation("com.linecorp.armeria:armeria")


### PR DESCRIPTION
See https://prometheus.github.io/client_java/exporters/formats/#exclude-the-shaded-protobuf-classes

runtime classpath

```
+--- io.prometheus:prometheus-metrics-exporter-httpserver -> 1.3.7
|    \--- io.prometheus:prometheus-metrics-exporter-common:1.3.7
|         +--- io.prometheus:prometheus-metrics-model:1.3.7
|         \--- io.prometheus:prometheus-metrics-exposition-textformats:1.3.7
|              +--- io.prometheus:prometheus-metrics-model:1.3.7
|              \--- io.prometheus:prometheus-metrics-config:1.3.7
\--- io.prometheus:prometheus-metrics-exposition-formats-no-protobuf -> 1.3.7
     +--- io.prometheus:prometheus-metrics-exposition-textformats:1.3.7 (*)
     \--- com.google.protobuf:protobuf-java:4.30.2 -> 4.31.0
```