### PR TITLE
Update to declarative config 1.0-rc.1

### DIFF
--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -23,7 +23,7 @@ class DeclarativeConfigurationTest {
   @Test
   void configFile(@TempDir Path tempDir) throws IOException {
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -62,7 +62,7 @@ class DeclarativeConfigurationTest {
   @BeforeEach
   void setup() throws IOException {
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"
@@ -199,7 +199,7 @@ class DeclarativeConfigurationTest {
   @Test
   void configFile_Error(@TempDir Path tempDir) throws IOException {
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/incubator/build.gradle.kts
+++ b/sdk-extensions/incubator/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 // 7. deleteJs2pTmp - delete tmp directory
 // ... proceed with normal sourcesJar, compileJava, etc
 
-val configurationTag = "0.4.0"
+val configurationTag = "1.0.0-rc.1"
 val configurationRef = "refs/tags/v$configurationTag" // Replace with commit SHA to point to experiment with a specific commit
 val configurationRepoZip = "https://github.com/open-telemetry/opentelemetry-configuration/archive/$configurationRef.zip"
 val buildDirectory = layout.buildDirectory.asFile.get()

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -36,6 +36,8 @@ final class OpenTelemetryConfigurationFactory
       throw new DeclarativeConfigException(
           "Unsupported file format. Supported formats include 0.4, 1.0*");
     }
+    // TODO(jack-berg): log warning if version is not exact match, which may result in unexpected
+    // behavior for experimental properties.
 
     if (Objects.equals(Boolean.TRUE, model.getDisabled())) {
       return builder.build();

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactory.java
@@ -11,11 +11,12 @@ import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 final class OpenTelemetryConfigurationFactory
     implements Factory<OpenTelemetryConfigurationModel, OpenTelemetrySdk> {
 
-  private static final String CURRENT_SUPPORTED_FILE_FORMAT = "0.4";
+  private static final Pattern SUPPORTED_FILE_FORMATS = Pattern.compile("^(0.4)|(1.0(-rc.\\d*)?)$");
 
   private static final OpenTelemetryConfigurationFactory INSTANCE =
       new OpenTelemetryConfigurationFactory();
@@ -30,9 +31,10 @@ final class OpenTelemetryConfigurationFactory
   public OpenTelemetrySdk create(
       OpenTelemetryConfigurationModel model, DeclarativeConfigContext context) {
     OpenTelemetrySdkBuilder builder = OpenTelemetrySdk.builder();
-    if (!CURRENT_SUPPORTED_FILE_FORMAT.equals(model.getFileFormat())) {
+    String fileFormat = model.getFileFormat();
+    if (fileFormat == null || !SUPPORTED_FILE_FORMATS.matcher(fileFormat).matches()) {
       throw new DeclarativeConfigException(
-          "Unsupported file format. Supported formats include: " + CURRENT_SUPPORTED_FILE_FORMAT);
+          "Unsupported file format. Supported formats include 0.4, 1.0*");
     }
 
     if (Objects.equals(Boolean.TRUE, model.getDisabled())) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+
+public class ServiceResourceDetector implements ComponentProvider<Resource> {
+  @Override
+  public Class<Resource> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return "service";
+  }
+
+  @Override
+  public Resource create(DeclarativeConfigProperties config) {
+    ConfigProperties properties = DefaultConfigProperties.create(Collections.emptyMap());
+    String serviceName = properties.getString("otel.service.name");
+    if (serviceName != null) {
+      return Resource.builder().put("service.name", serviceName).build();
+    }
+    return Resource.empty();
+  }
+}

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
@@ -15,6 +16,14 @@ import java.util.Collections;
 import java.util.UUID;
 
 public class ServiceResourceDetector implements ComponentProvider<Resource> {
+
+  private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+  private static final AttributeKey<String> SERVICE_INSTANCE_ID =
+      AttributeKey.stringKey("service.instance.id");
+
+  // multiple calls to this resource provider should return the same value
+  private static final String RANDOM_SERVICE_INSTANCE_ID = UUID.randomUUID().toString();
+
   @Override
   public Class<Resource> getType() {
     return Resource.class;
@@ -32,10 +41,10 @@ public class ServiceResourceDetector implements ComponentProvider<Resource> {
     ConfigProperties properties = DefaultConfigProperties.create(Collections.emptyMap());
     String serviceName = properties.getString("otel.service.name");
     if (serviceName != null) {
-      builder.put("service.name", serviceName).build();
+      builder.put(SERVICE_NAME, serviceName).build();
     }
 
-    builder.put("service.instance.id", UUID.randomUUID().toString());
+    builder.put(SERVICE_INSTANCE_ID, RANDOM_SERVICE_INSTANCE_ID);
 
     return builder.build();
   }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetector.java
@@ -10,7 +10,9 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
 import java.util.Collections;
+import java.util.UUID;
 
 public class ServiceResourceDetector implements ComponentProvider<Resource> {
   @Override
@@ -25,11 +27,16 @@ public class ServiceResourceDetector implements ComponentProvider<Resource> {
 
   @Override
   public Resource create(DeclarativeConfigProperties config) {
+    ResourceBuilder builder = Resource.builder();
+
     ConfigProperties properties = DefaultConfigProperties.create(Collections.emptyMap());
     String serviceName = properties.getString("otel.service.name");
     if (serviceName != null) {
-      return Resource.builder().put("service.name", serviceName).build();
+      builder.put("service.name", serviceName).build();
     }
-    return Resource.empty();
+
+    builder.put("service.instance.id", UUID.randomUUID().toString());
+
+    return builder.build();
   }
 }

--- a/sdk-extensions/incubator/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
+++ b/sdk-extensions/incubator/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.sdk.extension.incubator.fileconfig.ServiceResourceDetector

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationCreateTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationCreateTest.java
@@ -106,7 +106,7 @@ class DeclarativeConfigurationCreateTest {
     // exporter with OTLP exporter, following by invalid batch exporter which references invalid
     // exporter "foo".
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -133,7 +133,7 @@ class DeclarativeConfigurationCreateTest {
   @Test
   void parseAndCreate_EmptyComponentProviderConfig() {
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - test:\n"
@@ -151,7 +151,7 @@ class DeclarativeConfigurationCreateTest {
   @Test
   void create_ModelCustomizer() {
     OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
-    model.withFileFormat("0.4");
+    model.withFileFormat("1.0-rc.1");
     model.withTracerProvider(
         new TracerProviderModel()
             .withProcessors(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationParseTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigurationParseTest.java
@@ -113,7 +113,7 @@ class DeclarativeConfigurationParseTest {
   void parse_KitchenSinkExampleFile() throws IOException {
     OpenTelemetryConfigurationModel expected = new OpenTelemetryConfigurationModel();
 
-    expected.withFileFormat("0.4");
+    expected.withFileFormat("1.0-rc.1");
     expected.withDisabled(false);
     expected.withLogLevel("info");
 
@@ -171,9 +171,9 @@ class DeclarativeConfigurationParseTest {
                             new ExperimentalResourceDetectorModel()
                                 .withAdditionalProperty("host", null),
                             new ExperimentalResourceDetectorModel()
-                                .withAdditionalProperty("os", null),
+                                .withAdditionalProperty("process", null),
                             new ExperimentalResourceDetectorModel()
-                                .withAdditionalProperty("process", null))))
+                                .withAdditionalProperty("service", null))))
             .withSchemaUrl("https://opentelemetry.io/schemas/1.16.0");
     expected.withResource(resource);
 
@@ -705,7 +705,7 @@ class DeclarativeConfigurationParseTest {
       OpenTelemetryConfigurationModel config = DeclarativeConfiguration.parse(configExampleFile);
 
       // General config
-      assertThat(config.getFileFormat()).isEqualTo("0.4");
+      assertThat(config.getFileFormat()).isEqualTo("1.0-rc.1");
       assertThat(config.getResource()).isEqualTo(resource);
       assertThat(config.getAttributeLimits()).isEqualTo(attributeLimits);
       assertThat(config.getPropagator()).isEqualTo(propagator);
@@ -770,7 +770,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void parse_nullValuesParsedToEmptyObjects() {
     String objectPlaceholderString =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -788,7 +788,7 @@ class DeclarativeConfigurationParseTest {
             new ByteArrayInputStream(objectPlaceholderString.getBytes(StandardCharsets.UTF_8)));
 
     String noOjbectPlaceholderString =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -986,7 +986,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void read_WithEnvironmentVariables() {
     String yaml =
-        "file_format: \"0.4\"\n"
+        "file_format: \"1.0-rc.1\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -1005,7 +1005,7 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .withFileFormat("0.4")
+                .withFileFormat("1.0-rc.1")
                 .withTracerProvider(
                     new TracerProviderModel()
                         .withProcessors(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -105,6 +105,8 @@ class OpenTelemetryConfigurationFactoryTest {
         Arguments.of("0.4a", false),
         Arguments.of("foo", false),
         Arguments.of("1.0-rc.a", false),
+        Arguments.of("1.0.0", false),
+        Arguments.of("1.0.3", false),
         // Valid file formats
         Arguments.of("0.4", true),
         Arguments.of("1.0-rc.1", true),

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOn;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -63,8 +64,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OpenTelemetryConfigurationFactoryTest {
 
@@ -74,21 +79,37 @@ class OpenTelemetryConfigurationFactoryTest {
       new DeclarativeConfigContext(
           SpiHelper.create(OpenTelemetryConfigurationFactoryTest.class.getClassLoader()));
 
-  @Test
-  void create_InvalidFileFormat() {
-    List<OpenTelemetryConfigurationModel> testCases =
-        Arrays.asList(
-            new OpenTelemetryConfigurationModel(),
-            new OpenTelemetryConfigurationModel().withFileFormat("1"));
+  @ParameterizedTest
+  @MethodSource("fileFormatArgs")
+  void create_FileFormat(String fileFormat, boolean isValid) {
+    OpenTelemetryConfigurationModel model =
+        new OpenTelemetryConfigurationModel().withFileFormat(fileFormat);
 
-    List<Closeable> closeables = new ArrayList<>();
-    for (OpenTelemetryConfigurationModel testCase : testCases) {
+    if (isValid) {
+      assertThatCode(() -> OpenTelemetryConfigurationFactory.getInstance().create(model, context))
+          .doesNotThrowAnyException();
+    } else {
       assertThatThrownBy(
-              () -> OpenTelemetryConfigurationFactory.getInstance().create(testCase, context))
+              () -> OpenTelemetryConfigurationFactory.getInstance().create(model, context))
           .isInstanceOf(DeclarativeConfigException.class)
-          .hasMessage("Unsupported file format. Supported formats include: 0.4");
-      cleanup.addCloseables(closeables);
+          .hasMessage("Unsupported file format. Supported formats include 0.4, 1.0*");
     }
+  }
+
+  private static Stream<Arguments> fileFormatArgs() {
+    return Stream.of(
+        // Invalid file formats
+        Arguments.of(null, false),
+        Arguments.of("0.3", false),
+        Arguments.of("a0.4", false),
+        Arguments.of("0.4a", false),
+        Arguments.of("foo", false),
+        Arguments.of("1.0-rc.a", false),
+        // Valid file formats
+        Arguments.of("0.4", true),
+        Arguments.of("1.0-rc.1", true),
+        Arguments.of("1.0-rc.2", true),
+        Arguments.of("1.0", true));
   }
 
   @Test
@@ -99,7 +120,7 @@ class OpenTelemetryConfigurationFactoryTest {
 
     OpenTelemetrySdk sdk =
         OpenTelemetryConfigurationFactory.getInstance()
-            .create(new OpenTelemetryConfigurationModel().withFileFormat("0.4"), context);
+            .create(new OpenTelemetryConfigurationModel().withFileFormat("1.0-rc.1"), context);
     cleanup.addCloseable(sdk);
     cleanup.addCloseables(closeables);
 
@@ -116,7 +137,7 @@ class OpenTelemetryConfigurationFactoryTest {
         OpenTelemetryConfigurationFactory.getInstance()
             .create(
                 new OpenTelemetryConfigurationModel()
-                    .withFileFormat("0.4")
+                    .withFileFormat("1.0-rc.1")
                     .withDisabled(true)
                     // Logger provider configuration should be ignored since SDK is disabled
                     .withLoggerProvider(
@@ -210,7 +231,7 @@ class OpenTelemetryConfigurationFactoryTest {
         OpenTelemetryConfigurationFactory.getInstance()
             .create(
                 new OpenTelemetryConfigurationModel()
-                    .withFileFormat("0.4")
+                    .withFileFormat("1.0-rc.1")
                     .withPropagator(
                         new PropagatorModel()
                             .withCompositeList("tracecontext,baggage,ottrace,b3multi,b3,jaeger"))

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetectorTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/ServiceResourceDetectorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.extension.incubator.fileconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+
+class ServiceResourceDetectorTest {
+
+  @Test
+  void getTypeAndName() {
+    ServiceResourceDetector detector = new ServiceResourceDetector();
+
+    assertThat(detector.getType()).isEqualTo(Resource.class);
+    assertThat(detector.getName()).isEqualTo("service");
+  }
+
+  @Test
+  @ClearSystemProperty(key = "otel.service.name")
+  void create_SystemPropertySet() {
+    System.setProperty("otel.service.name", "test");
+
+    assertThat(new ServiceResourceDetector().create(DeclarativeConfigProperties.empty()))
+        .satisfies(
+            resource -> {
+              Attributes attributes = resource.getAttributes();
+              assertThat(attributes.get(AttributeKey.stringKey("service.name"))).isEqualTo("test");
+              assertThatCode(
+                      () ->
+                          UUID.fromString(
+                              Objects.requireNonNull(
+                                  attributes.get(AttributeKey.stringKey("service.instance.id")))))
+                  .doesNotThrowAnyException();
+            });
+  }
+
+  @Test
+  void create_NoSystemProperty() {
+    assertThat(new ServiceResourceDetector().create(DeclarativeConfigProperties.empty()))
+        .satisfies(
+            resource -> {
+              Attributes attributes = resource.getAttributes();
+              assertThat(attributes.get(AttributeKey.stringKey("service.name"))).isNull();
+              assertThatCode(
+                      () ->
+                          UUID.fromString(
+                              Objects.requireNonNull(
+                                  attributes.get(AttributeKey.stringKey("service.instance.id")))))
+                  .doesNotThrowAnyException();
+            });
+  }
+}

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/YamlDeclarativeConfigPropertiesTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/YamlDeclarativeConfigPropertiesTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 class YamlDeclarativeConfigPropertiesTest {
 
   private static final String extendedSchema =
-      "file_format: \"0.4\"\n"
+      "file_format: \"1.0-rc.1\"\n"
           + "disabled: false\n"
           + "\n"
           + "resource:\n"
@@ -69,7 +69,7 @@ class YamlDeclarativeConfigPropertiesTest {
   @Test
   void configurationSchema() {
     // Validate can read declarative configuration schema properties
-    assertThat(structuredConfigProps.getString("file_format")).isEqualTo("0.4");
+    assertThat(structuredConfigProps.getString("file_format")).isEqualTo("1.0-rc.1");
     DeclarativeConfigProperties resourceProps = structuredConfigProps.getStructured("resource");
     assertThat(resourceProps).isNotNull();
     List<DeclarativeConfigProperties> resourceAttributesList =


### PR DESCRIPTION
Release notes here: https://github.com/open-telemetry/opentelemetry-configuration/releases/tag/v1.0.0-rc.1

Users of 0.4 _should not_ be impacted as this release consists of only a small set of backwards compatible changes. 