### PR TITLE
[DO NOT MERGE] JFR API usage

### DIFF
--- a/exporters/otlp/profiles/build.gradle.kts
+++ b/exporters/otlp/profiles/build.gradle.kts
@@ -27,4 +27,10 @@ dependencies {
   testImplementation(project(":exporters:otlp:testing-internal"))
   testImplementation(project(":exporters:sender:okhttp"))
   testImplementation("io.grpc:grpc-stub")
+
+  tasks {
+    withType(JavaCompile::class) {
+      options.release.set(11)
+    }
+  }
 }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/JfrConverter.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/JfrConverter.java
@@ -1,0 +1,15 @@
+package io.opentelemetry.exporter.otlp.profiles;
+
+import jdk.jfr.consumer.RecordingFile;
+import java.io.File;
+import java.io.IOException;
+
+public class JfrConverter {
+
+  public static void main(String[] args) throws IOException {
+
+    File jfrFile = new File(args[0]);
+    RecordingFile recordingFile = new RecordingFile(jfrFile.toPath());
+
+  }
+}


### PR DESCRIPTION
@open-telemetry/java-maintainers
I'd like to read a JFR file, convert it to OTel profiling format and export it. The JFR consumer API is 9+ only. As seen here, building the profiling exporter with 11 works for the single module, but breaks the parent :exporters:otlp:all build.
Any preference on how to change the build deps to support this without making the blast radius of the change too big? Worst case I can split the JFR layer of the export code off into its own module, but I'd prefer to keep it bundled with the rest of the profiling code.  Thx.