### PR TITLE
Disable equals verifier ranges

### DIFF
--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -10,10 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 
 class AttributeKeyTest {
 
   @Test
+  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equalsVerifier() {
     EqualsVerifier.forClass(InternalAttributeKeyImpl.class)
         .withIgnoredFields("keyUtf8")

--- a/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/common/AttributeKeyTest.java
@@ -10,12 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 class AttributeKeyTest {
 
   @Test
-  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
+  @EnabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equalsVerifier() {
     EqualsVerifier.forClass(InternalAttributeKeyImpl.class)
         .withIgnoredFields("keyUtf8")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -89,7 +89,7 @@ val DEPENDENCIES = listOf(
   "io.opentracing:opentracing-api:0.33.0",
   "io.opentracing:opentracing-noop:0.33.0",
   "junit:junit:4.13.2",
-  "nl.jqno.equalsverifier:equalsverifier:3.19.4",
+  "nl.jqno.equalsverifier:equalsverifier:4.0",
   "org.awaitility:awaitility:4.3.0",
   "org.bouncycastle:bcpkix-jdk15on:1.70",
   "org.codehaus.mojo:animal-sniffer-annotations:1.24",

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueTest.java
@@ -15,10 +15,12 @@ import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 
 class AttributeKeyValueTest {
 
   @Test
+  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equalsVerifier() {
     EqualsVerifier.forClass(AttributeKeyValue.class).verify();
   }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueTest.java
@@ -15,12 +15,12 @@ import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 class AttributeKeyValueTest {
 
   @Test
-  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
+  @EnabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equalsVerifier() {
     EqualsVerifier.forClass(AttributeKeyValue.class).verify();
   }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
@@ -53,28 +53,28 @@ class ParentBasedSamplerTest {
   void alwaysOn() {
     // Sampled parent.
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOn())
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOn())
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOn())
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOn())
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
@@ -82,87 +82,87 @@ class ParentBasedSamplerTest {
   void alwaysOff() {
     // Sampled parent.
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOff())
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOff())
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOff())
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOff())
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
   @Test
   void notSampled_remoteParent() {
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setRemoteParentNotSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                notSampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setRemoteParentNotSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    notSampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setRemoteParentNotSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                notSampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setRemoteParentNotSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    notSampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setRemoteParentNotSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                notSampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setRemoteParentNotSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    notSampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setRemoteParentNotSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                notSampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setRemoteParentNotSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    notSampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
@@ -170,233 +170,233 @@ class ParentBasedSamplerTest {
   void parentBasedSampler_NotSampled_NotRemote_Parent() {
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setLocalParentNotSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setLocalParentNotSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setLocalParentNotSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setLocalParentNotSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setLocalParentNotSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setLocalParentNotSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setLocalParentNotSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                notSampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setLocalParentNotSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    notSampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
   @Test
   void sampled_remoteParent() {
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setRemoteParentSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                sampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setRemoteParentSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    sampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setRemoteParentSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                sampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setRemoteParentSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    sampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setRemoteParentSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                sampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setRemoteParentSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    sampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setRemoteParentSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                sampledRemoteParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setRemoteParentSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    sampledRemoteParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
   @Test
   void parentBasedSampler_Sampled_NotRemote_Parent() {
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setLocalParentSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setLocalParentSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setLocalParentSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setLocalParentSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setLocalParentSampled(Sampler.alwaysOff())
-            .build()
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setLocalParentSampled(Sampler.alwaysOff())
+                .build()
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOn())
-            .setLocalParentSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                sampledParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOn())
+                .setLocalParentSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    sampledParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
   @Test
   void invalidParent() {
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOff())
-            .shouldSample(
-                invalidParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOff())
+                .shouldSample(
+                    invalidParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOff())
-            .shouldSample(
-                invalidParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOff())
+                .shouldSample(
+                    invalidParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBasedBuilder(Sampler.alwaysOff())
-            .setRemoteParentSampled(Sampler.alwaysOn())
-            .setRemoteParentNotSampled(Sampler.alwaysOn())
-            .setLocalParentSampled(Sampler.alwaysOn())
-            .setLocalParentNotSampled(Sampler.alwaysOn())
-            .build()
-            .shouldSample(
-                invalidParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBasedBuilder(Sampler.alwaysOff())
+                .setRemoteParentSampled(Sampler.alwaysOn())
+                .setRemoteParentNotSampled(Sampler.alwaysOn())
+                .setLocalParentSampled(Sampler.alwaysOn())
+                .setLocalParentNotSampled(Sampler.alwaysOn())
+                .build()
+                .shouldSample(
+                    invalidParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-        Sampler.parentBased(Sampler.alwaysOn())
-            .shouldSample(
-                invalidParentContext,
-                traceId,
-                SPAN_NAME,
-                SPAN_KIND,
-                Attributes.empty(),
-                Collections.emptyList())
-            .getDecision())
+            Sampler.parentBased(Sampler.alwaysOn())
+                .shouldSample(
+                    invalidParentContext,
+                    traceId,
+                    SPAN_NAME,
+                    SPAN_KIND,
+                    Attributes.empty(),
+                    Collections.emptyList())
+                .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.sdk.trace.IdGenerator;
 import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 
 class ParentBasedSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
@@ -53,28 +53,28 @@ class ParentBasedSamplerTest {
   void alwaysOn() {
     // Sampled parent.
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOn())
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOn())
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOn())
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOn())
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
@@ -82,87 +82,87 @@ class ParentBasedSamplerTest {
   void alwaysOff() {
     // Sampled parent.
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOff())
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOff())
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOff())
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOff())
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
   @Test
   void notSampled_remoteParent() {
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setRemoteParentNotSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    notSampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setRemoteParentNotSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                notSampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setRemoteParentNotSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    notSampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setRemoteParentNotSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                notSampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setRemoteParentNotSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    notSampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setRemoteParentNotSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                notSampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setRemoteParentNotSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    notSampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setRemoteParentNotSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                notSampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
@@ -170,233 +170,233 @@ class ParentBasedSamplerTest {
   void parentBasedSampler_NotSampled_NotRemote_Parent() {
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setLocalParentNotSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setLocalParentNotSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setLocalParentNotSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setLocalParentNotSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setLocalParentNotSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setLocalParentNotSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setLocalParentNotSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    notSampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setLocalParentNotSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
   @Test
   void sampled_remoteParent() {
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setRemoteParentSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    sampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setRemoteParentSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                sampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setRemoteParentSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    sampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setRemoteParentSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                sampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setRemoteParentSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    sampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setRemoteParentSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                sampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setRemoteParentSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    sampledRemoteParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setRemoteParentSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                sampledRemoteParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
   }
 
   @Test
   void parentBasedSampler_Sampled_NotRemote_Parent() {
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setLocalParentSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setLocalParentSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setLocalParentSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setLocalParentSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setLocalParentSampled(Sampler.alwaysOff())
-                .build()
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setLocalParentSampled(Sampler.alwaysOff())
+            .build()
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOn())
-                .setLocalParentSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    sampledParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOn())
+            .setLocalParentSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
   @Test
   void invalidParent() {
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOff())
-                .shouldSample(
-                    invalidParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOff())
+            .shouldSample(
+                invalidParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOff())
-                .shouldSample(
-                    invalidParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOff())
+            .shouldSample(
+                invalidParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBasedBuilder(Sampler.alwaysOff())
-                .setRemoteParentSampled(Sampler.alwaysOn())
-                .setRemoteParentNotSampled(Sampler.alwaysOn())
-                .setLocalParentSampled(Sampler.alwaysOn())
-                .setLocalParentNotSampled(Sampler.alwaysOn())
-                .build()
-                .shouldSample(
-                    invalidParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBasedBuilder(Sampler.alwaysOff())
+            .setRemoteParentSampled(Sampler.alwaysOn())
+            .setRemoteParentNotSampled(Sampler.alwaysOn())
+            .setLocalParentSampled(Sampler.alwaysOn())
+            .setLocalParentNotSampled(Sampler.alwaysOn())
+            .build()
+            .shouldSample(
+                invalidParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.DROP);
 
     assertThat(
-            Sampler.parentBased(Sampler.alwaysOn())
-                .shouldSample(
-                    invalidParentContext,
-                    traceId,
-                    SPAN_NAME,
-                    SPAN_KIND,
-                    Attributes.empty(),
-                    Collections.emptyList())
-                .getDecision())
+        Sampler.parentBased(Sampler.alwaysOn())
+            .shouldSample(
+                invalidParentContext,
+                traceId,
+                SPAN_NAME,
+                SPAN_KIND,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision())
         .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
@@ -410,7 +410,7 @@ class ParentBasedSamplerTest {
   }
 
   @Test
-  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
+  @EnabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equals() {
     EqualsVerifier.forClass(ParentBasedSampler.class)
         .withNonnullFields(

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.sdk.trace.IdGenerator;
 import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 
 class ParentBasedSamplerTest {
   private static final String SPAN_NAME = "MySpanName";
@@ -409,6 +410,7 @@ class ParentBasedSamplerTest {
   }
 
   @Test
+  @DisabledForJreRange(minVersion = 17, disabledReason = "EqualsVerifier requires Java 17+")
   void equals() {
     EqualsVerifier.forClass(ParentBasedSampler.class)
         .withNonnullFields(


### PR DESCRIPTION
Supersedes #7319.

We only have a few places where we use the `EqualsVerifier`, so can we just prevent those tests from running with older JDKs? Is this a reasonable approach/compromise?