### PR TITLE
Prepare changelog for 1.60.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### SDK
+
+#### Extensions
+
+* Autoconfigure: fix warning always emitted
+  ([#8157](https://github.com/open-telemetry/opentelemetry-java/pull/8157))
+
 ## Version 1.60.0 (2026-03-06)
 
 ### API


### PR DESCRIPTION
#8159 targeted the main instead of `release/v1.60.x`