### PR TITLE
Change GAUGE to be CUMULATIVE in deltaPreferred()

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelector.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelector.java
@@ -32,14 +32,15 @@ public interface AggregationTemporalitySelector {
    *
    * <p>{@link AggregationTemporality#DELTA} is returned for {@link InstrumentType#COUNTER}, {@link
    * InstrumentType#OBSERVABLE_COUNTER}, and {@link InstrumentType#HISTOGRAM}. {@link
-   * AggregationTemporality#CUMULATIVE} is returned for {@link InstrumentType#UP_DOWN_COUNTER} and
-   * {@link InstrumentType#OBSERVABLE_UP_DOWN_COUNTER}.
+   * AggregationTemporality#CUMULATIVE} is returned for {@link InstrumentType#UP_DOWN_COUNTER},
+   * {@link InstrumentType#OBSERVABLE_UP_DOWN_COUNTER} and {@link InstrumentType#GAUGE}.
    */
   static AggregationTemporalitySelector deltaPreferred() {
     return instrumentType -> {
       switch (instrumentType) {
         case UP_DOWN_COUNTER:
         case OBSERVABLE_UP_DOWN_COUNTER:
+        case GAUGE:
           return AggregationTemporality.CUMULATIVE;
         case COUNTER:
         case OBSERVABLE_COUNTER:

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelectorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/AggregationTemporalitySelectorTest.java
@@ -48,7 +48,7 @@ class AggregationTemporalitySelectorTest {
     assertThat(selector.getAggregationTemporality(InstrumentType.OBSERVABLE_UP_DOWN_COUNTER))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
     assertThat(selector.getAggregationTemporality(InstrumentType.GAUGE))
-        .isEqualTo(AggregationTemporality.DELTA);
+        .isEqualTo(AggregationTemporality.CUMULATIVE);
   }
 
   @Test
@@ -94,6 +94,17 @@ class AggregationTemporalitySelectorTest {
                 + "UP_DOWN_COUNTER=CUMULATIVE, "
                 + "HISTOGRAM=DELTA, "
                 + "OBSERVABLE_COUNTER=DELTA, "
+                + "OBSERVABLE_UP_DOWN_COUNTER=CUMULATIVE, "
+                + "OBSERVABLE_GAUGE=DELTA, "
+                + "GAUGE=CUMULATIVE"
+                + "}");
+    assertThat(AggregationTemporalitySelector.asString(AggregationTemporalitySelector.lowMemory()))
+        .isEqualTo(
+            "AggregationTemporalitySelector{"
+                + "COUNTER=DELTA, "
+                + "UP_DOWN_COUNTER=CUMULATIVE, "
+                + "HISTOGRAM=DELTA, "
+                + "OBSERVABLE_COUNTER=CUMULATIVE, "
                 + "OBSERVABLE_UP_DOWN_COUNTER=CUMULATIVE, "
                 + "OBSERVABLE_GAUGE=DELTA, "
                 + "GAUGE=DELTA"


### PR DESCRIPTION
Problem:
In `AggregationTemporalitySelector#deltaPreferred()` : `GAUGE` seems to fallback to default i,e `DELTA`, which results in no data getting exported if a `GAUGE` instrument is not updated in each export interval. 

Solution:
Make `GAUGE` to be `CUMULATIVE` to consistently export the last set data.