### PR TITLE
Update argument name for set(long value)

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGauge.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleGauge.java
@@ -39,8 +39,8 @@ class SdkDoubleGauge extends AbstractInstrument implements DoubleGauge {
   }
 
   @Override
-  public void set(double increment) {
-    set(increment, Attributes.empty());
+  public void set(double value) {
+    set(value, Attributes.empty());
   }
 
   static class SdkDoubleGaugeBuilder implements DoubleGaugeBuilder {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGauge.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongGauge.java
@@ -38,8 +38,8 @@ class SdkLongGauge extends AbstractInstrument implements LongGauge {
   }
 
   @Override
-  public void set(long increment) {
-    set(increment, Attributes.empty());
+  public void set(long value) {
+    set(value, Attributes.empty());
   }
 
   static class SdkLongGaugeBuilder implements LongGaugeBuilder {


### PR DESCRIPTION
closes https://github.com/open-telemetry/opentelemetry-java/issues/7402

Rename argument from `increment` to `value` for set methods in `SdkLongGauge` and `SdkDoubleGauge`.
