### PR TITLE
Fix benchmark workflows

### DIFF
--- a/.github/workflows/benchmark-tags.yml
+++ b/.github/workflows/benchmark-tags.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write # for git push to benchmarks branch
     name: Benchmark SDK
-    runs-on: github-benchmark-runner
+    runs-on: equinix-bare-metal
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # for git push to benchmarks branch
     name: Benchmark SDK
-    runs-on: github-benchmark-runner
+    runs-on: equinix-bare-metal
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
TIL you can't target by runner name, only by labels, so I created a new label for this runner...

Follow-up to #7399

Related to https://github.com/open-telemetry/community/issues/2801