### PR TITLE
Clear context class loader from started threads

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
+++ b/context/src/main/java/io/opentelemetry/context/StrictContextStorage.java
@@ -252,6 +252,7 @@ final class StrictContextStorage implements ContextStorage, AutoCloseable {
       thread.setName("weak-ref-cleaner-strictcontextstorage");
       thread.setPriority(Thread.MIN_PRIORITY);
       thread.setDaemon(true);
+      thread.setContextClassLoader(null);
       thread.start();
     }
 

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/LeakDetectingSpanProcessor.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/LeakDetectingSpanProcessor.java
@@ -87,6 +87,7 @@ public final class LeakDetectingSpanProcessor implements SpanProcessor {
       thread.setName("weak-ref-cleaner-leakingspandetector");
       thread.setPriority(Thread.MIN_PRIORITY);
       thread.setDaemon(true);
+      thread.setContextClassLoader(null);
       thread.start();
       return pendingSpans;
     }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DaemonThreadFactory.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/DaemonThreadFactory.java
@@ -48,6 +48,7 @@ public final class DaemonThreadFactory implements ThreadFactory {
     try {
       t.setDaemon(true);
       t.setName(namePrefix + "-" + counter.incrementAndGet());
+      t.setContextClassLoader(null);
     } catch (SecurityException e) {
       // Well, we tried.
     }


### PR DESCRIPTION
Thread inherits context class loader from the thread that started it. This could be problematic when a thread is started from an application thread. For example with the `StrictContextStorage` (which is not used by default) some agent tests run on tomcat produce the following warning
```
Jul 14, 2025 4:08:02 PM org.apache.catalina.loader.WebappClassLoaderBase clearReferencesThreads
WARNING: The web application [app] appears to have started a thread named [weak-ref-cleaner-strictcontextstorage] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 java.base/jdk.internal.misc.Unsafe.park(Native Method)
 java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
 java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
 java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
 java.base/java.lang.ref.ReferenceQueue.await(ReferenceQueue.java:67)
 java.base/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:158)
 java.base/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:234)
 io.opentelemetry.context.StrictContextStorage$PendingScopes.run(StrictContextStorage.java:270)
 java.base/java.lang.Thread.run(Thread.java:1583)
```
Basically this tells that even when you undeploy the application the resources can't be freed because there is thread that has a reference to the application class loader.