### PR TITLE
Alternate strategy for pinning collector images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   extends: [
     'config:best-practices',
     'helpers:pinGitHubActionDigestsToSemver',
-    'customManagers:githubActionsVersions'
   ],
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     'config:best-practices',
     'helpers:pinGitHubActionDigestsToSemver',
   ],
+  ignorePaths: [], // overwrite default ignore which includes **/test/**
+                   // used to update docker image versions used in Java test files
   packageRules: [
     {
       // this is to reduce the number of renovate PRs
@@ -93,6 +95,18 @@
         '(?<currentValue>\\d+) # renovate: datasource=java-version',
       ],
       depNameTemplate: 'java',
+    },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'docker',
+      managerFilePatterns: [
+        '**/*.java'
+      ],
+      matchStrings: [
+        '"(?<depName>otel/opentelemetry-collector-contrib):(?<currentValue>[^@"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"',
+      ],
+      autoReplaceStringTemplate: '"{{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}"',
+      versioningTemplate: 'docker',
     },
   ],
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  # renovate: datasource=github-releases depName=opentelemetry-collector packageName=open-telemetry/opentelemetry-collector-releases
-  OTEL_COLLECTOR_VERSION: v0.132.4
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
@@ -60,17 +60,7 @@ import org.testcontainers.utility.DockerImageName;
 class CollectorIntegrationTest {
 
   private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib" + collectorVersion();
-
-  private static String collectorVersion() {
-    String otelCollectorVersion = System.getenv("OTEL_COLLECTOR_VERSION");
-    if (otelCollectorVersion != null) {
-      // strip the leading 'v'
-      return ":" + otelCollectorVersion.substring(1);
-    }
-    // Default to latest if not set
-    return ":latest";
-  }
+      "otel/opentelemetry-collector-contrib:latest";
 
   private static final Integer COLLECTOR_HEALTH_CHECK_PORT = 13133;
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
@@ -59,8 +59,7 @@ import org.testcontainers.utility.DockerImageName;
 @SuppressWarnings("NonFinalStaticField")
 class CollectorIntegrationTest {
 
-  private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib:0.132.2";
+  private static final String COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:0.132.2";
 
   private static final Integer COLLECTOR_HEALTH_CHECK_PORT = 13133;
 

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/CollectorIntegrationTest.java
@@ -60,7 +60,7 @@ import org.testcontainers.utility.DockerImageName;
 class CollectorIntegrationTest {
 
   private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib:latest";
+      "otel/opentelemetry-collector-contrib:0.132.2";
 
   private static final Integer COLLECTOR_HEALTH_CHECK_PORT = 13133;
 

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -115,17 +115,7 @@ abstract class OtlpExporterIntegrationTest {
   private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
 
   private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib" + collectorVersion();
-
-  private static String collectorVersion() {
-    String otelCollectorVersion = System.getenv("OTEL_COLLECTOR_VERSION");
-    if (otelCollectorVersion != null) {
-      // strip the leading 'v'
-      return ":" + otelCollectorVersion.substring(1);
-    }
-    // Default to latest if not set
-    return ":latest";
-  }
+      "otel/opentelemetry-collector-contrib:latest";
 
   private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
   private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -114,8 +114,7 @@ abstract class OtlpExporterIntegrationTest {
 
   private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
 
-  private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib:0.132.2";
+  private static final String COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:0.132.2";
 
   private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
   private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;

--- a/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
+++ b/integration-tests/otlp/src/main/java/io/opentelemetry/integrationtest/OtlpExporterIntegrationTest.java
@@ -115,7 +115,7 @@ abstract class OtlpExporterIntegrationTest {
   private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
 
   private static final String COLLECTOR_IMAGE =
-      "otel/opentelemetry-collector-contrib:latest";
+      "otel/opentelemetry-collector-contrib:0.132.2";
 
   private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
   private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;

--- a/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
+++ b/perf-harness/src/test/java/io/opentelemetry/perf/OtlpPipelineStressTest.java
@@ -68,7 +68,7 @@ public class OtlpPipelineStressTest {
 
   @Container
   public static final GenericContainer<?> collectorContainer =
-      new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:latest"))
+      new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.132.2"))
           .withImagePullPolicy(PullPolicy.alwaysPull())
           .withNetwork(network)
           .withNetworkAliases("otel-collector")

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/ExporterBenchmark.java
@@ -36,7 +36,7 @@ public class ExporterBenchmark {
   @State(Scope.Benchmark)
   public abstract static class AbstractProcessorBenchmark {
     private static final DockerImageName OTLP_COLLECTOR_IMAGE =
-        DockerImageName.parse("otel/opentelemetry-collector-contrib:latest");
+        DockerImageName.parse("otel/opentelemetry-collector-contrib:0.132.2");
     protected static final int OTLP_PORT = 5678;
     private static final int HEALTH_CHECK_PORT = 13133;
     protected SdkSpanBuilder sdkSpanBuilder;

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/SpanPipelineBenchmark.java
@@ -38,7 +38,7 @@ public class SpanPipelineBenchmark {
   @State(Scope.Benchmark)
   public abstract static class AbstractProcessorBenchmark {
     private static final DockerImageName OTLP_COLLECTOR_IMAGE =
-        DockerImageName.parse("otel/opentelemetry-collector-contrib:latest");
+        DockerImageName.parse("otel/opentelemetry-collector-contrib:0.132.2");
     private static final int EXPOSED_PORT = 5678;
     private static final int HEALTH_CHECK_PORT = 13133;
     private Tracer tracer;


### PR DESCRIPTION
Pros:
- running tests locally use the same version as CI
- version is collocated in the test file
- easily extendable to other images (one extra line in the renovate configuration)

Cons:
- complex renovate rule
- requires scanning test files which are normally ignored by renovate

cc @zeitlinger 