### PR TITLE
docs(logs): clarify setTimestamp javadoc for event timestamp behavior

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -5,19 +5,18 @@
 
 package io.opentelemetry.api.logs;
 
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-
-import io.opentelemetry.api.common.AttributeKey;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.context.Context;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Used to construct and emit log records from a {@link Logger}.


### PR DESCRIPTION
## Summary

The Javadoc for `LogRecordBuilder#setTimestamp` previously stated:

> "If unset, it will be set to the current time when emit() is called."

This is incorrect: the implementation only provides a default value for the **observed timestamp**,  
not for the **event timestamp**.

This PR updates the Javadoc to clarify that:

- Unset **event timestamps** are **NOT automatically populated** when `emit()` is called.
- Only the **observed timestamp** receives a default value.

---

## Related Issue

Fixes #8097  <!-- replace with actual issue number if available -->

---

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] Code change
