### PR TITLE
Add Java 24 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           - 11
           - 17
           - 21
-          - 23 # renovate: datasource=java-version
+          - 24 # renovate: datasource=java-version
         # Collect coverage on latest LTS
         include:
           - os: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
           - os: macos-13
             test-java-version: 21
           - os: macos-13
-            test-java-version: 23 # renovate: datasource=java-version
+            test-java-version: 24 # renovate: datasource=java-version
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -168,7 +168,7 @@ jobs:
       matrix:
         test-graal-version:
           - 21
-          - 23
+          - 24 # renovate: datasource=java-version
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: graalvm/setup-graalvm@7a1da54cb7fdef4ea19f6ecdfa9ecf59dc5a48fe # v1.3.6

--- a/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/SunMiscProhibitedSecurityManagerTest.java
+++ b/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/SunMiscProhibitedSecurityManagerTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.sdk.trace.internal;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.security.AccessControlException;
 import org.junit.jupiter.api.Test;
 
 class SunMiscProhibitedSecurityManagerTest {
@@ -17,9 +16,7 @@ class SunMiscProhibitedSecurityManagerTest {
   public void checkPackageAccess_ProhibitsSunMisc() {
     SunMiscProhibitedSecurityManager sm = new SunMiscProhibitedSecurityManager();
     assertThatThrownBy(() -> sm.checkPackageAccess("sun.misc"))
-        .isInstanceOf(AccessControlException.class)
-        .hasMessage(
-            "access denied (\"java.lang.RuntimePermission\" \"accessClassInPackage.sun.misc\")");
+        .isInstanceOf(SecurityException.class);
   }
 
   @Test
@@ -28,9 +25,7 @@ class SunMiscProhibitedSecurityManagerTest {
 
     assertThatThrownBy(
             () -> sm.checkPermission(new RuntimePermission("accessClassInPackage.sun.misc")))
-        .isInstanceOf(AccessControlException.class)
-        .hasMessage(
-            "access denied (\"java.lang.RuntimePermission\" \"accessClassInPackage.sun.misc\")");
+        .isInstanceOf(SecurityException.class);
   }
 
   @Test


### PR DESCRIPTION
Java 25 should be available in our matrix soon, but in the meantime, looks like we missed Java 24 b/c Renovate auto-update isn't working (I'm looking into this separately, but wanted to get this updated in the meantime).