### PR TITLE
sdk-logs: default event timestamp on emit

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java
@@ -31,22 +31,22 @@ public interface LogRecordBuilder {
   /**
    * Set the epoch {@code timestamp}, using the timestamp and unit.
    *
-   * <p>The {@code timestamp} is the time at which the log record occurred.
-   * If unset, the timestamp will remain unset.
+   * <p>The {@code timestamp} is the time at which the log record occurred. If unset, the timestamp
+   * will remain unset.
    *
-   * <p>The observed timestamp will be set to the current time when {@link #emit()}
-   * is called if it is not explicitly set.
+   * <p>The observed timestamp will be set to the current time when {@link #emit()} is called if it
+   * is not explicitly set.
    */
   LogRecordBuilder setTimestamp(long timestamp, TimeUnit unit);
 
   /**
    * Set the epoch {@code timestamp}, using the timestamp and unit.
    *
-   * <p>The {@code timestamp} is the time at which the log record occurred.
-   * If unset, the timestamp will remain unset.
+   * <p>The {@code timestamp} is the time at which the log record occurred. If unset, the timestamp
+   * will remain unset.
    *
-   * <p>The observed timestamp will be set to the current time when {@link #emit()}
-   * is called if it is not explicitly set.
+   * <p>The observed timestamp will be set to the current time when {@link #emit()} is called if it
+   * is not explicitly set.
    */
   LogRecordBuilder setTimestamp(Instant instant);
 


### PR DESCRIPTION
Fixes #8097

### What this changes

*Default event timestamp to `clock.now()` in `SdkLogRecordBuilder.emit()` when not explicitly set.
* This aligns behavior with the `setTimestamp` javadoc (timestamp should default at emit time).
* Updated `emit_NoFields` test accordingly.

### Testing

* Ran `:sdk:logs:test`

* Opening as a draft PR to coordinate and avoid duplicate work if someone else is already working on this.
