### PR TITLE
Fix javadoc copypasta/typo

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProviderBuilder.java
@@ -190,7 +190,8 @@ public final class SdkLoggerProviderBuilder {
 
   /**
    * Sets the {@link MeterProvider} to use to generate <a
-   * href="https://opentelemetry.io/docs/specs/semconv/otel/sdk-metrics/#log-metrics">SDK Log Metrics</a>.
+   * href="https://opentelemetry.io/docs/specs/semconv/otel/sdk-metrics/#log-metrics">SDK Log
+   * Metrics</a>.
    *
    * @since 1.58.0
    */


### PR DESCRIPTION
I ran into a small copypasta issue in the javadoc for the `SdkLoggerProviderBuilder`.