### PR TITLE
Handle instrumentation node changes in yaml config file format 0.4

### DIFF
--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtilTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtilTest.java
@@ -24,7 +24,7 @@ class InstrumentationConfigUtilTest {
    * href="https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/kitchen-sink.yaml">kitchen-sink.yaml</a>.
    */
   private static final String kitchenSinkInstrumentationConfig =
-      "instrumentation:\n"
+      "instrumentation/development:\n"
           + "  general:\n"
           + "    peer:\n"
           + "      service_mapping:\n"
@@ -54,11 +54,11 @@ class InstrumentationConfigUtilTest {
   private static final ConfigProvider kitchenSinkConfigProvider =
       toConfigProvider(kitchenSinkInstrumentationConfig);
   private static final ConfigProvider emptyInstrumentationConfigProvider =
-      toConfigProvider("instrumentation:\n");
+      toConfigProvider("instrumentation/development:\n");
   private static final ConfigProvider emptyGeneralConfigProvider =
-      toConfigProvider("instrumentation:\n  general:\n");
+      toConfigProvider("instrumentation/development:\n  general:\n");
   private static final ConfigProvider emptyHttpConfigProvider =
-      toConfigProvider("instrumentation:\n  general:\n    http:\n");
+      toConfigProvider("instrumentation/development:\n  general:\n    http:\n");
 
   private static ConfigProvider toConfigProvider(String configYaml) {
     OpenTelemetryConfigurationModel configuration =

--- a/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -72,7 +72,7 @@ class DeclarativeConfigurationTest {
             + "    - simple:\n"
             + "        exporter:\n"
             + "          console: {}\n"
-            + "instrumentation:\n"
+            + "instrumentation/development:\n"
             + "  general:\n"
             + "    http:\n"
             + "      client:\n"

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SdkConfigProvider.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SdkConfigProvider.java
@@ -18,7 +18,7 @@ public final class SdkConfigProvider implements ConfigProvider {
   private SdkConfigProvider(OpenTelemetryConfigurationModel model) {
     DeclarativeConfigProperties configProperties =
         DeclarativeConfiguration.toConfigProperties(model);
-    this.instrumentationConfig = configProperties.getStructured("instrumentation");
+    this.instrumentationConfig = configProperties.getStructured("instrumentation/development");
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-configuration/pull/179
`SdkConfigProvider` class update is necessary to handle breaking change for `instrumentation` yaml node. This change was introduced in declarative config file format version 0.4