### PR TITLE
Cleanup test resources to quiet logs

### DIFF
--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporter.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/TelemetryExporter.java
@@ -15,8 +15,9 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
-public interface TelemetryExporter<T> {
+public interface TelemetryExporter<T> extends AutoCloseable {
 
   /** Wraps a SpanExporter. */
   static TelemetryExporter<SpanData> wrap(SpanExporter exporter) {
@@ -103,4 +104,9 @@ public interface TelemetryExporter<T> {
   CompletableResultCode export(Collection<T> items);
 
   CompletableResultCode shutdown();
+
+  @Override
+  default void close() {
+    shutdown().join(10, TimeUnit.SECONDS);
+  }
 }


### PR DESCRIPTION
Recent changes introduced tests and forgot to shut them down after, which causes really noisy build logs. 

Fixing that up, and making it easier to do the right thing by having the TelemetryExporter test interface extend AutoCloseable. 