### PR TITLE
Update okhttp dependency to okhttp-jvm

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -7,25 +7,6 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
-val DEPENDENCY_BOMS = listOf(
-  // for some reason boms show up as runtime dependencies in license and vulnerability scans
-  // even if they are only used by test dependencies, so not using junit bom here
-  // (which is EPL licensed) or armeria bom (which is Apache licensed but is getting flagged
-  // by FOSSA for containing EPL-licensed)
-
-  "com.fasterxml.jackson:jackson-bom:2.19.2",
-  "com.google.guava:guava-bom:33.4.8-jre",
-  "com.google.protobuf:protobuf-bom:4.31.1",
-  "com.squareup.okhttp3:okhttp-bom:5.1.0",
-  "com.squareup.okio:okio-bom:3.15.0", // applies to transitive dependencies of okhttp
-  "io.grpc:grpc-bom:1.73.0",
-  "io.netty:netty-bom:4.2.3.Final",
-  "io.zipkin.brave:brave-bom:6.3.0",
-  "io.zipkin.reporter2:zipkin-reporter-bom:3.5.1",
-  "org.assertj:assertj-bom:3.27.3",
-  "org.testcontainers:testcontainers-bom:1.21.3",
-  "org.snakeyaml:snakeyaml-engine:2.10"
-)
 
 val autoValueVersion = "1.11.0"
 val errorProneVersion = "2.41.0"
@@ -37,6 +18,27 @@ val opencensusVersion = "0.31.1"
 val prometheusServerVersion = "1.3.10"
 val armeriaVersion = "1.32.5"
 val junitVersion = "5.13.4"
+val okhttpVersion = "5.1.0"
+
+val DEPENDENCY_BOMS = listOf(
+  // for some reason boms show up as runtime dependencies in license and vulnerability scans
+  // even if they are only used by test dependencies, so not using junit bom here
+  // (which is EPL licensed) or armeria bom (which is Apache licensed but is getting flagged
+  // by FOSSA for containing EPL-licensed)
+
+  "com.fasterxml.jackson:jackson-bom:2.19.2",
+  "com.google.guava:guava-bom:33.4.8-jre",
+  "com.google.protobuf:protobuf-bom:4.31.1",
+  "com.squareup.okhttp3:okhttp-bom:$okhttpVersion",
+  "com.squareup.okio:okio-bom:3.15.0", // applies to transitive dependencies of okhttp
+  "io.grpc:grpc-bom:1.73.0",
+  "io.netty:netty-bom:4.2.3.Final",
+  "io.zipkin.brave:brave-bom:6.3.0",
+  "io.zipkin.reporter2:zipkin-reporter-bom:3.5.1",
+  "org.assertj:assertj-bom:3.27.3",
+  "org.testcontainers:testcontainers-bom:1.21.3",
+  "org.snakeyaml:snakeyaml-engine:2.10"
+)
 
 val DEPENDENCIES = listOf(
   "org.junit.jupiter:junit-jupiter-api:${junitVersion}",
@@ -72,6 +74,7 @@ val DEPENDENCIES = listOf(
   "com.google.code.findbugs:jsr305:3.0.2",
   "com.google.guava:guava-beta-checker:1.0",
   "com.sun.net.httpserver:http:20070405",
+  "com.squareup.okhttp3:okhttp-jvm:$okhttpVersion",
   "com.tngtech.archunit:archunit-junit5:1.4.1",
   "com.uber.nullaway:nullaway:0.12.7",
   "edu.berkeley.cs.jqf:jqf-fuzz:1.7", // jqf-fuzz version 1.8+ requires Java 11+

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   jmhImplementation("com.linecorp.armeria:armeria")
   jmhImplementation("com.linecorp.armeria:armeria-grpc")
   jmhImplementation("io.opentelemetry.proto:opentelemetry-proto")
-  jmhRuntimeOnly("com.squareup.okhttp3:okhttp")
+  jmhRuntimeOnly("com.squareup.okhttp3:okhttp-jvm")
   jmhRuntimeOnly("io.grpc:grpc-netty")
 }
 
@@ -65,7 +65,7 @@ testing {
             }
           }
 
-          implementation("com.squareup.okhttp3:okhttp")
+          implementation("com.squareup.okhttp3:okhttp-jvm")
           implementation("io.grpc:grpc-stub")
         }
 

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -64,8 +64,12 @@ testing {
               }
             }
           }
+          if (it.equals("LATEST")) {
+            implementation("com.squareup.okhttp3:okhttp-jvm")
+          } else {
+            implementation("com.squareup.okhttp3:okhttp")
+          }
 
-          implementation("com.squareup.okhttp3:okhttp-jvm")
           implementation("io.grpc:grpc-stub")
         }
 

--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
   api("io.opentelemetry.proto:opentelemetry-proto")
   api("org.junit.jupiter:junit-jupiter-api")
-  implementation("com.squareup.okhttp3:okhttp")
+  implementation("com.squareup.okhttp3:okhttp-jvm")
   implementation("org.junit.jupiter:junit-jupiter-params")
 
   implementation("com.linecorp.armeria:armeria-grpc-protocol")

--- a/exporters/sender/okhttp/build.gradle.kts
+++ b/exporters/sender/okhttp/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   implementation(project(":exporters:common"))
   implementation(project(":sdk:common"))
 
-  implementation("com.squareup.okhttp3:okhttp")
+  implementation("com.squareup.okhttp3:okhttp-jvm")
 
   compileOnly("io.grpc:grpc-stub")
   compileOnly("com.fasterxml.jackson.core:jackson-core")

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation(project(":exporters:common"))
   implementation(project(":exporters:sender:okhttp"))
 
-  implementation("com.squareup.okhttp3:okhttp")
+  implementation("com.squareup.okhttp3:okhttp-jvm")
 
   compileOnly("io.grpc:grpc-api")
   compileOnly("io.grpc:grpc-protobuf")


### PR DESCRIPTION
This hopefully resolves #7491 

I ended up having to change `dependencyManagement/build.gradle.kts` because I was getting errors seeming to indicate the BOM wasn't working for the okhttp-jvm package.

I was getting:

```
* What went wrong:
Execution failed for task ':exporters:sender:okhttp:compileJava'.
> Could not resolve all files for configuration ':exporters:sender:okhttp:compileClasspath'.
   > Could not find com.squareup.okhttp3:okhttp-jvm:.
     Required by:
         project :exporters:sender:okhttp
```

If there's a different way to handle that so we don't have to list out the bom and the okhttp-jvm dependencies in `dependencyManagement/build.gradle.kts` separately, let me know