### PR TITLE
Add repository AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,3 @@ build and test commands, style expectations, and scope.
 Additional guidance for agents:
 
 * Prefer small, localized changes over broad refactors.
-* Mention generated outputs such as `docs/apidiffs/current_vs_latest` when they are affected.


### PR DESCRIPTION
## Summary
- add a root AGENTS.md with repository-specific guidance for working in opentelemetry-java
- document module layout, build and test entry points, style expectations, and repo-specific constraints

## Testing
- not run (docs-only change)