### PR TITLE
feat(metrics): add `OnDemandMetricReader` that only exports when calling forceFlush

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/OnDemandMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/OnDemandMetricReader.java
@@ -1,0 +1,64 @@
+package io.opentelemetry.sdk.metrics.export;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Collection;
+
+/**
+ * A {@link MetricReader} implementation that only exports metrics when {@link #forceFlush()} is called.
+ */
+public final class OnDemandMetricReader implements MetricReader {
+  private final MetricExporter exporter;
+  private volatile CollectionRegistration collectionRegistration = CollectionRegistration.noop();
+
+  public OnDemandMetricReader(MetricExporter exporter) {
+    this.exporter = exporter;
+  }
+
+  @Override
+  public void register(CollectionRegistration collectionRegistration) {
+    this.collectionRegistration = collectionRegistration;
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return exporter.getAggregationTemporality(instrumentType);
+  }
+
+  @Override
+  public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
+    return exporter.getDefaultAggregation(instrumentType);
+  }
+
+  @Override
+  public MemoryMode getMemoryMode() {
+    return exporter.getMemoryMode();
+  }
+
+  @Override
+  public CompletableResultCode forceFlush() {
+    try {
+      Collection<MetricData> metricData = collectionRegistration.collectAllMetrics();
+      if (metricData.isEmpty()) {
+        return CompletableResultCode.ofSuccess();
+      }
+      return exporter.export(metricData);
+    } catch (RuntimeException e) {
+      return CompletableResultCode.ofExceptionalFailure(e);
+    }
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return exporter.shutdown();
+  }
+
+  @Override
+  public String toString() {
+    return "OnDemandMetricReader{exporter=" + exporter + "}";
+  }
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/OnDemandMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/OnDemandMetricReaderTest.java
@@ -1,0 +1,82 @@
+package io.opentelemetry.sdk.metrics.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OnDemandMetricReaderTest {
+
+  private MetricExporter metricExporter;
+  private CollectionRegistration collectionRegistration;
+  private OnDemandMetricReader onDemandMetricReader;
+
+  @BeforeEach
+  void setup() {
+    metricExporter = mock(MetricExporter.class);
+    collectionRegistration = mock(CollectionRegistration.class);
+    onDemandMetricReader = new OnDemandMetricReader(metricExporter);
+    onDemandMetricReader.register(collectionRegistration);
+  }
+
+  @Test
+  void forceFlush_ExportsMetrics() {
+    List<MetricData> metrics = Collections.singletonList(mock(MetricData.class));
+    when(collectionRegistration.collectAllMetrics()).thenReturn(metrics);
+    when(metricExporter.export(metrics)).thenReturn(CompletableResultCode.ofSuccess());
+
+    CompletableResultCode result = onDemandMetricReader.forceFlush();
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(collectionRegistration).collectAllMetrics();
+    verify(metricExporter).export(metrics);
+  }
+
+  @Test
+  void forceFlush_NoMetrics() {
+    when(collectionRegistration.collectAllMetrics()).thenReturn(Collections.emptyList());
+
+    CompletableResultCode result = onDemandMetricReader.forceFlush();
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(collectionRegistration).collectAllMetrics();
+  }
+
+  @Test
+  void forceFlush_ExporterFails() {
+    List<MetricData> metrics = Collections.singletonList(mock(MetricData.class));
+    when(collectionRegistration.collectAllMetrics()).thenReturn(metrics);
+    when(metricExporter.export(metrics)).thenReturn(CompletableResultCode.ofFailure());
+
+    CompletableResultCode result = onDemandMetricReader.forceFlush();
+
+    assertThat(result.isSuccess()).isFalse();
+    verify(collectionRegistration).collectAllMetrics();
+    verify(metricExporter).export(metrics);
+  }
+
+  @Test
+  void shutdown_DelegatesToExporter() {
+    when(metricExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+    CompletableResultCode result = onDemandMetricReader.shutdown();
+
+    assertThat(result.isSuccess()).isTrue();
+    verify(metricExporter).shutdown();
+  }
+
+  @Test
+  void toString_ReturnsExpectedString() {
+    when(metricExporter.toString()).thenReturn("MockMetricExporter{}");
+
+    assertThat(onDemandMetricReader.toString())
+        .isEqualTo("OnDemandMetricReader{exporter=MockMetricExporter{}}");
+  }
+}


### PR DESCRIPTION
POC for #7391