### PR TITLE
fix: use KeyManagerFactory.getDefaultAlgorithm() in TlsUtil.keyManager()

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsUtil.java
@@ -84,7 +84,7 @@ public final class TlsUtil {
       ks.setKeyEntry("trusted", key, "".toCharArray(), chain.toArray(new Certificate[] {}));
 
       KeyManagerFactory kmf =
-          KeyManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+          KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
       kmf.init(ks, "".toCharArray());
       return (X509KeyManager) kmf.getKeyManagers()[0];
     } catch (CertificateException


### PR DESCRIPTION
TlsUtil.keyManager() was incorrectly using TrustManagerFactory.getDefaultAlgorithm() to initialize KeyManagerFactory, which could cause NoSuchAlgorithmException.

Fixes #8112