### PR TITLE
Update benchmark runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,9 @@ jobs:
     permissions:
       contents: write # for git push to benchmarks branch
     name: Benchmark SDK
-    runs-on: equinix-bare-metal
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    container:
+      image: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The [benchmark actions](https://github.com/open-telemetry/opentelemetry-java/actions/workflows/benchmark.yml) have not been running since July 27th, which looks to be related to https://github.com/open-telemetry/community/issues/2801.

I picked the latest LTS ubuntu as the container as a starting point, but open to suggestions if we should use something more java specific, or if we want to try not using a container at all?

Some references from that other issue: 
* https://github.com/open-telemetry/sig-project-infra/pull/43/files
* https://github.com/open-telemetry/opentelemetry-rust/blob/main/.github/workflows/benchmark.yml#L26-L29
