### PR TITLE
Move snapshot publishing to daily build

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -1,0 +1,53 @@
+name: Build (daily)
+
+on:
+  schedule:
+    # daily at 3:24 UTC
+    - cron: "24 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    uses: ./.github/workflows/reusable-link-check.yml
+
+  publish-snapshots:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Set up Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
+
+      - name: Publish to Sonatype
+        run: ./gradlew assemble publishToSonatype
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+  workflow-notification:
+    permissions:
+      contents: read
+      issues: write
+    needs:
+      - link-check
+      - publish-snapshots
+    if: always()
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: >-
+        ${{
+          needs.link-check.result == 'success' &&
+          needs.publish-snapshots.result == 'success'
+        }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,47 +104,6 @@ jobs:
     if: ${{ !startsWith(github.ref_name, 'release/') }}
     uses: ./.github/workflows/reusable-link-check.yml
 
-  publish-snapshots:
-    # the condition is on the steps below instead of here on the job, because skipping the job
-    # causes the job to show up as canceled in the GitHub UI which prevents the build section from
-    # collapsing when everything (else) is green
-    #
-    # and the name is updated when the steps below are skipped which makes what's happening clearer
-    # in the GitHub UI
-    #
-    # note: the condition below has to be written so that '' is last since it resolves to false
-    # and so would not short-circuit if used in the second-last position
-    name: publish-snapshots${{ (github.ref_name != 'main' || github.repository != 'open-telemetry/opentelemetry-java') && ' (skipped)' || '' }}
-    # intentionally not blocking snapshot publishing on markdown-link-check
-    needs: build
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - id: setup-java
-        name: Set up Java
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Set up gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        # skipping release branches because the versions in those branches are not snapshots
-        # (also this skips pull requests)
-        if: ${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' }}
-      - name: Publish to Sonatype
-        run: ./gradlew assemble publishToSonatype
-        # skipping release branches because the versions in those branches are not snapshots
-        # (also this skips pull requests)
-        if: ${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java' }}
-        env:
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-
   build-graal:
     name: Build GraalVM
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think publishing snapshots only daily is fine. The new daily workflow will trigger issue creation when snapshot publishing fails.

Port of https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2481

FWIW, java contrib repo publishing is working again, though not really convinced it's related to this change 🤷‍♂️ 