### PR TITLE
Disable errorprone RequestExplicitNullMarking

### DIFF
--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -88,6 +88,7 @@ tasks {
         // We annotate packages with @ParametersAreNonnullByDefault from com.google.code.findbugs:jsr305.
         // @NullMarked is the equivalent from jspecify.
         disable("AddNullMarkedToPackageInfo")
+        disable("RequireExplicitNullMarking")
 
         // This check causes too many changes to be introduced at once to be manageable.
         disable("SuppressWarningsWithoutExplanation")


### PR DESCRIPTION
Currently not causing failures, but spamming:

```
C:\src\opentelemetry-java\context\src\main\java\io\opentelemetry\context\propagation\internal\ExtendedTextMapGetter.java:17: Note: [RequireExplicitNullMarking] Top-level classes must either be directly annotated with @NullMarked/@NullUnmarked or be in a package or module that is explicitly @NullMarked/@NullUnmarked.
public interface ExtendedTextMapGetter<C> extends TextMapGetter<C> {
       ^
    (see https://errorprone.info/bugpattern/RequireExplicitNullMarking)
```