### PR TITLE
low allocation marshalers for json exporters.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of opentelemetry-exporter-logging-otlp-1.52.0-SNAPSHOT.jar against opentelemetry-exporter-logging-otlp-1.51.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.logs.export.LogRecordExporter create(boolean)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.metrics.export.MetricExporter create(io.opentelemetry.sdk.metrics.data.AggregationTemporality, boolean)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SpanExporter create(boolean)

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.logging.otlp;
 import io.opentelemetry.exporter.logging.otlp.internal.logs.OtlpStdoutLogRecordExporter;
 import io.opentelemetry.exporter.logging.otlp.internal.logs.OtlpStdoutLogRecordExporterBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.util.Collection;
@@ -30,6 +31,24 @@ public final class OtlpJsonLoggingLogRecordExporter implements LogRecordExporter
   public static LogRecordExporter create() {
     OtlpStdoutLogRecordExporter delegate =
         new OtlpStdoutLogRecordExporterBuilder(logger).setWrapperJsonObject(false).build();
+    return new OtlpJsonLoggingLogRecordExporter(delegate);
+  }
+
+  /**
+   * Returns a new {@link OtlpJsonLoggingLogRecordExporter}.
+   *
+   * @param wrapperJsonObject whether to wrap the JSON object in an outer JSON "resourceLogs"
+   *     object. When {@code true}, uses low allocation OTLP marshalers with {@link
+   *     MemoryMode#REUSABLE_DATA}. When {@code false}, uses {@link MemoryMode#IMMUTABLE_DATA}.
+   */
+  public static LogRecordExporter create(boolean wrapperJsonObject) {
+    MemoryMode memoryMode =
+        wrapperJsonObject ? MemoryMode.REUSABLE_DATA : MemoryMode.IMMUTABLE_DATA;
+    OtlpStdoutLogRecordExporter delegate =
+        new OtlpStdoutLogRecordExporterBuilder(logger)
+            .setWrapperJsonObject(wrapperJsonObject)
+            .setMemoryMode(memoryMode)
+            .build();
     return new OtlpJsonLoggingLogRecordExporter(delegate);
   }
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.logging.otlp;
 import io.opentelemetry.exporter.logging.otlp.internal.metrics.OtlpStdoutMetricExporter;
 import io.opentelemetry.exporter.logging.otlp.internal.metrics.OtlpStdoutMetricExporterBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -46,6 +47,27 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
     return new OtlpJsonLoggingMetricExporter(delegate, aggregationTemporality);
   }
 
+  /**
+   * Returns a new {@link OtlpJsonLoggingMetricExporter} with the given {@code
+   * aggregationTemporality}.
+   *
+   * @param aggregationTemporality the aggregation temporality to use
+   * @param wrapperJsonObject whether to wrap the JSON object in an outer JSON "resourceMetrics"
+   *     object. When {@code true}, uses low allocation OTLP marshalers with {@link
+   *     MemoryMode#REUSABLE_DATA}. When {@code false}, uses {@link MemoryMode#IMMUTABLE_DATA}.
+   */
+  public static MetricExporter create(
+      AggregationTemporality aggregationTemporality, boolean wrapperJsonObject) {
+    MemoryMode memoryMode =
+        wrapperJsonObject ? MemoryMode.REUSABLE_DATA : MemoryMode.IMMUTABLE_DATA;
+    OtlpStdoutMetricExporter delegate =
+        new OtlpStdoutMetricExporterBuilder(logger)
+            .setWrapperJsonObject(wrapperJsonObject)
+            .setMemoryMode(memoryMode)
+            .build();
+    return new OtlpJsonLoggingMetricExporter(delegate, aggregationTemporality);
+  }
+
   OtlpJsonLoggingMetricExporter(
       OtlpStdoutMetricExporter delegate, AggregationTemporality aggregationTemporality) {
     this.delegate = delegate;
@@ -53,8 +75,8 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
   }
 
   @Override
-  public CompletableResultCode export(Collection<MetricData> logs) {
-    return delegate.export(logs);
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    return delegate.export(metrics);
   }
 
   @Override

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -75,8 +75,8 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
   }
 
   @Override
-  public CompletableResultCode export(Collection<MetricData> metrics) {
-    return delegate.export(metrics);
+  public CompletableResultCode export(Collection<MetricData> logs) {
+    return delegate.export(logs);
   }
 
   @Override

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.exporter.logging.otlp;
 import io.opentelemetry.exporter.logging.otlp.internal.traces.OtlpStdoutSpanExporter;
 import io.opentelemetry.exporter.logging.otlp.internal.traces.OtlpStdoutSpanExporterBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
@@ -31,13 +32,31 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
     return new OtlpJsonLoggingSpanExporter(delegate);
   }
 
+  /**
+   * Returns a new {@link OtlpJsonLoggingSpanExporter}.
+   *
+   * @param wrapperJsonObject whether to wrap the JSON object in an outer JSON "resourceSpans"
+   *     object. When {@code true}, uses low allocation OTLP marshalers with {@link
+   *     MemoryMode#REUSABLE_DATA}. When {@code false}, uses {@link MemoryMode#IMMUTABLE_DATA}.
+   */
+  public static SpanExporter create(boolean wrapperJsonObject) {
+    MemoryMode memoryMode =
+        wrapperJsonObject ? MemoryMode.REUSABLE_DATA : MemoryMode.IMMUTABLE_DATA;
+    OtlpStdoutSpanExporter delegate =
+        new OtlpStdoutSpanExporterBuilder(logger)
+            .setWrapperJsonObject(wrapperJsonObject)
+            .setMemoryMode(memoryMode)
+            .build();
+    return new OtlpJsonLoggingSpanExporter(delegate);
+  }
+
   OtlpJsonLoggingSpanExporter(OtlpStdoutSpanExporter delegate) {
     this.delegate = delegate;
   }
 
   @Override
-  public CompletableResultCode export(Collection<SpanData> logs) {
-    return delegate.export(logs);
+  public CompletableResultCode export(Collection<SpanData> spans) {
+    return delegate.export(spans);
   }
 
   @Override

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -55,8 +55,8 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
   }
 
   @Override
-  public CompletableResultCode export(Collection<SpanData> spans) {
-    return delegate.export(spans);
+  public CompletableResultCode export(Collection<SpanData> logs) {
+    return delegate.export(logs);
   }
 
   @Override

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
@@ -46,6 +46,36 @@ class OtlpJsonLoggingLogRecordExporterTest {
   }
 
   @Test
+  void logWithWrapperJsonObjectFalse() throws Exception {
+    // Test that wrapperJsonObject=false produces the same output as the default create()
+    LogRecordExporter exporterWithoutWrapper = OtlpJsonLoggingLogRecordExporter.create(false);
+    testDataExporter.export(exporterWithoutWrapper);
+
+    assertThat(logs.getEvents())
+        .hasSize(1)
+        .allSatisfy(log -> assertThat(log.getLevel()).isEqualTo(Level.INFO));
+    String message = logs.getEvents().get(0).getMessage();
+    String expectedJson = testDataExporter.getExpectedJson(false);
+    JSONAssert.assertEquals("Got \n" + message, expectedJson, message, /* strict= */ false);
+    assertThat(message).doesNotContain("\n");
+  }
+
+  @Test
+  void logWithWrapperJsonObjectTrue() throws Exception {
+    // Test that wrapperJsonObject=true produces wrapper format (enables low allocation)
+    LogRecordExporter exporterWithWrapper = OtlpJsonLoggingLogRecordExporter.create(true);
+    testDataExporter.export(exporterWithWrapper);
+
+    assertThat(logs.getEvents())
+        .hasSize(1)
+        .allSatisfy(log -> assertThat(log.getLevel()).isEqualTo(Level.INFO));
+    String message = logs.getEvents().get(0).getMessage();
+    String expectedJson = testDataExporter.getExpectedJson(true);
+    JSONAssert.assertEquals("Got \n" + message, expectedJson, message, /* strict= */ false);
+    assertThat(message).doesNotContain("\n");
+  }
+
+  @Test
   void shutdown() {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
     assertThat(testDataExporter.export(exporter).join(10, TimeUnit.SECONDS).isSuccess()).isFalse();

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
@@ -49,7 +49,8 @@ class OtlpJsonLoggingMetricExporterTest {
 
   @Test
   void getAggregationTemporalityWithWrapperJsonObject() {
-    // Test that the new create method with wrapperJsonObject parameter maintains correct aggregation temporality
+    // Test that the new create method with wrapperJsonObject parameter maintains correct
+    // aggregation temporality
     assertThat(
             OtlpJsonLoggingMetricExporter.create(AggregationTemporality.CUMULATIVE, false)
                 .getAggregationTemporality(InstrumentType.COUNTER))
@@ -84,7 +85,8 @@ class OtlpJsonLoggingMetricExporterTest {
   @Test
   void logWithWrapperJsonObjectFalse() throws Exception {
     // Test that wrapperJsonObject=false produces the same output as the default create()
-    MetricExporter exporterWithoutWrapper = OtlpJsonLoggingMetricExporter.create(AggregationTemporality.CUMULATIVE, false);
+    MetricExporter exporterWithoutWrapper =
+        OtlpJsonLoggingMetricExporter.create(AggregationTemporality.CUMULATIVE, false);
     testDataExporter.export(exporterWithoutWrapper);
 
     assertThat(logs.getEvents())
@@ -99,7 +101,8 @@ class OtlpJsonLoggingMetricExporterTest {
   @Test
   void logWithWrapperJsonObjectTrue() throws Exception {
     // Test that wrapperJsonObject=true produces wrapper format (enables low allocation)
-    MetricExporter exporterWithWrapper = OtlpJsonLoggingMetricExporter.create(AggregationTemporality.CUMULATIVE, true);
+    MetricExporter exporterWithWrapper =
+        OtlpJsonLoggingMetricExporter.create(AggregationTemporality.CUMULATIVE, true);
     testDataExporter.export(exporterWithWrapper);
 
     assertThat(logs.getEvents())
@@ -114,7 +117,8 @@ class OtlpJsonLoggingMetricExporterTest {
   @Test
   void logWithWrapperJsonObjectTrueAndDeltaTemporality() throws Exception {
     // Test that wrapperJsonObject=true works with DELTA temporality too
-    MetricExporter exporterWithWrapper = OtlpJsonLoggingMetricExporter.create(AggregationTemporality.DELTA, true);
+    MetricExporter exporterWithWrapper =
+        OtlpJsonLoggingMetricExporter.create(AggregationTemporality.DELTA, true);
     testDataExporter.export(exporterWithWrapper);
 
     assertThat(logs.getEvents())

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
@@ -47,6 +47,36 @@ class OtlpJsonLoggingSpanExporterTest {
   }
 
   @Test
+  void logWithWrapperJsonObjectFalse() throws Exception {
+    // Test that wrapperJsonObject=false produces the same output as the default create()
+    SpanExporter exporterWithoutWrapper = OtlpJsonLoggingSpanExporter.create(false);
+    testDataExporter.export(exporterWithoutWrapper);
+
+    assertThat(logs.getEvents())
+        .hasSize(1)
+        .allSatisfy(log -> assertThat(log.getLevel()).isEqualTo(Level.INFO));
+    String message = logs.getEvents().get(0).getMessage();
+    String expectedJson = testDataExporter.getExpectedJson(false);
+    JSONAssert.assertEquals("Got \n" + message, expectedJson, message, /* strict= */ false);
+    assertThat(message).doesNotContain("\n");
+  }
+
+  @Test
+  void logWithWrapperJsonObjectTrue() throws Exception {
+    // Test that wrapperJsonObject=true produces wrapper format (enables low allocation)
+    SpanExporter exporterWithWrapper = OtlpJsonLoggingSpanExporter.create(true);
+    testDataExporter.export(exporterWithWrapper);
+
+    assertThat(logs.getEvents())
+        .hasSize(1)
+        .allSatisfy(log -> assertThat(log.getLevel()).isEqualTo(Level.INFO));
+    String message = logs.getEvents().get(0).getMessage();
+    String expectedJson = testDataExporter.getExpectedJson(true);
+    JSONAssert.assertEquals("Got \n" + message, expectedJson, message, /* strict= */ false);
+    assertThat(message).doesNotContain("\n");
+  }
+
+  @Test
   void flush() {
     assertThat(exporter.flush().isSuccess()).isTrue();
   }


### PR DESCRIPTION
### Context

This PR aims to introduce low allocation marshalers mentioned in this [github issue](https://github.com/open-telemetry/opentelemetry-java/issues/6474)