### PR TITLE
Remove unnecessary(?) animalsniffer exclusions

### DIFF
--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -1,5 +1,3 @@
-import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
-
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
@@ -64,12 +62,6 @@ testing {
 }
 
 tasks {
-  named<AnimalSniffer>("animalsnifferMain") {
-    // We cannot use IgnoreJreRequirement since it does not work correctly for fields.
-    // https://github.com/mojohaus/animal-sniffer/issues/131
-    exclude("**/concurrent/Jre*Adder*")
-  }
-
   check {
     dependsOn(testing.suites)
   }

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -1,5 +1,3 @@
-import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
-
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
@@ -78,13 +76,5 @@ testing {
 tasks {
   check {
     dependsOn(testing.suites)
-  }
-}
-
-tasks {
-  withType<AnimalSniffer>().configureEach {
-    // We catch NoClassDefFoundError to fallback to non-jctools queues.
-    exclude("**/internal/shaded/jctools/**")
-    exclude("**/internal/JcTools*")
   }
 }


### PR DESCRIPTION
@open-telemetry/android-approvers is this worrisome that removing these doesn't cause any failures?