### PR TITLE
DEVELOCITY_ACCESS_KEY now org secret

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -16,6 +16,7 @@ private admin repo.
 
 ### Organization secrets
 
+- `DEVELOCITY_ACCESS_KEY`
 - `FOSSA_API_KEY`
 - `OTELBOT_PRIVATE_KEY`
 


### PR DESCRIPTION
so I don't have to update it in 6 places when it expires

https://github.com/open-telemetry/community/pull/3081

(it's scoped only to Java repos)