### PR TITLE
Make StandardComponentId constructor public

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/internal/StandardComponentId.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/internal/StandardComponentId.java
@@ -51,7 +51,7 @@ public class StandardComponentId extends ComponentId.Lazy {
 
   private final ExporterType standardType;
 
-  StandardComponentId(ExporterType standardType) {
+  public StandardComponentId(ExporterType standardType) {
     super(standardType.value);
     this.standardType = standardType;
   }


### PR DESCRIPTION
This prevents the instantiation of Senders outside of the SDK. 

Related with https://github.com/open-telemetry/opentelemetry-java/issues/6718