### PR TITLE
`GlobalOpenTelemetry.get()` should never returns obfuscated Noop OpenTelemetry

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
+++ b/api/all/src/main/java/io/opentelemetry/api/GlobalOpenTelemetry.java
@@ -72,7 +72,7 @@ public final class GlobalOpenTelemetry {
    *     interface FQCN but the specified provider cannot be found.
    */
   public static OpenTelemetry get() {
-    OpenTelemetry openTelemetry = globalOpenTelemetry;
+    ObfuscatedOpenTelemetry openTelemetry = globalOpenTelemetry;
     if (openTelemetry == null) {
       synchronized (mutex) {
         openTelemetry = globalOpenTelemetry;
@@ -88,7 +88,7 @@ public final class GlobalOpenTelemetry {
         }
       }
     }
-    return openTelemetry;
+    return openTelemetry.delegate == OpenTelemetry.noop() ? OpenTelemetry.noop() : openTelemetry;
   }
 
   /**

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
@@ -115,4 +115,11 @@ public abstract class AbstractOpenTelemetryTest {
                 + "propagators=DefaultContextPropagators{textMapPropagator=NoopTextMapPropagator}"
                 + "}");
   }
+
+  @Test
+  void neverReturnsObfuscatedNoop() {
+    assertThat(GlobalOpenTelemetry.get()).isSameAs(OpenTelemetry.noop());
+    // ensure sequential calls of GlobalOpenTelemetry.get() return same object
+    assertThat(GlobalOpenTelemetry.get()).isSameAs(OpenTelemetry.noop());
+  }
 }

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkTest.java
@@ -372,7 +372,7 @@ class AutoConfiguredOpenTelemetrySdkTest {
 
   @Test
   void builder_setResultAsGlobalFalse() {
-    GlobalOpenTelemetry.set(OpenTelemetry.noop());
+    GlobalOpenTelemetry.set(mock(OpenTelemetry.class));
 
     OpenTelemetrySdk openTelemetry = builder.build().getOpenTelemetrySdk();
 

--- a/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -161,7 +162,7 @@ class DeclarativeConfigurationTest {
 
   @Test
   void configFile_setResultAsGlobalFalse() {
-    GlobalOpenTelemetry.set(OpenTelemetry.noop());
+    GlobalOpenTelemetry.set(mock(OpenTelemetry.class));
     ConfigProperties config =
         DefaultConfigProperties.createFromMap(
             Collections.singletonMap("otel.experimental.config.file", configFilePath.toString()));


### PR DESCRIPTION
Fix inconsistent behavior that first call will return Noop but later calls return obfuscated Noop.