### PR TITLE
Fix gradle deprecation warning

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,23 +5,6 @@ plugins {
   id("com.diffplug.spotless") version "8.0.0"
 }
 
-if (!hasLauncherForJavaVersion(17)) {
-  throw GradleException(
-    "JDK 17 is required to build and gradle was unable to detect it on the system.  " +
-        "Please install it and see https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection " +
-        "for details on how gradle detects java toolchains."
-  )
-}
-
-fun hasLauncherForJavaVersion(version: Int): Boolean {
-  return try {
-    javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(version) }.get()
-    true
-  } catch (e: Exception) {
-    false
-  }
-}
-
 spotless {
   kotlinGradle {
     ktlint().editorConfigOverride(mapOf(
@@ -67,12 +50,4 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20")
   implementation("org.owasp:dependency-check-gradle:12.1.8")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:2.0.1")
-}
-
-// We can't apply conventions to this build so include important ones such as the Java compilation
-// target.
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
-  }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,12 +6,13 @@ pluginManagement {
     id("org.jsonschema2pojo") version "1.2.2"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("org.graalvm.buildtools.native") version "0.10.6"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   }
 }
 
 plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   id("com.gradle.develocity")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Fixes

> Using toolchain 'Eclipse Temurin JDK 17 (17.0.16+8)' installed via auto-provisioning without toolchain repositories. This behavior has been deprecated. This will fail with an error in Gradle 10. Builds may fail when this toolchain is not available in other environments. Add toolchain repositories to this build. For more information, please refer to https://docs.gradle.org/9.1.0/userguide/toolchains.html#sub:download_repositories in the Gradle documentation.