### PR TITLE
Add assertion support for Span hasException(null)

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SpanDataAssert.java
@@ -375,18 +375,27 @@ public final class SpanDataAssert extends AbstractAssert<SpanDataAssert, SpanDat
 
   /**
    * Asserts the span has an exception event for the given {@link Throwable}. The stack trace is not
-   * matched against.
+   * matched against. If {@code exception} is {@code null}, asserts the span has no exception event.
    */
   // Workaround "passing @Nullable parameter 'stackTrace' where @NonNull is required", Nullaway
   // seems to think assertThat is supposed to be passed NonNull even though we know that can't be
   // true for assertions.
   @SuppressWarnings("NullAway")
-  public SpanDataAssert hasException(Throwable exception) {
+  public SpanDataAssert hasException(@Nullable Throwable exception) {
     EventData exceptionEvent =
         actual.getEvents().stream()
             .filter(event -> event.getName().equals(EXCEPTION_EVENT_NAME))
             .findFirst()
             .orElse(null);
+
+    if (exception == null) {
+      if (exceptionEvent != null) {
+        failWithMessage(
+            "Expected span [%s] to have no exception event but had <%s>",
+            actual.getName(), exceptionEvent);
+      }
+      return this;
+    }
 
     if (exceptionEvent == null) {
       failWithMessage(

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
@@ -301,6 +301,8 @@ class TraceAssertionsTest {
 
     assertThat(RESOURCE.getAttributes())
         .containsOnly(entry(DOG, "bark"), entry(AttributeKey.booleanKey("dog is cute"), true));
+
+    assertThat(buildTestSpan(SPAN_ID1, "span")).hasException(null);
   }
 
   @Test
@@ -563,6 +565,8 @@ class TraceAssertionsTest {
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () -> assertThat(SPAN1).hasException(new IllegalArgumentException("good argument")))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> assertThat(SPAN1).hasException(null))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasLinks()).isInstanceOf(AssertionError.class);
     assertThatThrownBy(() -> assertThat(SPAN1).hasLinks(Collections.emptyList()))


### PR DESCRIPTION
When `hasException(null)` is called, it now asserts that the span has **no exception event** instead of throwing a NullPointerException.

This would be convenient in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16049, e.g. when chaining:

```
     ...
     .hasException(emitExceptionsAsLogs()? null : exception)
     ...
```

I think the behavior reasonably follows convention:

- `hasSchemaUrl(@Nullable String)` asserts the schema URL equals the given value (including null)
- `hasBody(@Nullable Value<?>)` asserts the body equals the given value (including null)
- `equalTo(key, null)` in `hasAttributesSatisfyingExactly` asserts the attribute value is null/absent

This last one we use heavily in instrumentation repo, e.g.

```
   hasAttributesSatisfyingExactly(
     ...
     equalTo(DB_OPERATION, emitStableDatabaseSemconv() ? null : "SELECT")
     ...
   )
```
