### PR TITLE
update macos version to latest and switch to corretto for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - macos-15
           - ubuntu-latest
           - windows-latest
         test-java-version:
@@ -39,18 +38,6 @@ jobs:
             test-java-version: 21
             coverage: true
             jmh-based-tests: true
-        # macos-latest drops support for java 8 temurin. Run java 8 on macos-13. Run java 11+ on macos-latest.
-        exclude:
-          - os: macos-latest
-            test-java-version: 8
-          - os: macos-15
-            test-java-version: 11
-          - os: macos-15
-            test-java-version: 17
-          - os: macos-15
-            test-java-version: 21
-          - os: macos-15
-            test-java-version: 25 # renovate: datasource=java-version
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -58,6 +45,7 @@ jobs:
         name: Set up Java ${{ matrix.test-java-version }} for tests
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
+          # use corretto for testing, since it supports java 8 on more OS versions, including macos-latest
           distribution: corretto
           java-version: ${{ matrix.test-java-version }}
 


### PR DESCRIPTION
Corretto supports java 8 still on mac, so use that, rather than temurin for testing.