### PR TITLE
Small refactoring to make safety clearer

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/JsonEncoding.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/JsonEncoding.java
@@ -37,7 +37,7 @@ final class JsonEncoding {
         appendMap(sb, (List<KeyValue>) value.getValue());
         break;
       case BYTES:
-        appendBytes(sb, (ByteBuffer) value.getValue());
+        appendBytes(sb, (Value<ByteBuffer>) value);
         break;
       case EMPTY:
         sb.append("null");
@@ -97,9 +97,11 @@ final class JsonEncoding {
     }
   }
 
-  private static void appendBytes(StringBuilder sb, ByteBuffer value) {
-    byte[] bytes = new byte[value.remaining()];
-    value.get(bytes);
+  private static void appendBytes(StringBuilder sb, Value<ByteBuffer> value) {
+    ByteBuffer buf = value.getValue();
+    byte[] bytes = new byte[buf.remaining()];
+    // getValue() above returns a new ByteBuffer, so mutating its position here is safe
+    buf.get(bytes);
     sb.append('"').append(Base64.getEncoder().encodeToString(bytes)).append('"');
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueMarshaler.java
@@ -37,7 +37,7 @@ public final class AnyValueMarshaler {
       case KEY_VALUE_LIST:
         return KeyValueListAnyValueMarshaler.create((List<KeyValue>) value.getValue());
       case BYTES:
-        return BytesAnyValueMarshaler.create((ByteBuffer) value.getValue());
+        return BytesAnyValueMarshaler.create((Value<ByteBuffer>) value);
       case EMPTY:
         return EmptyAnyValueMarshaler.INSTANCE;
     }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueStatelessMarshaler.java
@@ -63,7 +63,7 @@ public final class AnyValueStatelessMarshaler implements StatelessMarshaler<Valu
         return;
       case BYTES:
         BytesAnyValueStatelessMarshaler.INSTANCE.writeTo(
-            output, (ByteBuffer) value.getValue(), context);
+            output, (Value<ByteBuffer>) value, context);
         return;
       case EMPTY:
         // no field to write
@@ -104,7 +104,7 @@ public final class AnyValueStatelessMarshaler implements StatelessMarshaler<Valu
             context);
       case BYTES:
         return BytesAnyValueStatelessMarshaler.INSTANCE.getBinarySerializedSize(
-            (ByteBuffer) value.getValue(), context);
+            (Value<ByteBuffer>) value, context);
       case EMPTY:
         return 0;
     }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BytesAnyValueMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BytesAnyValueMarshaler.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.internal.otlp;
 
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.exporter.internal.marshal.CodedOutputStream;
 import io.opentelemetry.exporter.internal.marshal.MarshalerWithSize;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
@@ -21,9 +22,11 @@ final class BytesAnyValueMarshaler extends MarshalerWithSize {
     this.value = value;
   }
 
-  static MarshalerWithSize create(ByteBuffer value) {
-    byte[] bytes = new byte[value.remaining()];
-    value.get(bytes);
+  static MarshalerWithSize create(Value<ByteBuffer> value) {
+    ByteBuffer buf = value.getValue();
+    byte[] bytes = new byte[buf.remaining()];
+    // getValue() above returns a new ByteBuffer, so mutating its position here is safe
+    buf.get(bytes);
     return new BytesAnyValueMarshaler(bytes);
   }
 

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BytesAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/BytesAnyValueStatelessMarshaler.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.exporter.internal.otlp;
 
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.exporter.internal.marshal.CodedOutputStream;
 import io.opentelemetry.exporter.internal.marshal.MarshalerContext;
 import io.opentelemetry.exporter.internal.marshal.Serializer;
@@ -14,22 +15,24 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /** See {@link BytesAnyValueMarshaler}. */
-final class BytesAnyValueStatelessMarshaler implements StatelessMarshaler<ByteBuffer> {
+final class BytesAnyValueStatelessMarshaler implements StatelessMarshaler<Value<ByteBuffer>> {
   static final BytesAnyValueStatelessMarshaler INSTANCE = new BytesAnyValueStatelessMarshaler();
 
   private BytesAnyValueStatelessMarshaler() {}
 
   @Override
-  public void writeTo(Serializer output, ByteBuffer value, MarshalerContext context)
+  public void writeTo(Serializer output, Value<ByteBuffer> value, MarshalerContext context)
       throws IOException {
     byte[] bytes = context.getData(byte[].class);
     output.writeBytes(AnyValue.BYTES_VALUE, bytes);
   }
 
   @Override
-  public int getBinarySerializedSize(ByteBuffer value, MarshalerContext context) {
-    byte[] bytes = new byte[value.remaining()];
-    value.get(bytes);
+  public int getBinarySerializedSize(Value<ByteBuffer> value, MarshalerContext context) {
+    ByteBuffer buf = value.getValue();
+    byte[] bytes = new byte[buf.remaining()];
+    // getValue() above returns a new ByteBuffer, so mutating its position here is safe
+    buf.get(bytes);
     context.addData(bytes);
     return AnyValue.BYTES_VALUE.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(bytes);
   }


### PR DESCRIPTION
Alternatively, I can just add comment explaining that the safety relies on the caller not reusing the byte buffer