### PR TITLE
[exporters] Native Marshallers should always write SUM

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointMarshaler.java
@@ -124,7 +124,7 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
     output.serializeFixed64(ExponentialHistogramDataPoint.START_TIME_UNIX_NANO, startTimeUnixNano);
     output.serializeFixed64(ExponentialHistogramDataPoint.TIME_UNIX_NANO, timeUnixNano);
     output.serializeFixed64(ExponentialHistogramDataPoint.COUNT, count);
-    output.serializeDouble(ExponentialHistogramDataPoint.SUM, sum);
+    output.serializeDoubleOptional(ExponentialHistogramDataPoint.SUM, sum);
     if (hasMin) {
       output.serializeDoubleOptional(ExponentialHistogramDataPoint.MIN, min);
     }
@@ -161,7 +161,7 @@ public class ExponentialHistogramDataPointMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.TIME_UNIX_NANO, timeUnixNano);
     size += MarshalerUtil.sizeSInt32(ExponentialHistogramDataPoint.SCALE, scale);
     size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.COUNT, count);
-    size += MarshalerUtil.sizeDouble(ExponentialHistogramDataPoint.SUM, sum);
+    size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.SUM, sum);
     if (hasMin) {
       size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MIN, min);
     }

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/ExponentialHistogramDataPointStatelessMarshaler.java
@@ -31,7 +31,7 @@ final class ExponentialHistogramDataPointStatelessMarshaler
         ExponentialHistogramDataPoint.START_TIME_UNIX_NANO, point.getStartEpochNanos());
     output.serializeFixed64(ExponentialHistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
     output.serializeFixed64(ExponentialHistogramDataPoint.COUNT, point.getCount());
-    output.serializeDouble(ExponentialHistogramDataPoint.SUM, point.getSum());
+    output.serializeDoubleOptional(ExponentialHistogramDataPoint.SUM, point.getSum());
     if (point.hasMin()) {
       output.serializeDoubleOptional(ExponentialHistogramDataPoint.MIN, point.getMin());
     }
@@ -73,7 +73,7 @@ final class ExponentialHistogramDataPointStatelessMarshaler
         MarshalerUtil.sizeFixed64(
             ExponentialHistogramDataPoint.TIME_UNIX_NANO, point.getEpochNanos());
     size += MarshalerUtil.sizeFixed64(ExponentialHistogramDataPoint.COUNT, point.getCount());
-    size += MarshalerUtil.sizeDouble(ExponentialHistogramDataPoint.SUM, point.getSum());
+    size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.SUM, point.getSum());
     if (point.hasMin()) {
       size += MarshalerUtil.sizeDoubleOptional(ExponentialHistogramDataPoint.MIN, point.getMin());
     }

--- a/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
+++ b/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/metrics/MetricsRequestMarshalerTest.java
@@ -531,6 +531,42 @@ class MetricsRequestMarshalerTest {
                 .build());
   }
 
+  @ParameterizedTest
+  @EnumSource(MarshalerSource.class)
+  void exponentialHistogramZeroSum(MarshalerSource marshalerSource) {
+    assertThat(
+            toExponentialHistogramDataPoints(
+                marshalerSource,
+                ImmutableList.of(
+                    ImmutableExponentialHistogramPointData.create(
+                        0,
+                        0,
+                        0,
+                        /* hasMin= */ false,
+                        0,
+                        /* hasMax= */ false,
+                        0,
+                        ImmutableExponentialHistogramBuckets.create(0, 0, Collections.emptyList()),
+                        ImmutableExponentialHistogramBuckets.create(0, 0, Collections.emptyList()),
+                        123,
+                        456,
+                        Attributes.empty(),
+                        Collections.emptyList()))))
+        .containsExactly(
+            ExponentialHistogramDataPoint.newBuilder()
+                .setStartTimeUnixNano(123)
+                .setTimeUnixNano(456)
+                .setCount(0)
+                .setScale(0)
+                .setSum(0)
+                .setZeroCount(0)
+                .setPositive(
+                    ExponentialHistogramDataPoint.Buckets.newBuilder().setOffset(0)) // no buckets
+                .setNegative(
+                    ExponentialHistogramDataPoint.Buckets.newBuilder().setOffset(0)) // no buckets
+                .build());
+  }
+
   @SuppressWarnings("PointlessArithmeticExpression")
   @ParameterizedTest
   @EnumSource(MarshalerSource.class)


### PR DESCRIPTION
Problem
=========

We found that sometimes we would export bad values from otel when the sum was 0 when we were also exporting deltas. My colleague @natasha-aleksandrova found that this was because the native histogram marshalers would omit the sum, since they were using the old `serializeDouble` method, instead of `serializeDoubleOptional`.

Solution
=========
Update the marshallers to use `serializeDoubleOptional` and add a test. I confirmed that the test fails before the change, and passes after the change.

Result
========

The native marshalers properly export the histogram even when the sum is 0!
