### PR TITLE
Fix benchmark container image

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     name: Benchmark SDK
     runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     container:
-      image: ubuntu-24.04
+      image: ubuntu:24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
I had a typo leading to:

```
/usr/bin/docker pull ubuntu-24.04
Using default tag: latest
Error response from daemon: pull access denied for ubuntu-24.04, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: Docker pull failed with exit code 1
```