### PR TITLE
Fix inverted condition in LegacySpanProcessorInstrumentation#finishSpans

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/LegacySpanProcessorInstrumentation.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/LegacySpanProcessorInstrumentation.java
@@ -58,7 +58,7 @@ final class LegacySpanProcessorInstrumentation implements SpanProcessorInstrumen
   @Override
   public void finishSpans(int count, @Nullable String error) {
     // Legacy metrics only record when no error.
-    if (error != null) {
+    if (error == null) {
       processedSpans().add(count, standardAttrs);
     }
   }


### PR DESCRIPTION
Resolves #8142

## Summary
Fix the inverted condition in `LegacySpanProcessorInstrumentation#finishSpans()` that prevents the `processedSpans` metric from being reported correctly.

The comment states "Legacy metrics only record when no error", but the condition was `error != null` (records only when there IS an error). Changed to `error == null` to match the intended behavior.

## Changes
- `sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/LegacySpanProcessorInstrumentation.java`: Changed `error != null` to `error == null` in `finishSpans()` method.