### PR TITLE
Exclude META-INF/maven from traces sdk shaded dependencies

### DIFF
--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -17,6 +17,7 @@ tasks {
   shadowJar {
     minimize()
 
+    exclude("META-INF/maven/**")
     relocate("org.jctools", "io.opentelemetry.internal.shaded.jctools")
   }
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16198#discussion_r2814648218