### PR TITLE
Increase benchmark timeout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     container:
       image: ubuntu:24.04@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
-    timeout-minutes: 10
+    timeout-minutes: 20 # since there is only a single bare metal runner across all repos
     steps:
       - name: Install Git
         run: |


### PR DESCRIPTION
Timeout appears to be slightly too low currently fails from time to time: https://github.com/open-telemetry/opentelemetry-java/actions/runs/17045637226