### PR TITLE
Decode plus sign correctly in resource attributes

### DIFF
--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/ResourceConfigurationTest.java
@@ -51,6 +51,27 @@ class ResourceConfigurationTest {
   }
 
   @Test
+  void decodePlusSignInCustomConfigResource() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.service.name", "my-app");
+    props.put(
+        "otel.resource.attributes", "food=cheese+cake,drink=juice,animal=  ,color=,shape=square");
+
+    assertThat(
+            ResourceConfiguration.configureResource(
+                DefaultConfigProperties.create(props, componentLoader),
+                SpiHelper.create(ResourceConfigurationTest.class.getClassLoader()),
+                (r, c) -> r))
+        .isEqualTo(
+            Resource.getDefault().toBuilder()
+                .put(stringKey("service.name"), "my-app")
+                .put("food", "cheese+cake")
+                .put("drink", "juice")
+                .put("shape", "square")
+                .build());
+  }
+
+  @Test
   void createEnvironmentResource_Empty() {
     Attributes attributes = ResourceConfiguration.createEnvironmentResource().getAttributes();
 


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java/issues/8030

Changes made : 

- Replace the `URLDecoder.decode` method with a custom decoder 
- Unit test