### PR TITLE
Migrate to new bare metal runner (Ubuntu 24)

### DIFF
--- a/.github/workflows/benchmark-tags.yml
+++ b/.github/workflows/benchmark-tags.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write # for git push to benchmarks branch
     name: Benchmark SDK
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:24.04@sha256:d1e2e92c075e5ca139d51a140fff46f84315c0fdce203eab2807c7e495eff4f9
     timeout-minutes: 20 # since there is only a single bare metal runner across all repos

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # for git push to benchmarks branch
     name: Benchmark SDK
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:24.04@sha256:d1e2e92c075e5ca139d51a140fff46f84315c0fdce203eab2807c7e495eff4f9
     timeout-minutes: 20 # since there is only a single bare metal runner across all repos


### PR DESCRIPTION
Old runner:

- name: `oracle-bare-metal-64cpu-512gb-x86-64`
- 512gb memory
- Oracle Linux 8

New runner:

-  name: `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`
- 1024gb memory
-  Ubuntu 24

I realize this could have some impact on benchmark baselines, so please post on https://github.com/open-telemetry/community/issues/3333 once you have migrated and are comfortable with the old one being removed.
