### PR TITLE
Current name is opentelemetry-exporter-sender-grpc-managed-channel

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -325,7 +325,7 @@ public class GrpcExporterBuilder<T extends Marshaler> {
     if (grpcSenderProviders.isEmpty()) {
       throw new IllegalStateException(
           "No GrpcSenderProvider found on classpath. Please add dependency on "
-              + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-grpc-upstream");
+              + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-grpc-managed-channel");
     }
 
     // Exactly one provider on classpath, use it

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterTest.java
@@ -44,7 +44,7 @@ class GrpcExporterTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "No GrpcSenderProvider found on classpath. Please add dependency on "
-                + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-grpc-upstream");
+                + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-grpc-managed-channel");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Not opentelemetry-exporter-sender-grpc-upstream