### PR TITLE
Disable warning message when using traceIdSampler as root

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerBuilder.java
@@ -20,7 +20,8 @@ public final class ParentBasedSamplerBuilder {
   @Nullable private Sampler localParentNotSampled;
 
   ParentBasedSamplerBuilder(Sampler root) {
-    maybeLogTraceIdSamplerWarning(root, "root");
+    // This is the only valid traceIdSampler location according to Spec
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#compatibility-warnings-for-traceidratiobased-sampler
     this.root = root;
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSamplerBuilderTest.java
@@ -28,18 +28,16 @@ class ParentBasedSamplerBuilderTest {
         .setLocalParentNotSampled(ratioSampler)
         .build();
 
-    assertThat(logs.getEvents()).hasSize(5);
+    assertThat(logs.getEvents()).hasSize(4);
     assertThat(logs.getEvents().get(0).getMessage())
-        .contains("TraceIdRatioBasedSampler is being used as a child sampler (root)");
-    assertThat(logs.getEvents().get(1).getMessage())
         .contains(
             "TraceIdRatioBasedSampler is being used as a child sampler (remoteParentNotSampled)");
-    assertThat(logs.getEvents().get(2).getMessage())
+    assertThat(logs.getEvents().get(1).getMessage())
         .contains(
             "TraceIdRatioBasedSampler is being used as a child sampler (remoteParentSampled)");
-    assertThat(logs.getEvents().get(3).getMessage())
+    assertThat(logs.getEvents().get(2).getMessage())
         .contains("TraceIdRatioBasedSampler is being used as a child sampler (localParentSampled)");
-    assertThat(logs.getEvents().get(4).getMessage())
+    assertThat(logs.getEvents().get(3).getMessage())
         .contains(
             "TraceIdRatioBasedSampler is being used as a child sampler (localParentNotSampled)");
   }


### PR DESCRIPTION
Closes #8064

I believe this warning was added incorrectly during refactoring: https://github.com/open-telemetry/opentelemetry-java/pull/7948/changes#diff-f5b51b22d75fd6b9122f6e30138f8688a744a5d168088e0f5ddb7fa4579a2f7cR23