### PR TITLE
Removed `@Nullable` annotation to maintain binary compatibility with `1.49.0` for Kotlin users

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/ArrayBackedAttributesBuilder.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
 
 class ArrayBackedAttributesBuilder implements AttributesBuilder {
   private final List<Object> data;
@@ -38,7 +37,7 @@ class ArrayBackedAttributesBuilder implements AttributesBuilder {
   }
 
   @Override
-  public <T> AttributesBuilder put(AttributeKey<T> key, @Nullable T value) {
+  public <T> AttributesBuilder put(AttributeKey<T> key, T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
@@ -35,11 +35,15 @@ public interface AttributesBuilder {
   // version.
   <T> AttributesBuilder put(AttributeKey<Long> key, int value);
 
-  /** Puts a {@link AttributeKey} with associated value into this. */
+  /**
+   * Puts an {@link AttributeKey} with an associated value into this if the value is non-null.
+   * Providing a null value does not remove or unset previously set values.
+   */
   <T> AttributesBuilder put(AttributeKey<T> key, T value);
 
   /**
-   * Puts a String attribute into this.
+   * Puts a String attribute into this if the value is non-null. Providing a null value does not
+   * remove or unset previously set values.
    *
    * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
    * your keys, if possible.

--- a/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
 
 /** A builder of {@link Attributes} supporting an arbitrary number of key-value pairs. */
 public interface AttributesBuilder {
@@ -36,22 +35,18 @@ public interface AttributesBuilder {
   // version.
   <T> AttributesBuilder put(AttributeKey<Long> key, int value);
 
-  /**
-   * Puts an {@link AttributeKey} with an associated value into this if the value is non-null.
-   * Providing a null value does not remove or unset previously set values.
-   */
-  <T> AttributesBuilder put(AttributeKey<T> key, @Nullable T value);
+  /** Puts a {@link AttributeKey} with associated value into this. */
+  <T> AttributesBuilder put(AttributeKey<T> key, T value);
 
   /**
-   * Puts a String attribute into this if the value is non-null. Providing a null value does not
-   * remove or unset previously set values.
+   * Puts a String attribute into this.
    *
    * <p>Note: It is strongly recommended to use {@link #put(AttributeKey, Object)}, and pre-allocate
    * your keys, if possible.
    *
    * @return this Builder
    */
-  default AttributesBuilder put(String key, @Nullable String value) {
+  default AttributesBuilder put(String key, String value) {
     return put(stringKey(key), value);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/logs/DefaultLogger.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/DefaultLogger.java
@@ -10,7 +10,6 @@ import io.opentelemetry.api.common.Value;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 class DefaultLogger implements Logger {
 
@@ -78,7 +77,7 @@ class DefaultLogger implements Logger {
     }
 
     @Override
-    public <T> LogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
+    public <T> LogRecordBuilder setAttribute(AttributeKey<T> key, T value) {
       return this;
     }
 

--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -107,6 +107,8 @@ public interface LogRecordBuilder {
    * Sets an attribute on the {@code LogRecord}. If the {@code LogRecord} previously contained a
    * mapping for the key, the old value is replaced by the specified value.
    *
+   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
+   *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
@@ -116,6 +118,8 @@ public interface LogRecordBuilder {
   /**
    * Sets a String attribute on the {@code LogRecord}. If the {@code LogRecord} previously contained
    * a mapping for the key, the old value is replaced by the specified value.
+   *
+   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
    *
    * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
    * pre-allocate your keys, if possible.

--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.api.common.Value;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Used to construct and emit log records from a {@link Logger}.
@@ -108,19 +107,15 @@ public interface LogRecordBuilder {
    * Sets an attribute on the {@code LogRecord}. If the {@code LogRecord} previously contained a
    * mapping for the key, the old value is replaced by the specified value.
    *
-   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
-   *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
    */
-  <T> LogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value);
+  <T> LogRecordBuilder setAttribute(AttributeKey<T> key, T value);
 
   /**
    * Sets a String attribute on the {@code LogRecord}. If the {@code LogRecord} previously contained
    * a mapping for the key, the old value is replaced by the specified value.
-   *
-   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
    *
    * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
    * pre-allocate your keys, if possible.
@@ -130,7 +125,7 @@ public interface LogRecordBuilder {
    * @return this.
    * @since 1.48.0
    */
-  default LogRecordBuilder setAttribute(String key, @Nullable String value) {
+  default LogRecordBuilder setAttribute(String key, String value) {
     return setAttribute(stringKey(key), value);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/PropagatedSpan.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/PropagatedSpan.java
@@ -8,7 +8,6 @@ package io.opentelemetry.api.trace;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -43,7 +42,7 @@ final class PropagatedSpan implements Span {
   }
 
   @Override
-  public Span setAttribute(String key, @Nullable String value) {
+  public Span setAttribute(String key, String value) {
     return this;
   }
 
@@ -63,7 +62,7 @@ final class PropagatedSpan implements Span {
   }
 
   @Override
-  public <T> Span setAttribute(AttributeKey<T> key, @Nullable T value) {
+  public <T> Span setAttribute(AttributeKey<T> key, T value) {
     return this;
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -88,9 +88,7 @@ public interface Span extends ImplicitContextKeyed {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
-   * <p>Empty String "" and null are valid attribute {@code value}s, but not valid keys.
-   *
-   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
+   * <p>Empty String "" and null are valid attribute {@code value}, but not valid keys.
    *
    * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
    * pre-allocate your keys, if possible.
@@ -99,7 +97,7 @@ public interface Span extends ImplicitContextKeyed {
    * @param value the value for this attribute.
    * @return this.
    */
-  default Span setAttribute(String key, @Nullable String value) {
+  default Span setAttribute(String key, String value) {
     return setAttribute(AttributeKey.stringKey(key), value);
   }
 
@@ -152,13 +150,13 @@ public interface Span extends ImplicitContextKeyed {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
-   * <p>Note: Providing a null value is a no-op.
+   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.
    * @return this.
    */
-  <T> Span setAttribute(AttributeKey<T> key, @Nullable T value);
+  <T> Span setAttribute(AttributeKey<T> key, T value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for

--- a/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Span.java
@@ -88,7 +88,9 @@ public interface Span extends ImplicitContextKeyed {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
-   * <p>Empty String "" and null are valid attribute {@code value}, but not valid keys.
+   * <p>Empty String "" and null are valid attribute {@code value}s, but not valid keys.
+   *
+   * <p>Note: Providing a null value is a no-op and will not remove previously set values.
    *
    * <p>Note: It is strongly recommended to use {@link #setAttribute(AttributeKey, Object)}, and
    * pre-allocate your keys, if possible.
@@ -150,7 +152,7 @@ public interface Span extends ImplicitContextKeyed {
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
    *
-   * <p>Note: the behavior of null values is undefined, and hence strongly discouraged.
+   * <p>Note: Providing a null value is a no-op.
    *
    * @param key the key for this attribute.
    * @param value the value for this attribute.

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributesTest.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Attributes}s. */
@@ -566,7 +565,7 @@ class AttributesTest {
           }
 
           @Override
-          public <T> AttributesBuilder put(AttributeKey<T> key, @Nullable T value) {
+          public <T> AttributesBuilder put(AttributeKey<T> key, T value) {
             return null;
           }
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLogger.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedDefaultLogger.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 class ExtendedDefaultLogger implements ExtendedLogger {
 
@@ -52,7 +51,7 @@ class ExtendedDefaultLogger implements ExtendedLogger {
     }
 
     @Override
-    public <T> ExtendedLogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
+    public <T> ExtendedLogRecordBuilder setAttribute(AttributeKey<T> key, T value) {
       return this;
     }
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedLogRecordBuilder.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/logs/ExtendedLogRecordBuilder.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.context.Context;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /** Extended {@link LogRecordBuilder} with experimental APIs. */
 public interface ExtendedLogRecordBuilder extends LogRecordBuilder {
@@ -120,7 +119,7 @@ public interface ExtendedLogRecordBuilder extends LogRecordBuilder {
    * attribute APIs.
    */
   @Override
-  <T> ExtendedLogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value);
+  <T> ExtendedLogRecordBuilder setAttribute(AttributeKey<T> key, T value);
 
   /**
    * Set an attribute.

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/DelegatingSpan.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/DelegatingSpan.java
@@ -15,7 +15,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Delegates <i>all</i> {@link Span} methods to some underlying Span via {@link
@@ -53,12 +52,12 @@ interface DelegatingSpan extends Span {
   }
 
   @Override
-  default <T> Span setAttribute(AttributeKey<T> key, @Nullable T value) {
+  default <T> Span setAttribute(AttributeKey<T> key, T value) {
     return getDelegate().setAttribute(key, value);
   }
 
   @Override
-  default Span setAttribute(String key, @Nullable String value) {
+  default Span setAttribute(String key, String value) {
     return getDelegate().setAttribute(key, value);
   }
 

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryNoRecordEventsSpanImpl.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenTelemetryNoRecordEventsSpanImpl.java
@@ -37,7 +37,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 final class OpenTelemetryNoRecordEventsSpanImpl extends Span
     implements io.opentelemetry.api.trace.Span {
@@ -110,7 +110,7 @@ final class OpenTelemetryNoRecordEventsSpanImpl extends Span
   }
 
   @Override
-  public io.opentelemetry.api.trace.Span setAttribute(String key, @Nullable String value) {
+  public io.opentelemetry.api.trace.Span setAttribute(String key, @Nonnull String value) {
     return this;
   }
 
@@ -130,7 +130,7 @@ final class OpenTelemetryNoRecordEventsSpanImpl extends Span
   }
 
   @Override
-  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nullable T value) {
+  public <T> io.opentelemetry.api.trace.Span setAttribute(AttributeKey<T> key, @Nonnull T value) {
     return this;
   }
 

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogRecordBuilder.java
@@ -116,7 +116,7 @@ final class ExtendedSdkLogRecordBuilder extends SdkLogRecordBuilder
   }
 
   @Override
-  public <T> ExtendedSdkLogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
+  public <T> ExtendedSdkLogRecordBuilder setAttribute(AttributeKey<T> key, T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLogRecordBuilder.java
@@ -102,7 +102,7 @@ class SdkLogRecordBuilder implements LogRecordBuilder {
   }
 
   @Override
-  public <T> SdkLogRecordBuilder setAttribute(AttributeKey<T> key, @Nullable T value) {
+  public <T> SdkLogRecordBuilder setAttribute(AttributeKey<T> key, T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java
@@ -314,7 +314,7 @@ final class SdkSpan implements ReadWriteSpan {
   }
 
   @Override
-  public <T> ReadWriteSpan setAttribute(AttributeKey<T> key, @Nullable T value) {
+  public <T> ReadWriteSpan setAttribute(AttributeKey<T> key, T value) {
     if (key == null || key.getKey().isEmpty() || value == null) {
       return this;
     }


### PR DESCRIPTION
This reverts PR #7271, thereby addressing #7358, which broke binary compatibility in for Kotlin users in release `1.50.0`

