### PR TITLE
Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,6 +95,7 @@
         '(?<currentValue>\\d+) # renovate: datasource=java-version',
       ],
       depNameTemplate: 'java',
+      extractVersionTemplate: '^(?<version>\\d+)',
     },
     {
       customType: 'regex',


### PR DESCRIPTION
I forgot to port https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2105 here

Should fix this not getting updated to 24 (let alone 25 once temurin distro is available)

https://github.com/open-telemetry/opentelemetry-java/blob/723b998785387367cd519325e907767c0699eeda/.github/workflows/build.yml#L35