### PR TITLE
Patch LazyStorage to pass its ClassLoader to ServiceLoader

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/LazyStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/LazyStorage.java
@@ -104,7 +104,8 @@ final class LazyStorage {
     }
 
     List<ContextStorageProvider> providers = new ArrayList<>();
-    for (ContextStorageProvider provider : ServiceLoader.load(ContextStorageProvider.class)) {
+    for (ContextStorageProvider provider :
+        ServiceLoader.load(ContextStorageProvider.class, LazyStorage.class.getClassLoader())) {
       if (provider
           .getClass()
           .getName()


### PR DESCRIPTION
`LazyStorage` passes its `ContextStorageProvider.class` to `ServiceLoader.load()`.  However, this is done from the `LazyStorage` static initializer, so the application has little to no control over the execution thread context for this code, and by default `ServiceLoader` uses the Thread context classloader, which may or may not have a difference instance of `ContextStorageProvider` and its desendants.

This patch passes the classloader from `LazyStorage` to `ServiceLoader` so that it is able to find true (rather than just symbolic) descendants of that same class.  Otherwise, if OpenTelemetry is loaded in a multi-classloader application, it can easily end up throwing a `ServiceConfigurationError` because `ServiceLoader` sees a different set of class instances than the set from which the passed-in `ContextStorageProvider.class` is from.