### PR TITLE
fix(config): Cache component providers in DeclarativeConfigContext

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContext.java
@@ -26,6 +26,7 @@ class DeclarativeConfigContext {
   private final List<Closeable> closeables = new ArrayList<>();
   @Nullable private volatile MeterProvider meterProvider;
   @Nullable private Resource resource = null;
+  @Nullable private List<ComponentProvider> componentProviders = null;
 
   // Visible for testing
   DeclarativeConfigContext(SpiHelper spiHelper) {
@@ -87,8 +88,9 @@ class DeclarativeConfigContext {
     String name = configKeyValue.getKey();
     DeclarativeConfigProperties config = configKeyValue.getValue();
 
-    // TODO(jack-berg): cache loaded component providers
-    List<ComponentProvider> componentProviders = spiHelper.load(ComponentProvider.class);
+    if (componentProviders == null) {
+      componentProviders = spiHelper.load(ComponentProvider.class);
+    }
     List<ComponentProvider> matchedProviders =
         componentProviders.stream()
             .filter(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContextTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/DeclarativeConfigContextTest.java
@@ -7,10 +7,17 @@ package io.opentelemetry.sdk.extension.incubator.fileconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
 import io.opentelemetry.common.ComponentLoader;
+import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DeclarativeConfigContextTest {
@@ -25,5 +32,42 @@ class DeclarativeConfigContextTest {
     Resource resource = Resource.empty();
     context.setResource(resource);
     assertThat(context.getResource()).isSameAs(resource);
+  }
+
+  @Test
+  void componentProvidersCached() {
+    SpiHelper spiHelper =
+        spy(SpiHelper.create(DeclarativeConfigContextTest.class.getClassLoader()));
+    DeclarativeConfigContext context = new DeclarativeConfigContext(spiHelper);
+
+    ComponentLoader componentLoader =
+        ComponentLoader.forClassLoader(DeclarativeConfigContextTest.class.getClassLoader());
+
+    // First loadComponent call should load providers
+    assertThatThrownBy(
+            () ->
+                context.loadComponent(
+                    Resource.class,
+                    ConfigKeyValue.of(
+                        "nonexistent",
+                        YamlDeclarativeConfigProperties.create(
+                            Collections.emptyMap(), componentLoader))))
+        .isInstanceOf(DeclarativeConfigException.class)
+        .hasMessageContaining("No component provider detected");
+
+    // Second loadComponent call should use cached providers, not reload
+    assertThatThrownBy(
+            () ->
+                context.loadComponent(
+                    Resource.class,
+                    ConfigKeyValue.of(
+                        "another",
+                        YamlDeclarativeConfigProperties.create(
+                            Collections.emptyMap(), componentLoader))))
+        .isInstanceOf(DeclarativeConfigException.class)
+        .hasMessageContaining("No component provider detected");
+
+    // Verify spiHelper.load() was only called once
+    verify(spiHelper, times(1)).load(ComponentProvider.class);
   }
 }


### PR DESCRIPTION
Fixes a TODO left by @jack-berg in the configuration file to cache the config providers instead of repeat loading.