### PR TITLE
Fix japicmp

### DIFF
--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -74,7 +74,7 @@ fun getAllPublishedModules(): List<Project> {
   }.toList()
 }
 
-fun getOldClassPath(version: String): List<File> {
+fun getClasspathForVersion(version: String): List<File> {
   // Temporarily change the group name because we want to fetch an artifact with the same
   // Maven coordinates as the project, which Gradle would not allow otherwise.
   val existingGroup = group
@@ -95,7 +95,7 @@ fun getOldClassPath(version: String): List<File> {
   }
 }
 
-fun getNewClassPath(): List<File> {
+fun getCurrentClassPath(): List<File> {
   return getAllPublishedModules().map {
     val archiveFile = it.tasks.getByName<Jar>("jar").archiveFile
     archiveFile.get().asFile
@@ -125,8 +125,8 @@ if (!project.hasProperty("otel.release") && !project.name.startsWith("bom")) {
         // and generates false positive compatibility errors when methods are lifted into superclasses,
         // superinterfaces.
         val archiveName = base.archivesName.get()
-        val newClassPath = getNewClassPath()
-        val oldClassPath = getOldClassPath(baselineVersion)
+        val newClassPath = apiNewVersion?.let { getClasspathForVersion(it) } ?: getCurrentClassPath()
+        val oldClassPath = getClasspathForVersion(baselineVersion)
         val pattern = (archiveName + "-([0-9\\.]*)(-SNAPSHOT)?.jar").toRegex()
         val newArchive = newClassPath.singleOrNull { it.name.matches(pattern) }
         val oldArchive = oldClassPath.singleOrNull { it.name.matches(pattern) }

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-api.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-api.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-api-1.60.0-SNAPSHOT.jar against opentelemetry-api-1.58.0.jar
+Comparing source compatibility of opentelemetry-api-1.59.0.jar against opentelemetry-api-1.58.0.jar
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.api.common.AttributeKey  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	GENERIC TEMPLATES: === T:java.lang.Object

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-common.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-common.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-common-1.60.0-SNAPSHOT.jar against opentelemetry-common-1.58.0.jar
+Comparing source compatibility of opentelemetry-common-1.59.0.jar against opentelemetry-common-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-context.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-context.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-context-1.60.0-SNAPSHOT.jar against opentelemetry-context-1.58.0.jar
+Comparing source compatibility of opentelemetry-context-1.59.0.jar against opentelemetry-context-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-common.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-common.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-common-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-common-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-common-1.59.0.jar against opentelemetry-exporter-common-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-logging-otlp.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-logging-otlp.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-logging-otlp-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-logging-otlp-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-logging-otlp-1.59.0.jar against opentelemetry-exporter-logging-otlp-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-logging.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-logging.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-logging-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-logging-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-logging-1.59.0.jar against opentelemetry-exporter-logging-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-otlp-common.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-otlp-common.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-otlp-common-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-otlp-common-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-otlp-common-1.59.0.jar against opentelemetry-exporter-otlp-common-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-otlp-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-otlp-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-otlp-1.59.0.jar against opentelemetry-exporter-otlp-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-grpc-managed-channel.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-grpc-managed-channel.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-sender-grpc-managed-channel-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-sender-grpc-managed-channel-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-sender-grpc-managed-channel-1.59.0.jar against opentelemetry-exporter-sender-grpc-managed-channel-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-jdk.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-jdk.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-sender-jdk-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-sender-jdk-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-sender-jdk-1.59.0.jar against opentelemetry-exporter-sender-jdk-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-okhttp.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-sender-okhttp.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-exporter-sender-okhttp-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-sender-okhttp-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-sender-okhttp-1.59.0.jar against opentelemetry-exporter-sender-okhttp-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-zipkin.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-exporter-zipkin.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-exporter-zipkin-1.60.0-SNAPSHOT.jar against opentelemetry-exporter-zipkin-1.58.0.jar
+Comparing source compatibility of opentelemetry-exporter-zipkin-1.59.0.jar against opentelemetry-exporter-zipkin-1.58.0.jar
 ===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.exporter.zipkin.ZipkinSpanExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW ANNOTATION: java.lang.Deprecated

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-extension-kotlin.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-extension-kotlin.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-extension-kotlin-1.60.0-SNAPSHOT.jar against opentelemetry-extension-kotlin-1.58.0.jar
+Comparing source compatibility of opentelemetry-extension-kotlin-1.59.0.jar against opentelemetry-extension-kotlin-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-extension-trace-propagators.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-extension-trace-propagators.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-extension-trace-propagators-1.60.0-SNAPSHOT.jar against opentelemetry-extension-trace-propagators-1.58.0.jar
+Comparing source compatibility of opentelemetry-extension-trace-propagators-1.59.0.jar against opentelemetry-extension-trace-propagators-1.58.0.jar
 ===  UNCHANGED CLASS: PUBLIC FINAL io.opentelemetry.extension.trace.propagation.JaegerPropagator  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW ANNOTATION: java.lang.Deprecated

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-opentracing-shim.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-opentracing-shim.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-opentracing-shim-1.60.0-SNAPSHOT.jar against opentelemetry-opentracing-shim-1.58.0.jar
+Comparing source compatibility of opentelemetry-opentracing-shim-1.59.0.jar against opentelemetry-opentracing-shim-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-common.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-common.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-sdk-common-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-common-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-common-1.59.0.jar against opentelemetry-sdk-common-1.58.0.jar
 +++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.sdk.common.export.Compressor  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	+++  NEW SUPERCLASS: java.lang.Object

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-autoconfigure-spi.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-autoconfigure-spi.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-extension-autoconfigure-spi-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-extension-autoconfigure-spi-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-extension-autoconfigure-spi-1.59.0.jar against opentelemetry-sdk-extension-autoconfigure-spi-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-autoconfigure.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-autoconfigure.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-extension-autoconfigure-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-extension-autoconfigure-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-extension-autoconfigure-1.59.0.jar against opentelemetry-sdk-extension-autoconfigure-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-extension-jaeger-remote-sampler.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-extension-jaeger-remote-sampler-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-extension-jaeger-remote-sampler-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-extension-jaeger-remote-sampler-1.59.0.jar against opentelemetry-sdk-extension-jaeger-remote-sampler-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-logs.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-logs-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-logs-1.59.0.jar against opentelemetry-sdk-logs-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-metrics-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-metrics-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-metrics-1.59.0.jar against opentelemetry-sdk-metrics-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-testing.txt
@@ -1,4 +1,4 @@
-Comparing source compatibility of opentelemetry-sdk-testing-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-testing-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-testing-1.59.0.jar against opentelemetry-sdk-testing-1.58.0.jar
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.AttributesAssert  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.AttributesAssert containsEntry(java.lang.String, io.opentelemetry.api.common.Value<?>)

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk-trace.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-trace-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-trace-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-trace-1.59.0.jar against opentelemetry-sdk-trace-1.58.0.jar
 No changes.

--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-sdk.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-sdk-1.60.0-SNAPSHOT.jar against opentelemetry-sdk-1.58.0.jar
+Comparing source compatibility of opentelemetry-sdk-1.59.0.jar against opentelemetry-sdk-1.58.0.jar
 No changes.


### PR DESCRIPTION
Resolves #7972 

The recent post release #8056 japicmp step once again compared the wrong api versions.

Got around to fixing it so it doesn't happen again.