### PR TITLE
Fix TraceState key validation limits to match W3C spec

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 
 final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
 
-  private static final int MAX_VENDOR_ID_SIZE = 13;
+  private static final int MAX_VENDOR_ID_SIZE = 14;
 
   // Needs to be in this class to avoid initialization deadlock because super class depends on
   // subclass (the auto-value generate class).
@@ -24,7 +24,7 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
   private static final int MAX_ENTRIES = 32;
   private static final int KEY_MAX_SIZE = 256;
   private static final int VALUE_MAX_SIZE = 256;
-  private static final int MAX_TENANT_ID_SIZE = 240;
+  private static final int MAX_TENANT_ID_SIZE = 241;
 
   // Later calls to put must be at the front of trace state. We append to the list and then reverse
   // when finished.
@@ -157,11 +157,11 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
           return false;
         }
         isMultiTenantVendorKey = true;
-        // tenant id (the part to the left of the '@' sign) must be 240 characters or less
+        // tenant id (the part to the left of the '@' sign) must be 241 characters or less
         if (i > MAX_TENANT_ID_SIZE) {
           return false;
         }
-        // vendor id (the part to the right of the '@' sign) must be 1-13 characters long
+        // vendor id (the part to the right of the '@' sign) must be 1-14 characters long
         int remainingKeyChars = key.length() - i - 1;
         if (remainingKeyChars > MAX_VENDOR_ID_SIZE || remainingKeyChars == 0) {
           return false;

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -123,20 +123,37 @@ class TraceStateTest {
   }
 
   @Test
-  void testVendorIdLongerThan13Characters() {
-    assertThat(TraceState.builder().put("1@nrabcdefghijkl", FIRST_VALUE).build())
+  void testVendorIdWith14Characters() {
+    String key = "1@nrabcdefghijkl";
+    assertThat(TraceState.builder().put(key, FIRST_VALUE).build().get(key)).isEqualTo(FIRST_VALUE);
+  }
+
+  @Test
+  void testVendorIdLongerThan14Characters() {
+    assertThat(TraceState.builder().put("1@nrabcdefghijklm", FIRST_VALUE).build())
         .isEqualTo(TraceState.getDefault());
   }
 
   @Test
-  void testVendorIdLongerThan13Characters_longTenantId() {
-    assertThat(TraceState.builder().put("12345678901234567890@nrabcdefghijkl", FIRST_VALUE).build())
+  void testVendorIdLongerThan14Characters_longTenantId() {
+    assertThat(
+            TraceState.builder().put("12345678901234567890@nrabcdefghijklm", FIRST_VALUE).build())
         .isEqualTo(TraceState.getDefault());
   }
 
   @Test
-  void tenantIdLongerThan240Characters() {
+  void tenantIdWith241Characters() {
     char[] chars = new char[241];
+    Arrays.fill(chars, 'a');
+    String tenantId = new String(chars);
+    assertThat(
+            TraceState.builder().put(tenantId + "@nr", FIRST_VALUE).build().get(tenantId + "@nr"))
+        .isEqualTo(FIRST_VALUE);
+  }
+
+  @Test
+  void tenantIdLongerThan241Characters() {
+    char[] chars = new char[242];
     Arrays.fill(chars, 'a');
     String tenantId = new String(chars);
     assertThat(TraceState.builder().put(tenantId + "@nr", FIRST_VALUE).build())


### PR DESCRIPTION
## Summary

This PR fixes the multi-tenant vendor key validation limits in `ArrayBasedTraceStateBuilder` to properly comply with the W3C Trace Context specification.

**Changes:**
- Update `MAX_VENDOR_ID_SIZE` from 13 to 14 characters
- Update `MAX_TENANT_ID_SIZE` from 240 to 241 characters  
- Update documentation and comments to reflect correct limits
- Add comprehensive test cases for boundary conditions

## Background

The current implementation incorrectly rejects valid keys according to the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/#key). The ABNF rules define:

```
tenant-id = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
system-id = lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
```

This means:
- `tenant-id`: 1 + 240 = **241 characters maximum**
- `system-id`: 1 + 13 = **14 characters maximum**

## Test Plan

- [x] Added test cases for 241-character tenant IDs (should pass)
- [x] Added test cases for 242-character tenant IDs (should fail)  
- [x] Added test cases for 14-character vendor IDs (should pass)
- [x] Added test cases for 15-character vendor IDs (should fail)
- [x] All existing tests continue to pass
- [x] Ran `./gradlew check` successfully

## Validation

Before this fix:
- Keys with 241-character tenant IDs were incorrectly rejected
- Keys with 14-character vendor IDs were incorrectly rejected

After this fix:
- All test cases pass
- Implementation correctly follows W3C specification