### PR TITLE
Add Gradle toolchain support so -PtestJavaVersion will automatically download Java version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ pluginManagement {
 }
 
 plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   id("com.gradle.develocity")
 }
 


### PR DESCRIPTION
This is same as instrumentation repo uses.