### PR TITLE
Add zeitlinger as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ For more information about the maintainer role, see the [community repository](h
 
 ### Approvers
 
+- [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana Labs
 - [Jason Plumb](https://github.com/breedx-splk), Splunk
 - [Josh Suereth](https://github.com/jsuereth), Google
 - [Lauri Tulmin](https://github.com/laurit), Splunk
@@ -277,7 +278,7 @@ For more information about the approver role, see the [community repository](htt
 
 ### Triagers
 
-- [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana Labs
+None.
 
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
 


### PR DESCRIPTION
@zeitlinger has been a contributor for several years, and has recently been helping drive the spring boot starter and declarative configuration efforts in `opentelemetry-java-instrumentation`. Thanks for all your contributions @zeitlinger!