### PR TITLE
Change ConfigProvider.getInstrumentationConfig() to not return null

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/ConfigProvider.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/ConfigProvider.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.api.incubator.config;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -23,15 +22,14 @@ public interface ConfigProvider {
   /**
    * Returns the {@link DeclarativeConfigProperties} corresponding to <a
    * href="https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/instrumentation.json">instrumentation
-   * config</a>, or {@code null} if unavailable.
+   * config</a>. Returns {@link DeclarativeConfigProperties#empty()} if unavailable.
    *
    * @return the instrumentation {@link DeclarativeConfigProperties}
    */
-  @Nullable
   DeclarativeConfigProperties getInstrumentationConfig();
 
   /** Returns a no-op {@link ConfigProvider}. */
   static ConfigProvider noop() {
-    return () -> null;
+    return DeclarativeConfigProperties::empty;
   }
 }

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtil.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtil.java
@@ -124,9 +124,8 @@ public class InstrumentationConfigUtil {
 
   /**
    * Walk down the {@code segments} of {@link ConfigProvider#getInstrumentationConfig()} and call
-   * {@code accessor} on the terminal node. Returns null if {@link
-   * ConfigProvider#getInstrumentationConfig()} is null, or if null is encountered walking the
-   * {@code segments}, or if {@code accessor} returns null.
+   * {@code accessor} on the terminal node. Returns null if null is encountered walking the {@code
+   * segments}, or if {@code accessor} returns null.
    *
    * <p>See other methods in {@link InstrumentationConfigUtil} for usage examples.
    */
@@ -136,9 +135,6 @@ public class InstrumentationConfigUtil {
       Function<DeclarativeConfigProperties, T> accessor,
       String... segments) {
     DeclarativeConfigProperties config = configProvider.getInstrumentationConfig();
-    if (config == null) {
-      return null;
-    }
     for (String segment : segments) {
       config = config.getStructured(segment);
       if (config == null) {

--- a/api/incubator/src/testConvertToModel/java/io/opentelemetry/api/incubator/InstrumentationConfigUtilTest.java
+++ b/api/incubator/src/testConvertToModel/java/io/opentelemetry/api/incubator/InstrumentationConfigUtilTest.java
@@ -61,7 +61,7 @@ class InstrumentationConfigUtilTest {
 
   @Test
   void getInstrumentationConfigModel_UnsetConfig() {
-    ConfigProvider configProvider = () -> null;
+    ConfigProvider configProvider = DeclarativeConfigProperties::empty;
 
     assertThat(
             InstrumentationConfigUtil.getInstrumentationConfigModel(

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/ExtendedOpenTelemetrySdk.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/ExtendedOpenTelemetrySdk.java
@@ -11,7 +11,6 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.SdkConfigProvider;
 import java.io.Closeable;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /** A new interface for creating OpenTelemetrySdk that supports getting {@link ConfigProvider}. */
@@ -74,7 +73,6 @@ public final class ExtendedOpenTelemetrySdk extends OpenTelemetrySdk
     }
 
     @Override
-    @Nullable
     public DeclarativeConfigProperties getInstrumentationConfig() {
       return delegate.getInstrumentationConfig();
     }

--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SdkConfigProvider.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SdkConfigProvider.java
@@ -9,18 +9,22 @@ import io.opentelemetry.api.incubator.config.ConfigProvider;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
-import javax.annotation.Nullable;
 
 /** SDK implementation of {@link ConfigProvider}. */
 public final class SdkConfigProvider implements ConfigProvider {
 
-  @Nullable private final DeclarativeConfigProperties instrumentationConfig;
+  private final DeclarativeConfigProperties instrumentationConfig;
 
   private SdkConfigProvider(
       OpenTelemetryConfigurationModel model, ComponentLoader componentLoader) {
     DeclarativeConfigProperties configProperties =
         DeclarativeConfiguration.toConfigProperties(model, componentLoader);
-    this.instrumentationConfig = configProperties.getStructured("instrumentation/development");
+    DeclarativeConfigProperties instrumentationConfigOrNull =
+        configProperties.getStructured("instrumentation/development");
+    this.instrumentationConfig =
+        instrumentationConfigOrNull == null
+            ? DeclarativeConfigProperties.empty()
+            : instrumentationConfigOrNull;
   }
 
   /**
@@ -45,7 +49,6 @@ public final class SdkConfigProvider implements ConfigProvider {
     return new SdkConfigProvider(model, componentLoader);
   }
 
-  @Nullable
   @Override
   public DeclarativeConfigProperties getInstrumentationConfig() {
     return instrumentationConfig;


### PR DESCRIPTION
null-checking this all the time is awkward

This was being used to detect whether in declarative configuration world or not, but I think instrumentations can still be split brained if they really want to by first looking for the specific declarative configuration they care about and falling back to system properties.

cc @zeitlinger 