### PR TITLE
sdk-extensions: remove 'Visible for test' comment

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/LogRecordExporterConfiguration.java
@@ -35,7 +35,6 @@ final class LogRecordExporterConfiguration {
     EXPORTER_ARTIFACT_ID_BY_NAME.put("otlp", "opentelemetry-exporter-otlp");
   }
 
-  // Visible for test
   static Map<String, LogRecordExporter> configureLogRecordExporters(
       ConfigProperties config,
       SpiHelper spiHelper,


### PR DESCRIPTION
The function under the comment is invoked from other public classes, and should be indicated as a public function.