### PR TITLE
Proactively avoid Unsafe on Java 23+

### DIFF
--- a/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testFullConfig/java/io/opentelemetry/sdk/autoconfigure/LoggerProviderConfigurationTest.java
@@ -19,7 +19,6 @@ import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
-import io.opentelemetry.sdk.trace.internal.JcTools;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +26,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -140,7 +138,8 @@ class LoggerProviderConfigurationTest {
                 assertThat(worker)
                     .extracting("queue")
                     .isInstanceOfSatisfying(
-                        Queue.class, queue -> assertThat(JcTools.capacity(queue)).isEqualTo(2));
+                        ArrayBlockingQueue.class,
+                        queue -> assertThat(queue.remainingCapacity()).isEqualTo(2));
                 assertThat(worker)
                     .extracting("logRecordExporter")
                     .isInstanceOf(SystemOutLogRecordExporter.class);

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -7,13 +7,13 @@ package io.opentelemetry.sdk.trace.internal;
 
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscArrayQueue;
+import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 
 /**
  * Internal accessor of JCTools package for fast queues.
@@ -25,11 +25,15 @@ public final class JcTools {
 
   private static final AtomicBoolean queueCreationWarningLogged = new AtomicBoolean();
   private static final Logger logger = Logger.getLogger(JcTools.class.getName());
+  private static final boolean PROACTIVELY_AVOID_UNSAFE = proactivelyAvoidUnsafe();
 
   /**
    * Returns a new {@link Queue} appropriate for use with multiple producers and a single consumer.
    */
   public static <T> Queue<T> newFixedSizeQueue(int capacity) {
+    if (PROACTIVELY_AVOID_UNSAFE) {
+      return new MpscAtomicArrayQueue<>(capacity);
+    }
     try {
       return new MpscArrayQueue<>(capacity);
     } catch (java.lang.NoClassDefFoundError | java.lang.ExceptionInInitializerError e) {
@@ -41,7 +45,7 @@ public final class JcTools {
       }
       // Happens when modules such as jdk.unsupported are disabled in a custom JRE distribution,
       // or a security manager preventing access to Unsafe is installed.
-      return new ArrayBlockingQueue<>(capacity);
+      return new MpscAtomicArrayQueue<>(capacity);
     }
   }
 
@@ -50,11 +54,7 @@ public final class JcTools {
    * to use the shaded classes.
    */
   public static long capacity(Queue<?> queue) {
-    if (queue instanceof MessagePassingQueue) {
-      return ((MessagePassingQueue<?>) queue).capacity();
-    } else {
-      return (long) ((ArrayBlockingQueue<?>) queue).remainingCapacity() + queue.size();
-    }
+    return ((MessagePassingQueue<?>) queue).capacity();
   }
 
   /**
@@ -65,22 +65,26 @@ public final class JcTools {
    */
   @SuppressWarnings("unchecked")
   public static <T> int drain(Queue<T> queue, int limit, Consumer<T> consumer) {
-    if (queue instanceof MessagePassingQueue) {
-      return ((MessagePassingQueue<T>) queue).drain(consumer::accept, limit);
-    } else {
-      return drainNonJcQueue(queue, limit, consumer);
-    }
+    return ((MessagePassingQueue<T>) queue).drain(consumer::accept, limit);
   }
 
-  private static <T> int drainNonJcQueue(
-      Queue<T> queue, int maxExportBatchSize, Consumer<T> consumer) {
-    int polledCount = 0;
-    T item;
-    while (polledCount < maxExportBatchSize && (item = queue.poll()) != null) {
-      consumer.accept(item);
-      ++polledCount;
+  private static boolean proactivelyAvoidUnsafe() {
+    double javaVersion = getJavaVersion();
+    // Avoid Unsafe on Java 23+ due to JEP-498 deprecation warnings:
+    // "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called"
+    return javaVersion >= 23 || javaVersion == -1;
+  }
+
+  private static double getJavaVersion() {
+    String specVersion = System.getProperty("java.specification.version");
+    if (specVersion != null) {
+      try {
+        return Double.parseDouble(specVersion);
+      } catch (NumberFormatException exception) {
+        // ignore
+      }
     }
-    return polledCount;
+    return -1;
   }
 
   private JcTools() {}

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.trace.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -69,22 +70,22 @@ public final class JcTools {
   }
 
   private static boolean proactivelyAvoidUnsafe() {
-    double javaVersion = getJavaVersion();
+    Optional<Double> javaVersion = getJavaVersion();
     // Avoid Unsafe on Java 23+ due to JEP-498 deprecation warnings:
     // "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called"
-    return javaVersion >= 23 || javaVersion == -1;
+    return javaVersion.map(version -> version >= 23).orElse(true);
   }
 
-  private static double getJavaVersion() {
+  private static Optional<Double> getJavaVersion() {
     String specVersion = System.getProperty("java.specification.version");
     if (specVersion != null) {
       try {
-        return Double.parseDouble(specVersion);
+        return Optional.of(Double.parseDouble(specVersion));
       } catch (NumberFormatException exception) {
         // ignore
       }
     }
-    return -1;
+    return Optional.empty();
   }
 
   private JcTools() {}

--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -5,15 +5,9 @@
 
 package io.opentelemetry.sdk.trace.internal;
 
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.jctools.queues.MessagePassingQueue;
-import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 
 /**
@@ -24,30 +18,11 @@ import org.jctools.queues.atomic.MpscAtomicArrayQueue;
  */
 public final class JcTools {
 
-  private static final AtomicBoolean queueCreationWarningLogged = new AtomicBoolean();
-  private static final Logger logger = Logger.getLogger(JcTools.class.getName());
-  private static final boolean PROACTIVELY_AVOID_UNSAFE = proactivelyAvoidUnsafe();
-
   /**
    * Returns a new {@link Queue} appropriate for use with multiple producers and a single consumer.
    */
   public static <T> Queue<T> newFixedSizeQueue(int capacity) {
-    if (PROACTIVELY_AVOID_UNSAFE) {
-      return new MpscAtomicArrayQueue<>(capacity);
-    }
-    try {
-      return new MpscArrayQueue<>(capacity);
-    } catch (java.lang.NoClassDefFoundError | java.lang.ExceptionInInitializerError e) {
-      if (!queueCreationWarningLogged.getAndSet(true)) {
-        logger.log(
-            Level.WARNING,
-            "Cannot create high-performance queue, reverting to ArrayBlockingQueue ({0})",
-            Objects.toString(e, "unknown cause"));
-      }
-      // Happens when modules such as jdk.unsupported are disabled in a custom JRE distribution,
-      // or a security manager preventing access to Unsafe is installed.
-      return new MpscAtomicArrayQueue<>(capacity);
-    }
+    return new MpscAtomicArrayQueue<>(capacity);
   }
 
   /**
@@ -67,25 +42,6 @@ public final class JcTools {
   @SuppressWarnings("unchecked")
   public static <T> int drain(Queue<T> queue, int limit, Consumer<T> consumer) {
     return ((MessagePassingQueue<T>) queue).drain(consumer::accept, limit);
-  }
-
-  private static boolean proactivelyAvoidUnsafe() {
-    Optional<Double> javaVersion = getJavaVersion();
-    // Avoid Unsafe on Java 23+ due to JEP-498 deprecation warnings:
-    // "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called"
-    return javaVersion.map(version -> version >= 23).orElse(true);
-  }
-
-  private static Optional<Double> getJavaVersion() {
-    String specVersion = System.getProperty("java.specification.version");
-    if (specVersion != null) {
-      try {
-        return Optional.of(Double.parseDouble(specVersion));
-      } catch (NumberFormatException exception) {
-        // ignore
-      }
-    }
-    return Optional.empty();
   }
 
   private JcTools() {}

--- a/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsSecurityManagerTest.java
+++ b/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsSecurityManagerTest.java
@@ -11,7 +11,7 @@ import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
+import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
@@ -30,7 +30,7 @@ public class JcToolsSecurityManagerTest {
       Queue<Object> queue =
           AccessController.doPrivileged(
               (PrivilegedAction<Queue<Object>>) () -> JcTools.newFixedSizeQueue(10));
-      assertThat(queue).isInstanceOf(ArrayBlockingQueue.class);
+      assertThat(queue).isInstanceOf(MpscAtomicArrayQueue.class);
     } finally {
       System.setSecurityManager(null);
     }

--- a/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
+++ b/sdk/trace-shaded-deps/src/test/java/io/opentelemetry/sdk/trace/internal/JcToolsTest.java
@@ -9,41 +9,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import org.jctools.queues.MpscArrayQueue;
+import org.jctools.queues.MessagePassingQueue;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class JcToolsTest {
 
   ArrayList<String> batch = new ArrayList<>(10);
 
   @Test
-  void drain_ArrayBlockingQueue() {
-    // Arrange
-    batch.add("Test3");
-    Queue<String> queue = new ArrayBlockingQueue<>(10);
-    queue.add("Test1");
-    queue.add("Test2");
-
-    // Act
-    JcTools.drain(queue, 5, batch::add);
-
-    // Assert
-    assertThat(batch).hasSize(3);
-    assertThat(queue).hasSize(0);
-  }
-
-  @Test
   void drain_MessagePassingQueue() {
     // Arrange
     batch.add("Test3");
-    Queue<String> queue = new MpscArrayQueue<>(10);
+    Queue<String> queue = JcTools.newFixedSizeQueue(10);
     queue.add("Test1");
     queue.add("Test2");
 
@@ -58,7 +35,7 @@ class JcToolsTest {
   @Test
   void drain_MaxBatch() {
     // Arrange
-    Queue<String> queue = new MpscArrayQueue<>(10);
+    Queue<String> queue = JcTools.newFixedSizeQueue(10);
     queue.add("Test1");
     queue.add("Test2");
 
@@ -79,7 +56,7 @@ class JcToolsTest {
     Queue<Object> objects = JcTools.newFixedSizeQueue(capacity);
 
     // Assert
-    assertThat(objects).isInstanceOf(MpscArrayQueue.class);
+    assertThat(objects).isInstanceOf(MessagePassingQueue.class);
   }
 
   @Test
@@ -93,17 +70,5 @@ class JcToolsTest {
 
     // Assert
     assertThat(queueSize).isGreaterThan(capacity);
-  }
-
-  @Test
-  void capacity_ArrayBlockingQueue() {
-    // Arrange
-    Queue<String> queue = new ArrayBlockingQueue<>(10);
-
-    // Act
-    long queueSize = JcTools.capacity(queue);
-
-    // Assert
-    assertThat(queueSize).isEqualTo(10);
   }
 }


### PR DESCRIPTION
The `delayMs=0` tests seem to have a lot of variance, I've seen them fluctuate in both directions.

## Java 8 Results

### BatchSpanProcessorBenchmark.export Results

| Test Configuration | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|--------------------|--------------------|--------------------|------------|----------|
| delayMs=0, spanCount=1000 | 2,902.557 ±659.449 | 2,677.476 ±481.106 | -225.081 | **-7.8%** |
| delayMs=0, spanCount=2000 | 1,180.198 ±153.058 | 1,487.399 ±446.232 | +307.202 | **+26.0%** |
| delayMs=0, spanCount=5000 | 459.718 ±26.793 | 495.353 ±157.615 | +35.635 | **+7.8%** |
| delayMs=1, spanCount=1000 | 852.660 ±16.069 | 840.142 ±9.107 | -12.519 | **-1.5%** |
| delayMs=1, spanCount=2000 | 848.187 ±14.081 | 860.653 ±5.051 | +12.466 | **+1.5%** |
| delayMs=1, spanCount=5000 | 844.831 ±6.976 | 842.294 ±8.436 | -2.537 | **-0.3%** |
| delayMs=5, spanCount=1000 | 192.646 ±1.071 | 191.746 ±0.166 | -0.900 | **-0.5%** |
| delayMs=5, spanCount=2000 | 191.869 ±0.669 | 191.323 ±0.142 | -0.545 | **-0.3%** |
| delayMs=5, spanCount=5000 | 192.395 ±0.587 | 191.904 ±0.155 | -0.491 | **-0.3%** |
| delayMs=1 | 6,495.065 ±21.094 | 6,494.511 ±22.144 | -0.553 | **-0.0%** |
| delayMs=1 | 12,990.008 ±35.990 | 12,989.210 ±37.926 | -0.798 | **-0.0%** |
| delayMs=1 | 32,455.636 ±85.836 | 32,451.134 ±107.924 | -4.502 | **-0.0%** |
| delayMs=1 | 64,677.531 ±723.640 | 64,771.413 ±375.335 | +93.882 | **+0.1%** |
| delayMs=1 | 128,407.393 ±1000.361 | 128,357.234 ±821.825 | -50.159 | **-0.0%** |

### Multi-threading Benchmark Results

| Benchmark | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|-----------|--------------------|--------------------|------------|----------|
| export_01Thread (delayMs=1) | 6,495.065 ±21.094 | 6,494.511 ±22.144 | -0.553 | **-0.01%** |
| export_02Thread (delayMs=1) | 12,990.008 ±35.990 | 12,989.210 ±37.926 | -0.798 | **-0.01%** |
| export_05Thread (delayMs=1) | 32,455.636 ±85.836 | 32,451.134 ±107.924 | -4.502 | **-0.01%** |
| export_10Thread (delayMs=1) | 64,677.531 ±723.640 | 64,771.413 ±375.335 | +93.882 | **+0.15%** |
| export_20Thread (delayMs=1) | 128,407.393 ±1000.361 | 128,357.234 ±821.825 | -50.159 | **-0.04%** |

## Java 17 Results

### BatchSpanProcessorBenchmark.export Results

| Test Configuration | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|--------------------|--------------------|--------------------|------------|----------|
| delayMs=0, spanCount=1000 | 3,679.256 ±790.480 | 3,189.126 ±805.833 | -490.130 | **-13.3%** |
| delayMs=0, spanCount=2000 | 1,469.195 ±253.238 | 1,450.430 ±535.113 | -18.765 | **-1.3%** |
| delayMs=0, spanCount=5000 | 479.057 ±117.375 | 741.342 ±215.326 | +262.285 | **+54.8%** |
| delayMs=1, spanCount=1000 | 837.619 ±15.090 | 846.656 ±16.155 | +9.037 | **+1.1%** |
| delayMs=1, spanCount=2000 | 846.046 ±9.929 | 835.721 ±5.460 | -10.325 | **-1.2%** |
| delayMs=1, spanCount=5000 | 847.892 ±5.528 | 847.507 ±20.862 | -0.386 | **-0.0%** |
| delayMs=5, spanCount=1000 | 191.873 ±1.272 | 191.185 ±0.674 | -0.687 | **-0.4%** |
| delayMs=5, spanCount=2000 | 191.765 ±1.446 | 191.489 ±1.188 | -0.276 | **-0.1%** |
| delayMs=5, spanCount=5000 | 191.484 ±1.672 | 191.150 ±1.526 | -0.334 | **-0.2%** |
| delayMs=1 | 6,495.296 ±26.959 | 6,495.014 ±28.248 | -0.283 | **-0.0%** |
| delayMs=1 | 12,986.684 ±69.585 | 12,984.156 ±67.239 | -2.528 | **-0.0%** |
| delayMs=1 | 32,450.418 ±140.282 | 32,451.362 ±153.871 | +0.944 | **+0.0%** |
| delayMs=1 | 64,835.326 ±419.437 | 64,845.004 ±482.903 | +9.678 | **+0.0%** |
| delayMs=1 | 128,302.847 ±1380.143 | 128,207.056 ±1418.474 | -95.792 | **-0.1%** |

### Multi-threading Benchmark Results

| Benchmark | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|-----------|--------------------|--------------------|------------|----------|
| export_01Thread (delayMs=1) | 6,495.296 ±26.959 | 6,495.014 ±28.248 | -0.283 | **-0.00%** |
| export_02Thread (delayMs=1) | 12,986.684 ±69.585 | 12,984.156 ±67.239 | -2.528 | **-0.02%** |
| export_05Thread (delayMs=1) | 32,450.418 ±140.282 | 32,451.362 ±153.871 | +0.944 | **+0.00%** |
| export_10Thread (delayMs=1) | 64,835.326 ±419.437 | 64,845.004 ±482.903 | +9.678 | **+0.01%** |
| export_20Thread (delayMs=1) | 128,302.847 ±1380.143 | 128,207.056 ±1418.474 | -95.792 | **-0.07%** |

## Java 24 Results

### BatchSpanProcessorBenchmark.export Results

| Test Configuration | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|--------------------|--------------------|--------------------|------------|----------|
| delayMs=0, spanCount=1000 | 3,109.623 ±826.821 | 3,443.793 ±1197.910 | +334.170 | **+10.7%** |
| delayMs=0, spanCount=2000 | 1,326.157 ±199.990 | 1,155.285 ±61.366 | -170.872 | **-12.9%** |
| delayMs=0, spanCount=5000 | 622.792 ±40.550 | 511.532 ±87.939 | -111.260 | **-17.9%** |
| delayMs=1, spanCount=1000 | 845.640 ±2.345 | 853.888 ±15.808 | +8.247 | **+1.0%** |
| delayMs=1, spanCount=2000 | 842.823 ±2.052 | 839.436 ±1.850 | -3.387 | **-0.4%** |
| delayMs=1, spanCount=5000 | 840.577 ±2.887 | 836.613 ±8.446 | -3.964 | **-0.5%** |
| delayMs=5, spanCount=1000 | 191.576 ±1.589 | 191.705 ±1.989 | +0.129 | **+0.1%** |
| delayMs=5, spanCount=2000 | 191.105 ±1.219 | 190.458 ±1.547 | -0.647 | **-0.3%** |
| delayMs=5, spanCount=5000 | 191.087 ±1.460 | 191.182 ±1.319 | +0.095 | **+0.0%** |
| delayMs=1 | 6,494.026 ±32.405 | 6,494.527 ±25.915 | +0.501 | **+0.0%** |
| delayMs=1 | 12,986.492 ±53.347 | 12,986.381 ±56.660 | -0.112 | **-0.0%** |
| delayMs=1 | 32,455.839 ±167.412 | 32,458.205 ±160.005 | +2.366 | **+0.0%** |
| delayMs=1 | 64,832.548 ±242.614 | 64,887.898 ±320.588 | +55.350 | **+0.1%** |
| delayMs=1 | 127,782.627 ±237.159 | 128,444.628 ±637.934 | +662.002 | **+0.5%** |

### Multi-threading Benchmark Results

| Benchmark | Main Branch (ops/s) | PR Branch (ops/s) | Difference | % Change |
|-----------|--------------------|--------------------|------------|----------|
| export_01Thread (delayMs=1) | 6,494.026 ±32.405 | 6,494.527 ±25.915 | +0.501 | **+0.01%** |
| export_02Thread (delayMs=1) | 12,986.492 ±53.347 | 12,986.381 ±56.660 | -0.112 | **-0.00%** |
| export_05Thread (delayMs=1) | 32,455.839 ±167.412 | 32,458.205 ±160.005 | +2.366 | **+0.01%** |
| export_10Thread (delayMs=1) | 64,832.548 ±242.614 | 64,887.898 ±320.588 | +55.350 | **+0.09%** |
| export_20Thread (delayMs=1) | 127,782.627 ±237.159 | 128,444.628 ±637.934 | +662.002 | **+0.52%** |
