### PR TITLE
Remove unnecessary condition for this repo

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,12 +103,6 @@ develocity {
     capture {
       fileFingerprints = true
     }
-
-    buildScanPublished {
-      File("build-scan.txt").printWriter().use { writer ->
-        writer.println(buildScanUri)
-      }
-    }
   }
 }
 


### PR DESCRIPTION
~I ported too much in #7776 as @laurit pointed out in https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2379#discussion_r2450391921~

oh, realized this repo doesn't use `build-scans.txt` in the CI workflow, so none of it is needed