### PR TITLE
Don't allow `this` to escape constructor

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
@@ -41,8 +41,8 @@ public abstract class AggregatorHandle<T extends PointData> {
   private final boolean isDoubleType;
   private volatile boolean valuesRecorded = false;
 
-  protected AggregatorHandle(ExemplarReservoirFactory reservoirFactory) {
-    this.isDoubleType = isDoubleType();
+  protected AggregatorHandle(ExemplarReservoirFactory reservoirFactory, boolean isDoubleType) {
+    this.isDoubleType = isDoubleType;
     if (isDoubleType) {
       this.doubleReservoirFactory = reservoirFactory.createDoubleExemplarReservoir();
       this.longReservoirFactory = null;
@@ -79,19 +79,6 @@ public abstract class AggregatorHandle<T extends PointData> {
             .collectAndResetLongs(attributes),
         reset);
   }
-
-  /**
-   * Indicates whether this {@link AggregatorHandle} supports double or long values.
-   *
-   * <p>If it supports doubles, it MUST implement {@link #doAggregateThenMaybeResetDoubles(long,
-   * long, Attributes, List, boolean)} and {@link #doRecordDouble(double)}.
-   *
-   * <p>If it supports long, it MUST implement {@link #doAggregateThenMaybeResetLongs(long, long,
-   * Attributes, List, boolean)} and {@link #doRecordLong(long)}.
-   *
-   * @return true if it supports doubles, false if it supports longs.
-   */
-  protected abstract boolean isDoubleType();
 
   /** Implementation of the {@link #aggregateThenMaybeReset(long, long, Attributes, boolean)} . */
   protected T doAggregateThenMaybeResetDoubles(

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramAggregator.java
@@ -100,7 +100,7 @@ public final class DoubleBase2ExponentialHistogramAggregator
         int maxBuckets,
         int maxScale,
         MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ true);
       this.maxBuckets = maxBuckets;
       this.maxScale = maxScale;
       this.sum = 0;
@@ -258,11 +258,6 @@ public final class DoubleBase2ExponentialHistogramAggregator
         downScale(buckets.getScaleReduction(value));
         buckets.record(value);
       }
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return true;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleExplicitBucketHistogramAggregator.java
@@ -110,14 +110,14 @@ public final class DoubleExplicitBucketHistogramAggregator
     private final long[] counts;
 
     // Used only when MemoryMode = REUSABLE_DATA
-    @Nullable private MutableHistogramPointData reusablePoint;
+    @Nullable private final MutableHistogramPointData reusablePoint;
 
     Handle(
         List<Double> boundaryList,
         double[] boundaries,
         ExemplarReservoirFactory reservoirFactory,
         MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ true);
       this.boundaryList = boundaryList;
       this.boundaries = boundaries;
       this.counts = new long[this.boundaries.length + 1];
@@ -127,6 +127,8 @@ public final class DoubleExplicitBucketHistogramAggregator
       this.count = 0;
       if (memoryMode == MemoryMode.REUSABLE_DATA) {
         this.reusablePoint = new MutableHistogramPointData(counts.length);
+      } else {
+        this.reusablePoint = null;
       }
     }
 
@@ -136,11 +138,6 @@ public final class DoubleExplicitBucketHistogramAggregator
       // from LongHistogram, we redirect calls from #recordLong to #recordDouble. Without this, the
       // base AggregatorHandle implementation of #recordLong throws.
       super.recordDouble((double) value, attributes, context);
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return true;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
@@ -100,7 +100,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoublePointDa
     @Nullable private final MutableDoublePointData reusablePoint;
 
     private Handle(ExemplarReservoirFactory reservoirFactory, MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ true);
       if (memoryMode == MemoryMode.REUSABLE_DATA) {
         reusablePoint = new MutableDoublePointData();
       } else {
@@ -125,11 +125,6 @@ public final class DoubleLastValueAggregator implements Aggregator<DoublePointDa
         return ImmutableDoublePointData.create(
             startEpochNanos, epochNanos, attributes, value, exemplars);
       }
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return true;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleSumAggregator.java
@@ -113,13 +113,8 @@ public final class DoubleSumAggregator
     @Nullable private final MutableDoublePointData reusablePoint;
 
     Handle(ExemplarReservoirFactory reservoirFactory, MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ true);
       reusablePoint = memoryMode == MemoryMode.REUSABLE_DATA ? new MutableDoublePointData() : null;
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return true;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DropAggregator.java
@@ -53,12 +53,8 @@ public final class DropAggregator implements Aggregator<PointData> {
   public static final Aggregator<PointData> INSTANCE = new DropAggregator();
 
   private static final AggregatorHandle<PointData> HANDLE =
-      new AggregatorHandle<PointData>(ExemplarReservoirFactory.noSamples()) {
-        @Override
-        protected boolean isDoubleType() {
-          return true;
-        }
-
+      new AggregatorHandle<PointData>(
+          ExemplarReservoirFactory.noSamples(), /* isDoubleType= */ true) {
         @Override
         protected PointData doAggregateThenMaybeResetDoubles(
             long startEpochNanos,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
@@ -95,17 +95,12 @@ public final class LongLastValueAggregator implements Aggregator<LongPointData> 
     @Nullable private final MutableLongPointData reusablePoint;
 
     Handle(ExemplarReservoirFactory reservoirFactory, MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ false);
       if (memoryMode == MemoryMode.REUSABLE_DATA) {
         reusablePoint = new MutableLongPointData();
       } else {
         reusablePoint = null;
       }
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return false;
     }
 
     @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
@@ -106,7 +106,7 @@ public final class LongSumAggregator
     @Nullable private final MutableLongPointData reusablePointData;
 
     Handle(ExemplarReservoirFactory reservoirFactory, MemoryMode memoryMode) {
-      super(reservoirFactory);
+      super(reservoirFactory, /* isDoubleType= */ false);
       reusablePointData =
           memoryMode == MemoryMode.REUSABLE_DATA ? new MutableLongPointData() : null;
     }
@@ -126,11 +126,6 @@ public final class LongSumAggregator
         return ImmutableLongPointData.create(
             startEpochNanos, epochNanos, attributes, value, exemplars);
       }
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return false;
     }
 
     @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandleTest.java
@@ -102,24 +102,14 @@ class AggregatorHandleTest {
   private static class TestDoubleAggregatorHandle extends TestAggregatorHandle {
 
     TestDoubleAggregatorHandle(DoubleExemplarReservoir reservoir) {
-      super(reservoir, null);
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return true;
+      super(reservoir, null, /* isDoubleType= */ true);
     }
   }
 
   private static class TestLongAggregatorHandle extends TestAggregatorHandle {
 
     TestLongAggregatorHandle(LongExemplarReservoir reservoir) {
-      super(null, reservoir);
-    }
-
-    @Override
-    protected boolean isDoubleType() {
-      return false;
+      super(null, reservoir, /* isDoubleType= */ false);
     }
   }
 
@@ -130,7 +120,8 @@ class AggregatorHandleTest {
 
     TestAggregatorHandle(
         @Nullable DoubleExemplarReservoir doubleReservoir,
-        @Nullable LongExemplarReservoir longReservoir) {
+        @Nullable LongExemplarReservoir longReservoir,
+        boolean isDoubleType) {
       super(
           new ExemplarReservoirFactory() {
             @Override
@@ -142,7 +133,8 @@ class AggregatorHandleTest {
             public LongExemplarReservoir createLongExemplarReservoir() {
               return Objects.requireNonNull(longReservoir);
             }
-          });
+          },
+          isDoubleType);
     }
 
     @Nullable


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java/pull/7784/files#r2453708480

Alternatively, I can suppress the warning, but this PR seems like an overall simplification.