### PR TITLE
Rename ComposableTraceIdRatioBased to ComposableProbability

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableProbabilitySampler.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableProbabilitySampler.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.trace.data.LinkData;
 import java.util.List;
 import java.util.function.Function;
 
-final class ComposableTraceIdRatioBasedSampler implements ComposableSampler {
+final class ComposableProbabilitySampler implements ComposableSampler {
   private static long calculateThreshold(double ratio) {
     return ImmutableSamplingIntent.MAX_THRESHOLD
         - Math.round(ratio * (double) ImmutableSamplingIntent.MAX_THRESHOLD);
@@ -21,7 +21,7 @@ final class ComposableTraceIdRatioBasedSampler implements ComposableSampler {
   private final SamplingIntent intent;
   private final String description;
 
-  ComposableTraceIdRatioBasedSampler(double ratio) {
+  ComposableProbabilitySampler(double ratio) {
     long threshold = calculateThreshold(ratio);
     String thresholdStr;
     if (threshold == ImmutableSamplingIntent.MAX_THRESHOLD) {

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableSampler.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableSampler.java
@@ -24,8 +24,8 @@ public interface ComposableSampler {
   }
 
   /** Returns a {@link ComposableSampler} that samples each span with a fixed ratio. */
-  static ComposableSampler traceIdRatioBased(double ratio) {
-    return new ComposableTraceIdRatioBasedSampler(ratio);
+  static ComposableSampler probability(double ratio) {
+    return new ComposableProbabilitySampler(ratio);
   }
 
   /**

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableProbabilitySamplerTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableProbabilitySamplerTest.java
@@ -21,21 +21,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class ComposableTraceIdRatioBasedSamplerTest {
+class ComposableProbabilitySamplerTest {
   @Test
   void testDescription() {
-    assertThat(ComposableSampler.traceIdRatioBased(1.0).getDescription())
+    assertThat(ComposableSampler.probability(1.0).getDescription())
         .isEqualTo("ComposableTraceIdRatioBasedSampler{threshold=0, ratio=1.0}");
-    assertThat(ComposableSampler.traceIdRatioBased(1.0))
+    assertThat(ComposableSampler.probability(1.0))
         .hasToString("ComposableTraceIdRatioBasedSampler{threshold=0, ratio=1.0}");
 
-    assertThat(ComposableSampler.traceIdRatioBased(0.5).getDescription())
+    assertThat(ComposableSampler.probability(0.5).getDescription())
         .isEqualTo("ComposableTraceIdRatioBasedSampler{threshold=8, ratio=0.5}");
-    assertThat(ComposableSampler.traceIdRatioBased(0.25).getDescription())
+    assertThat(ComposableSampler.probability(0.25).getDescription())
         .isEqualTo("ComposableTraceIdRatioBasedSampler{threshold=c, ratio=0.25}");
-    assertThat(ComposableSampler.traceIdRatioBased(1e-300).getDescription())
+    assertThat(ComposableSampler.probability(1e-300).getDescription())
         .isEqualTo("ComposableTraceIdRatioBasedSampler{threshold=max, ratio=1.0E-300}");
-    assertThat(ComposableSampler.traceIdRatioBased(0).getDescription())
+    assertThat(ComposableSampler.probability(0).getDescription())
         .isEqualTo("ComposableTraceIdRatioBasedSampler{threshold=max, ratio=0.0}");
   }
 
@@ -53,7 +53,7 @@ class ComposableTraceIdRatioBasedSamplerTest {
   })
   void sampling(double ratio, long threshold) {
     Supplier<String> generator = traceIdGenerator();
-    Sampler sampler = CompositeSampler.wrap(ComposableSampler.traceIdRatioBased(ratio));
+    Sampler sampler = CompositeSampler.wrap(ComposableSampler.probability(ratio));
     int numSampled = 0;
     for (int i = 0; i < 10000; i++) {
       SamplingResult result =

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/CompositeSamplerTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/CompositeSamplerTest.java
@@ -189,7 +189,7 @@ class CompositeSamplerTest {
   void testMaxThreshold() {
     Input input = new Input();
 
-    Sampler sampler = CompositeSampler.wrap(ComposableSampler.traceIdRatioBased(0.0));
+    Sampler sampler = CompositeSampler.wrap(ComposableSampler.probability(0.0));
 
     Output output = sample(input, sampler);
 
@@ -237,7 +237,7 @@ class CompositeSamplerTest {
     Input input = new Input();
     input.setParentRandomValue(0x7FFFFFFFFFFFFFL);
 
-    Sampler sampler = CompositeSampler.wrap(ComposableSampler.traceIdRatioBased(0.5));
+    Sampler sampler = CompositeSampler.wrap(ComposableSampler.probability(0.5));
 
     Output output = sample(input, sampler);
 
@@ -251,7 +251,7 @@ class CompositeSamplerTest {
     Input input = new Input();
     input.setParentRandomValue(0x80000000000000L);
 
-    Sampler sampler = CompositeSampler.wrap(ComposableSampler.traceIdRatioBased(0.5));
+    Sampler sampler = CompositeSampler.wrap(ComposableSampler.probability(0.5));
 
     Output output = sample(input, sampler);
 
@@ -268,7 +268,7 @@ class CompositeSamplerTest {
     input.setParentRandomValue(0x80000000000000L);
     input.setParentSampled(false);
 
-    Sampler sampler = CompositeSampler.wrap(ComposableSampler.traceIdRatioBased(1.0));
+    Sampler sampler = CompositeSampler.wrap(ComposableSampler.probability(1.0));
     Output output = sample(input, sampler);
 
     assertThat(output.samplingResult.getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);


### PR DESCRIPTION
Rename the composible ratio sampler to match the new name in the spec

https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableprobability

This doesn't touch the top-level, where `TraceIdRatio` has a new development spec to output deprecation warnings - I think this will need to be implemented when the spec is marked stable, though not sure.