### PR TITLE
OTLP exporter should tolerate instances of LogRecordData when incubator is present

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IncubatingUtil.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/IncubatingUtil.java
@@ -28,10 +28,27 @@ import java.util.function.BiConsumer;
  */
 public class IncubatingUtil {
 
+  private static final boolean INCUBATOR_AVAILABLE;
+
+  static {
+    boolean incubatorAvailable = false;
+    try {
+      Class.forName("io.opentelemetry.api.incubator.common.ExtendedAttributes");
+      incubatorAvailable = true;
+    } catch (ClassNotFoundException e) {
+      // Not available
+    }
+    INCUBATOR_AVAILABLE = incubatorAvailable;
+  }
+
   private static final byte[] EMPTY_BYTES = new byte[0];
   private static final KeyValueMarshaler[] EMPTY_REPEATED = new KeyValueMarshaler[0];
 
   private IncubatingUtil() {}
+
+  public static boolean isExtendedLogRecordData(LogRecordData logRecordData) {
+    return INCUBATOR_AVAILABLE && logRecordData instanceof ExtendedLogRecordData;
+  }
 
   @SuppressWarnings("AvoidObjectArrays")
   public static KeyValueMarshaler[] createdExtendedAttributesMarhsalers(

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/logs/LogMarshaler.java
@@ -24,19 +24,6 @@ import java.io.IOException;
 import javax.annotation.Nullable;
 
 final class LogMarshaler extends MarshalerWithSize {
-  private static final boolean INCUBATOR_AVAILABLE;
-
-  static {
-    boolean incubatorAvailable = false;
-    try {
-      Class.forName("io.opentelemetry.api.incubator.common.ExtendedAttributes");
-      incubatorAvailable = true;
-    } catch (ClassNotFoundException e) {
-      // Not available
-    }
-    INCUBATOR_AVAILABLE = incubatorAvailable;
-  }
-
   private static final String INVALID_TRACE_ID = TraceId.getInvalid();
   private static final String INVALID_SPAN_ID = SpanId.getInvalid();
 
@@ -54,12 +41,12 @@ final class LogMarshaler extends MarshalerWithSize {
 
   static LogMarshaler create(LogRecordData logRecordData) {
     KeyValueMarshaler[] attributeMarshalers =
-        INCUBATOR_AVAILABLE
+        IncubatingUtil.isExtendedLogRecordData(logRecordData)
             ? IncubatingUtil.createdExtendedAttributesMarhsalers(logRecordData)
             : KeyValueMarshaler.createForAttributes(logRecordData.getAttributes());
 
     int attributeSize =
-        INCUBATOR_AVAILABLE
+        IncubatingUtil.isExtendedLogRecordData(logRecordData)
             ? IncubatingUtil.extendedAttributesSize(logRecordData)
             : logRecordData.getAttributes().size();
 


### PR DESCRIPTION
Fixes #7363