### PR TITLE
Shutting down a grpcsender without interrupting the thread

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -214,7 +214,7 @@ public final class OkHttpGrpcSender<T extends Marshaler> implements GrpcSender<T
   public CompletableResultCode shutdown() {
     client.dispatcher().cancelAll();
     if (managedExecutor) {
-      client.dispatcher().executorService().shutdownNow();
+      client.dispatcher().executorService().shutdown();
     }
     client.connectionPool().evictAll();
     return CompletableResultCode.ofSuccess();


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-android/issues/1134

## Summary

This is to avoid the following crash from happening when a grpc exporter is shut down while okhttp is waiting to establish a connection with the server.

```
java.lang.InterruptedException
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:1765)
	at java.util.concurrent.LinkedBlockingDeque.pollFirst(LinkedBlockingDeque.java:515)
	at java.util.concurrent.LinkedBlockingDeque.poll(LinkedBlockingDeque.java:677)
	at okhttp3.internal.connection.FastFallbackExchangeFinder.awaitTcpConnect(FastFallbackExchangeFinder.kt:162)
	at okhttp3.internal.connection.FastFallbackExchangeFinder.find(FastFallbackExchangeFinder.kt:69)
	at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:280)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:101)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:85)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:74)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at io.opentelemetry.exporter.sender.okhttp.internal.RetryInterceptor.intercept(RetryInterceptor.java:96)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:208)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:530)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
	at java.lang.Thread.run(Thread.java:1119)
```

## Description

The crash happens when okhttp gets an unhandled interrupted exception [here](https://github.com/square/okhttp/blob/8b74eb4508853d0f8042258d8de9f714d7adc3c0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/FastFallbackExchangeFinder.kt#L162) which propagates to the host app.

The proposed solution is to avoid interrupting the thread, so that the execution will return [here](https://github.com/square/okhttp/blob/8b74eb4508853d0f8042258d8de9f714d7adc3c0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt#L280) after a timeout, and then finish [here](https://github.com/square/okhttp/blob/8b74eb4508853d0f8042258d8de9f714d7adc3c0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt#L290) as the call is cancelled prior to attempting to shut down the executor.

## Alternative solution

Asking okhttp to handle possible `java.lang.InterruptedException`s [here](https://github.com/square/okhttp/blob/8b74eb4508853d0f8042258d8de9f714d7adc3c0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/FastFallbackExchangeFinder.kt#L162).