### PR TITLE
Fix intermittent Windows build failure in GraalVM integration tests

### DIFF
--- a/integration-tests/graal-incubating/build.gradle.kts
+++ b/integration-tests/graal-incubating/build.gradle.kts
@@ -49,7 +49,7 @@ graalvmNative {
 // GraalVM Native Build Tools plugin is not yet compatible with configuration cache
 // https://github.com/graalvm/native-build-tools/issues/477
 tasks.configureEach {
-  if (name.startsWith("native")) {
+  if (name.startsWith("native") || name == "test" || name == "collectReachabilityMetadata") {
     notCompatibleWithConfigurationCache("GraalVM Native Build Tools plugin is not compatible with configuration cache")
   }
 }

--- a/integration-tests/graal/build.gradle.kts
+++ b/integration-tests/graal/build.gradle.kts
@@ -46,7 +46,7 @@ graalvmNative {
 // GraalVM Native Build Tools plugin is not yet compatible with configuration cache
 // https://github.com/graalvm/native-build-tools/issues/477
 tasks.configureEach {
-  if (name.startsWith("native")) {
+  if (name.startsWith("native") || name == "test" || name == "collectReachabilityMetadata") {
     notCompatibleWithConfigurationCache("GraalVM Native Build Tools plugin is not compatible with configuration cache")
   }
 }


### PR DESCRIPTION
Attempting to fix intermittent build errors with configuration cache like this: https://github.com/open-telemetry/opentelemetry-java/actions/runs/21372325100/job/61519814680