### PR TITLE
Add fallback endpoint support for OTLP exporters

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-otlp.txt
@@ -1,2 +1,19 @@
 Comparing source compatibility of opentelemetry-exporter-otlp-1.61.0-SNAPSHOT.jar against opentelemetry-exporter-otlp-1.60.1.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder setFallbackEndpoint(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder setFallbackEndpoint(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder setFallbackEndpoint(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder setFallbackEndpoint(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder setFallbackEndpoint(java.lang.String)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder setFallbackEndpoint(java.lang.String)

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
@@ -17,10 +17,12 @@ import io.opentelemetry.sdk.common.export.GrpcStatusCode;
 import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * Generic gRPC exporter.
@@ -41,6 +43,7 @@ public final class GrpcExporter {
 
   private final String type;
   private final GrpcSender grpcSender;
+  @Nullable private final GrpcSender fallbackGrpcSender;
   private final ExporterInstrumentation exporterMetrics;
 
   public GrpcExporter(
@@ -49,8 +52,19 @@ public final class GrpcExporter {
       StandardComponentId componentId,
       Supplier<MeterProvider> meterProviderSupplier,
       URI endpoint) {
+    this(grpcSender, internalTelemetryVersion, componentId, meterProviderSupplier, endpoint, null);
+  }
+
+  public GrpcExporter(
+      GrpcSender grpcSender,
+      InternalTelemetryVersion internalTelemetryVersion,
+      StandardComponentId componentId,
+      Supplier<MeterProvider> meterProviderSupplier,
+      URI endpoint,
+      @Nullable GrpcSender fallbackGrpcSender) {
     this.type = componentId.getStandardType().signal().logFriendlyName();
     this.grpcSender = grpcSender;
+    this.fallbackGrpcSender = fallbackGrpcSender;
     this.exporterMetrics =
         new ExporterInstrumentation(
             internalTelemetryVersion, meterProviderSupplier, componentId, endpoint);
@@ -69,7 +83,22 @@ public final class GrpcExporter {
     grpcSender.send(
         exportRequest.toBinaryMessageWriter(),
         grpcResponse -> onResponse(result, metricRecording, grpcResponse),
-        throwable -> onError(result, metricRecording, throwable));
+        throwable -> {
+          if (fallbackGrpcSender != null) {
+            logger.log(
+                Level.INFO,
+                "Primary endpoint failed for "
+                    + type
+                    + "s, attempting fallback endpoint. Error: "
+                    + throwable.getMessage());
+            fallbackGrpcSender.send(
+                exportRequest.toBinaryMessageWriter(),
+                grpcResponse -> onResponse(result, metricRecording, grpcResponse),
+                fallbackThrowable -> onError(result, metricRecording, fallbackThrowable));
+          } else {
+            onError(result, metricRecording, throwable);
+          }
+        });
 
     return result;
   }
@@ -143,6 +172,11 @@ public final class GrpcExporter {
       logger.log(Level.INFO, "Calling shutdown() multiple times.");
       return CompletableResultCode.ofSuccess();
     }
-    return grpcSender.shutdown();
+    CompletableResultCode primaryResult = grpcSender.shutdown();
+    if (fallbackGrpcSender != null) {
+      CompletableResultCode fallbackResult = fallbackGrpcSender.shutdown();
+      return CompletableResultCode.ofAll(Arrays.asList(primaryResult, fallbackResult));
+    }
+    return primaryResult;
   }
 }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterBuilder.java
@@ -57,6 +57,7 @@ public class GrpcExporterBuilder {
   private Duration timeout;
   private Duration connectTimeout = Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECS);
   private URI endpoint;
+  @Nullable private URI fallbackEndpoint;
   @Nullable private Compressor compressor;
   private final Map<String, String> constantHeaders = new HashMap<>();
   private Supplier<Map<String, String>> headerSupplier = Collections::emptyMap;
@@ -101,6 +102,11 @@ public class GrpcExporterBuilder {
 
   public GrpcExporterBuilder setEndpoint(String endpoint) {
     this.endpoint = ExporterBuilderUtil.validateEndpoint(endpoint);
+    return this;
+  }
+
+  public GrpcExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    this.fallbackEndpoint = ExporterBuilderUtil.validateEndpoint(fallbackEndpoint);
     return this;
   }
 
@@ -190,6 +196,7 @@ public class GrpcExporterBuilder {
     copy.internalTelemetryVersion = internalTelemetryVersion;
     copy.grpcChannel = grpcChannel;
     copy.componentLoader = componentLoader;
+    copy.fallbackEndpoint = fallbackEndpoint;
     return copy;
   }
 
@@ -233,12 +240,33 @@ public class GrpcExporterBuilder {
                 grpcChannel));
     LOGGER.log(Level.FINE, "Using GrpcSender: " + grpcSender.getClass().getName());
 
+    GrpcSender fallbackSender = null;
+    if (fallbackEndpoint != null) {
+      boolean isFallbackPlainHttp = "http".equals(fallbackEndpoint.getScheme());
+      fallbackSender =
+          grpcSenderProvider.createSender(
+              ImmutableGrpcSenderConfig.create(
+                  fallbackEndpoint,
+                  fullMethodName,
+                  compressor,
+                  timeout,
+                  connectTimeout,
+                  headerSupplier,
+                  retryPolicy,
+                  isFallbackPlainHttp ? null : tlsConfigHelper.getSslContext(),
+                  isFallbackPlainHttp ? null : tlsConfigHelper.getTrustManager(),
+                  executorService,
+                  grpcChannel));
+      LOGGER.log(Level.FINE, "Using fallback GrpcSender: " + fallbackSender.getClass().getName());
+    }
+
     return new GrpcExporter(
         grpcSender,
         internalTelemetryVersion,
         ComponentId.generateLazy(exporterType),
         meterProviderSupplier,
-        endpoint);
+        endpoint,
+        fallbackSender);
   }
 
   public String toString(boolean includePrefixAndSuffix) {
@@ -247,6 +275,9 @@ public class GrpcExporterBuilder {
             ? new StringJoiner(", ", "GrpcExporterBuilder{", "}")
             : new StringJoiner(", ");
     joiner.add("endpoint=" + endpoint.toString());
+    if (fallbackEndpoint != null) {
+      joiner.add("fallbackEndpoint=" + fallbackEndpoint);
+    }
     joiner.add("fullMethodName=" + fullMethodName);
     joiner.add("timeoutNanos=" + timeout.toNanos());
     joiner.add("connectTimeoutNanos=" + connectTimeout.toNanos());

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporter.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporter.java
@@ -19,6 +19,7 @@ import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -41,6 +42,7 @@ public final class HttpExporter {
 
   private final String type;
   private final HttpSender httpSender;
+  @Nullable private final HttpSender fallbackHttpSender;
   private final ExporterInstrumentation exporterMetrics;
   private final boolean exportAsJson;
 
@@ -51,8 +53,27 @@ public final class HttpExporter {
       InternalTelemetryVersion internalTelemetryVersion,
       URI endpoint,
       boolean exportAsJson) {
+    this(
+        componentId,
+        httpSender,
+        meterProviderSupplier,
+        internalTelemetryVersion,
+        endpoint,
+        exportAsJson,
+        null);
+  }
+
+  public HttpExporter(
+      StandardComponentId componentId,
+      HttpSender httpSender,
+      Supplier<MeterProvider> meterProviderSupplier,
+      InternalTelemetryVersion internalTelemetryVersion,
+      URI endpoint,
+      boolean exportAsJson,
+      @Nullable HttpSender fallbackHttpSender) {
     this.type = componentId.getStandardType().signal().logFriendlyName();
     this.httpSender = httpSender;
+    this.fallbackHttpSender = fallbackHttpSender;
     this.exporterMetrics =
         new ExporterInstrumentation(
             internalTelemetryVersion, meterProviderSupplier, componentId, endpoint);
@@ -74,7 +95,26 @@ public final class HttpExporter {
     httpSender.send(
         messageWriter,
         httpResponse -> onResponse(result, metricRecording, httpResponse),
-        throwable -> onError(result, metricRecording, throwable));
+        throwable -> {
+          if (fallbackHttpSender != null) {
+            logger.log(
+                Level.INFO,
+                "Primary endpoint failed for "
+                    + type
+                    + "s, attempting fallback endpoint. Error: "
+                    + throwable.getMessage());
+            MessageWriter fallbackMessageWriter =
+                exportAsJson
+                    ? exportRequest.toJsonMessageWriter()
+                    : exportRequest.toBinaryMessageWriter();
+            fallbackHttpSender.send(
+                fallbackMessageWriter,
+                httpResponse -> onResponse(result, metricRecording, httpResponse),
+                fallbackThrowable -> onError(result, metricRecording, fallbackThrowable));
+          } else {
+            onError(result, metricRecording, throwable);
+          }
+        });
 
     return result;
   }
@@ -131,7 +171,12 @@ public final class HttpExporter {
       logger.log(Level.INFO, "Calling shutdown() multiple times.");
       return CompletableResultCode.ofSuccess();
     }
-    return httpSender.shutdown();
+    CompletableResultCode primaryResult = httpSender.shutdown();
+    if (fallbackHttpSender != null) {
+      CompletableResultCode fallbackResult = fallbackHttpSender.shutdown();
+      return CompletableResultCode.ofAll(Arrays.asList(primaryResult, fallbackResult));
+    }
+    return primaryResult;
   }
 
   private static String extractErrorStatus(String statusMessage, @Nullable byte[] responseBody) {

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/http/HttpExporterBuilder.java
@@ -53,6 +53,7 @@ public final class HttpExporterBuilder {
   private StandardComponentId.ExporterType exporterType;
 
   private URI endpoint;
+  @Nullable private URI fallbackEndpoint;
 
   private Duration timeout = Duration.ofSeconds(DEFAULT_TIMEOUT_SECS);
   @Nullable private Compressor compressor;
@@ -93,6 +94,11 @@ public final class HttpExporterBuilder {
 
   public HttpExporterBuilder setEndpoint(String endpoint) {
     this.endpoint = ExporterBuilderUtil.validateEndpoint(endpoint);
+    return this;
+  }
+
+  public HttpExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    this.fallbackEndpoint = ExporterBuilderUtil.validateEndpoint(fallbackEndpoint);
     return this;
   }
 
@@ -205,6 +211,7 @@ public final class HttpExporterBuilder {
     copy.internalTelemetryVersion = internalTelemetryVersion;
     copy.proxyOptions = proxyOptions;
     copy.componentLoader = componentLoader;
+    copy.fallbackEndpoint = fallbackEndpoint;
     return copy;
   }
 
@@ -231,12 +238,13 @@ public final class HttpExporterBuilder {
         };
 
     boolean isPlainHttp = endpoint.getScheme().equals("http");
+    String contentType = exportAsJson ? "application/json" : "application/x-protobuf";
     HttpSenderProvider httpSenderProvider = SenderUtil.resolveHttpSenderProvider(componentLoader);
     HttpSender httpSender =
         httpSenderProvider.createSender(
             ImmutableHttpSenderConfig.create(
                 endpoint,
-                exportAsJson ? "application/json" : "application/x-protobuf",
+                contentType,
                 compressor,
                 timeout,
                 connectTimeout,
@@ -248,13 +256,34 @@ public final class HttpExporterBuilder {
                 executorService));
     LOGGER.log(Level.FINE, "Using HttpSender: " + httpSender.getClass().getName());
 
+    HttpSender fallbackSender = null;
+    if (fallbackEndpoint != null) {
+      boolean isFallbackPlainHttp = fallbackEndpoint.getScheme().equals("http");
+      fallbackSender =
+          httpSenderProvider.createSender(
+              ImmutableHttpSenderConfig.create(
+                  fallbackEndpoint,
+                  contentType,
+                  compressor,
+                  timeout,
+                  connectTimeout,
+                  headerSupplier,
+                  proxyOptions,
+                  retryPolicy,
+                  isFallbackPlainHttp ? null : tlsConfigHelper.getSslContext(),
+                  isFallbackPlainHttp ? null : tlsConfigHelper.getTrustManager(),
+                  executorService));
+      LOGGER.log(Level.FINE, "Using fallback HttpSender: " + fallbackSender.getClass().getName());
+    }
+
     return new HttpExporter(
         ComponentId.generateLazy(exporterType),
         httpSender,
         meterProviderSupplier,
         internalTelemetryVersion,
         endpoint,
-        exportAsJson);
+        exportAsJson,
+        fallbackSender);
   }
 
   public String toString(boolean includePrefixAndSuffix) {
@@ -263,6 +292,9 @@ public final class HttpExporterBuilder {
             ? new StringJoiner(", ", "HttpExporterBuilder{", "}")
             : new StringJoiner(", ");
     joiner.add("endpoint=" + endpoint);
+    if (fallbackEndpoint != null) {
+      joiner.add("fallbackEndpoint=" + fallbackEndpoint);
+    }
     joiner.add("timeoutNanos=" + timeout.toNanos());
     joiner.add("proxyOptions=" + proxyOptions);
     joiner.add(

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/grpc/GrpcExporterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.doAnswer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.export.GrpcResponse;
 import io.opentelemetry.sdk.common.export.GrpcSender;
@@ -223,5 +224,115 @@ class GrpcExporterTest {
                                                   .build())
                                           .hasBucketCounts(1))));
     }
+  }
+
+  @Test
+  @SuppressLogger(GrpcExporter.class)
+  void export_FallbackOnPrimaryTransportError() {
+    GrpcSender mockPrimarySender = Mockito.mock(GrpcSender.class);
+    GrpcSender mockFallbackSender = Mockito.mock(GrpcSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    GrpcExporter exporter =
+        new GrpcExporter(
+            mockPrimarySender,
+            InternalTelemetryVersion.LATEST,
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_GRPC_SPAN_EXPORTER),
+            () -> SdkMeterProvider.builder().build(),
+            URI.create("http://primary:4317"),
+            mockFallbackSender);
+
+    // Primary sender fails with transport error, fallback succeeds
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Connection refused"));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    doAnswer(
+            invoc -> {
+              Consumer<GrpcResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(ImmutableGrpcResponse.create(GrpcStatusCode.OK, null, new byte[0]));
+              return null;
+            })
+        .when(mockFallbackSender)
+        .send(any(), any(), any());
+
+    exporter.export(mockMarshaller, 10);
+
+    // Verify fallback was called
+    Mockito.verify(mockFallbackSender).send(any(), any(), any());
+  }
+
+  @Test
+  @SuppressLogger(GrpcExporter.class)
+  void export_NoFallbackOnSuccess() {
+    GrpcSender mockPrimarySender = Mockito.mock(GrpcSender.class);
+    GrpcSender mockFallbackSender = Mockito.mock(GrpcSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    GrpcExporter exporter =
+        new GrpcExporter(
+            mockPrimarySender,
+            InternalTelemetryVersion.LATEST,
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_GRPC_SPAN_EXPORTER),
+            () -> SdkMeterProvider.builder().build(),
+            URI.create("http://primary:4317"),
+            mockFallbackSender);
+
+    doAnswer(
+            invoc -> {
+              Consumer<GrpcResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(ImmutableGrpcResponse.create(GrpcStatusCode.OK, null, new byte[0]));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    exporter.export(mockMarshaller, 10);
+
+    Mockito.verify(mockFallbackSender, Mockito.never()).send(any(), any(), any());
+  }
+
+  @Test
+  @SuppressLogger(GrpcExporter.class)
+  void export_BothEndpointsFail() {
+    GrpcSender mockPrimarySender = Mockito.mock(GrpcSender.class);
+    GrpcSender mockFallbackSender = Mockito.mock(GrpcSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    GrpcExporter exporter =
+        new GrpcExporter(
+            mockPrimarySender,
+            InternalTelemetryVersion.LATEST,
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_GRPC_SPAN_EXPORTER),
+            () -> SdkMeterProvider.builder().build(),
+            URI.create("http://primary:4317"),
+            mockFallbackSender);
+
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Primary connection refused"));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Fallback connection refused"));
+              return null;
+            })
+        .when(mockFallbackSender)
+        .send(any(), any(), any());
+
+    CompletableResultCode result = exporter.export(mockMarshaller, 10);
+
+    assertThat(result.isSuccess()).isFalse();
   }
 }

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/http/HttpExporterTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/http/HttpExporterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doAnswer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.export.HttpResponse;
 import io.opentelemetry.sdk.common.export.HttpSender;
@@ -211,6 +212,122 @@ class HttpExporterTest {
                                                   .build())
                                           .hasBucketCounts(1))));
     }
+  }
+
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_FallbackOnPrimaryTransportError() {
+    HttpSender mockPrimarySender = Mockito.mock(HttpSender.class);
+    HttpSender mockFallbackSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockPrimarySender,
+            () -> SdkMeterProvider.builder().build(),
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://primary:4318"),
+            false,
+            mockFallbackSender);
+
+    // Primary sender fails with transport error, fallback succeeds
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Connection refused"));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    doAnswer(
+            invoc -> {
+              Consumer<HttpResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(new FakeHttpResponse(200, "Ok"));
+              return null;
+            })
+        .when(mockFallbackSender)
+        .send(any(), any(), any());
+
+    exporter.export(mockMarshaller, 10);
+
+    // Verify fallback was called
+    Mockito.verify(mockFallbackSender).send(any(), any(), any());
+  }
+
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_NoFallbackOnSuccess() {
+    HttpSender mockPrimarySender = Mockito.mock(HttpSender.class);
+    HttpSender mockFallbackSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockPrimarySender,
+            () -> SdkMeterProvider.builder().build(),
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://primary:4318"),
+            false,
+            mockFallbackSender);
+
+    // Primary sender succeeds
+    doAnswer(
+            invoc -> {
+              Consumer<HttpResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(new FakeHttpResponse(200, "Ok"));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    exporter.export(mockMarshaller, 10);
+
+    // Verify fallback was NOT called
+    Mockito.verify(mockFallbackSender, Mockito.never()).send(any(), any(), any());
+  }
+
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_BothEndpointsFail() {
+    HttpSender mockPrimarySender = Mockito.mock(HttpSender.class);
+    HttpSender mockFallbackSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockPrimarySender,
+            () -> SdkMeterProvider.builder().build(),
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://primary:4318"),
+            false,
+            mockFallbackSender);
+
+    // Both senders fail
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Primary connection refused"));
+              return null;
+            })
+        .when(mockPrimarySender)
+        .send(any(), any(), any());
+
+    doAnswer(
+            invoc -> {
+              Consumer<Throwable> onError = invoc.getArgument(2);
+              onError.accept(new IOException("Fallback connection refused"));
+              return null;
+            })
+        .when(mockFallbackSender)
+        .send(any(), any(), any());
+
+    CompletableResultCode result = exporter.export(mockMarshaller, 10);
+
+    assertThat(result.isSuccess()).isFalse();
   }
 
   private static class FakeHttpResponse implements HttpResponse {

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -109,6 +109,18 @@ public final class OtlpHttpLogRecordExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://, and include the full HTTP path. If the
+   * primary endpoint fails with a transport error (after retries), the exporter will attempt to
+   * send to this fallback endpoint.
+   */
+  public OtlpHttpLogRecordExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -129,6 +129,18 @@ public final class OtlpHttpMetricExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://, and include the full HTTP path. If the
+   * primary endpoint fails with a transport error (after retries), the exporter will attempt to
+   * send to this fallback endpoint.
+   */
+  public OtlpHttpMetricExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -109,6 +109,18 @@ public final class OtlpHttpSpanExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://, and include the full HTTP path. If the
+   * primary endpoint fails with a transport error (after retries), the exporter will attempt to
+   * send to this fallback endpoint.
+   */
+  public OtlpHttpSpanExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -65,6 +65,38 @@ public final class OtlpConfigUtil {
       Consumer<RetryPolicy> setRetryPolicy,
       Consumer<MemoryMode> setMemoryMode,
       Consumer<InternalTelemetryVersion> setInternalTelemetryVersion) {
+    configureOtlpExporterBuilder(
+        dataType,
+        config,
+        setComponentLoader,
+        setEndpoint,
+        addHeader,
+        setCompression,
+        setTimeout,
+        setTrustedCertificates,
+        setClientTls,
+        setRetryPolicy,
+        setMemoryMode,
+        setInternalTelemetryVersion,
+        null);
+  }
+
+  /** Invoke the setters with the OTLP configuration for the {@code dataType}. */
+  @SuppressWarnings("TooManyParameters")
+  public static void configureOtlpExporterBuilder(
+      String dataType,
+      ConfigProperties config,
+      Consumer<ComponentLoader> setComponentLoader,
+      Consumer<String> setEndpoint,
+      BiConsumer<String, String> addHeader,
+      Consumer<String> setCompression,
+      Consumer<Duration> setTimeout,
+      Consumer<byte[]> setTrustedCertificates,
+      BiConsumer<byte[], byte[]> setClientTls,
+      Consumer<RetryPolicy> setRetryPolicy,
+      Consumer<MemoryMode> setMemoryMode,
+      Consumer<InternalTelemetryVersion> setInternalTelemetryVersion,
+      @Nullable Consumer<String> setFallbackEndpoint) {
     setComponentLoader.accept(config.getComponentLoader());
 
     String protocol = getOtlpProtocol(dataType, config);
@@ -140,6 +172,34 @@ public final class OtlpConfigUtil {
 
     if (clientKeyBytes != null && clientKeyChainBytes != null) {
       setClientTls.accept(clientKeyBytes, clientKeyChainBytes);
+    }
+
+    if (setFallbackEndpoint != null) {
+      boolean isFallbackHttpProtobuf = isHttpProtobuf;
+      URL fallbackEndpoint =
+          validateEndpoint(
+              config.getString("otel.exporter.otlp." + dataType + ".fallback.endpoint"),
+              isFallbackHttpProtobuf);
+      if (fallbackEndpoint != null) {
+        if (fallbackEndpoint.getPath().isEmpty()) {
+          fallbackEndpoint = createUrl(fallbackEndpoint, "/");
+        }
+      } else {
+        fallbackEndpoint =
+            validateEndpoint(
+                config.getString("otel.exporter.otlp.fallback.endpoint"), isFallbackHttpProtobuf);
+        if (fallbackEndpoint != null && isFallbackHttpProtobuf) {
+          String fallbackPath = fallbackEndpoint.getPath();
+          if (!fallbackPath.endsWith("/")) {
+            fallbackPath += "/";
+          }
+          fallbackPath += signalPath(dataType);
+          fallbackEndpoint = createUrl(fallbackEndpoint, fallbackPath);
+        }
+      }
+      if (fallbackEndpoint != null) {
+        setFallbackEndpoint.accept(fallbackEndpoint.toString());
+      }
     }
 
     Boolean retryDisabled = config.getBoolean("otel.java.exporter.otlp.retry.disabled");

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpLogRecordExporterProvider.java
@@ -54,7 +54,8 @@ public class OtlpLogRecordExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
@@ -73,7 +74,8 @@ public class OtlpLogRecordExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpMetricExporterProvider.java
@@ -55,7 +55,8 @@ public class OtlpMetricExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       ExporterBuilderUtil.configureOtlpAggregationTemporality(
           config, builder::setAggregationTemporalitySelector);
       ExporterBuilderUtil.configureOtlpHistogramDefaultAggregation(
@@ -78,7 +79,8 @@ public class OtlpMetricExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       ExporterBuilderUtil.configureOtlpAggregationTemporality(
           config, builder::setAggregationTemporalitySelector);
       ExporterBuilderUtil.configureOtlpHistogramDefaultAggregation(

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProvider.java
@@ -53,7 +53,8 @@ public class OtlpSpanExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();
@@ -72,7 +73,8 @@ public class OtlpSpanExporterProvider
           builder::setClientTls,
           builder::setRetryPolicy,
           builder::setMemoryMode,
-          builder::setInternalTelemetryVersion);
+          builder::setInternalTelemetryVersion,
+          builder::setFallbackEndpoint);
       builder.setMeterProvider(meterProviderRef::get);
 
       return builder.build();

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/OtlpGrpcLogRecordExporterBuilder.java
@@ -138,6 +138,17 @@ public final class OtlpGrpcLogRecordExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://. If the primary endpoint fails with a
+   * transport error (after retries), the exporter will attempt to send to this fallback endpoint.
+   */
+  public OtlpGrpcLogRecordExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/metrics/OtlpGrpcMetricExporterBuilder.java
@@ -157,6 +157,17 @@ public final class OtlpGrpcMetricExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://. If the primary endpoint fails with a
+   * transport error (after retries), the exporter will attempt to send to this fallback endpoint.
+   */
+  public OtlpGrpcMetricExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
@@ -135,6 +135,17 @@ public final class OtlpGrpcSpanExporterBuilder {
   }
 
   /**
+   * Sets the fallback OTLP endpoint to connect to when the primary endpoint is unavailable. The
+   * endpoint must start with either http:// or https://. If the primary endpoint fails with a
+   * transport error (after retries), the exporter will attempt to send to this fallback endpoint.
+   */
+  public OtlpGrpcSpanExporterBuilder setFallbackEndpoint(String fallbackEndpoint) {
+    requireNonNull(fallbackEndpoint, "fallbackEndpoint");
+    delegate.setFallbackEndpoint(fallbackEndpoint);
+    return this;
+  }
+
+  /**
    * Sets the method used to compress payloads. If unset, compression is disabled. Compression
    * method "gzip" and "none" are supported out of the box. Additional compression methods can be
    * supported by providing custom {@link Compressor} implementations via the service loader.

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtilTest.java
@@ -386,6 +386,93 @@ class OtlpConfigUtilTest {
   }
 
   @Test
+  void configureOtlpExporterBuilder_FallbackEndpoint() {
+    // No fallback endpoint configured
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_TRACES, ImmutableMap.of("otel.exporter.otlp.protocol", "http/protobuf")))
+        .isEmpty();
+
+    // Generic fallback endpoint
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_TRACES,
+                ImmutableMap.of(
+                    "otel.exporter.otlp.protocol",
+                    "http/protobuf",
+                    "otel.exporter.otlp.fallback.endpoint",
+                    "http://fallback:4318")))
+        .isEqualTo("http://fallback:4318/v1/traces");
+
+    // Signal-specific fallback endpoint takes precedence
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_TRACES,
+                ImmutableMap.of(
+                    "otel.exporter.otlp.protocol",
+                    "http/protobuf",
+                    "otel.exporter.otlp.fallback.endpoint",
+                    "http://generic-fallback:4318",
+                    "otel.exporter.otlp.traces.fallback.endpoint",
+                    "http://traces-fallback:4318/v1/traces")))
+        .isEqualTo("http://traces-fallback:4318/v1/traces");
+
+    // Fallback for metrics
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_METRICS,
+                ImmutableMap.of(
+                    "otel.exporter.otlp.protocol",
+                    "http/protobuf",
+                    "otel.exporter.otlp.fallback.endpoint",
+                    "http://fallback:4318")))
+        .isEqualTo("http://fallback:4318/v1/metrics");
+
+    // Fallback for logs
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_LOGS,
+                ImmutableMap.of(
+                    "otel.exporter.otlp.protocol",
+                    "http/protobuf",
+                    "otel.exporter.otlp.fallback.endpoint",
+                    "http://fallback:4318")))
+        .isEqualTo("http://fallback:4318/v1/logs");
+
+    // gRPC fallback endpoint
+    assertThat(
+            configureFallbackEndpoint(
+                DATA_TYPE_TRACES,
+                ImmutableMap.of(
+                    "otel.exporter.otlp.protocol",
+                    "grpc",
+                    "otel.exporter.otlp.fallback.endpoint",
+                    "http://fallback:4317")))
+        .isEqualTo("http://fallback:4317");
+  }
+
+  private static String configureFallbackEndpoint(String dataType, Map<String, String> properties) {
+    AtomicReference<String> fallbackEndpoint = new AtomicReference<>("");
+
+    OtlpConfigUtil.configureOtlpExporterBuilder(
+        dataType,
+        DefaultConfigProperties.createFromMap(properties),
+        value -> {},
+        value -> {},
+        (value1, value2) -> {},
+        value -> {},
+        value -> {},
+        value -> {},
+        (value1, value2) -> {},
+        value -> {},
+        value -> {},
+        value -> {},
+        fallbackEndpoint::set);
+
+    return fallbackEndpoint.get();
+  }
+
+  @Test
   void configureOtlpAggregationTemporality() {
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
## Summary
- Adds configurable fallback endpoint for OTLP exporters (HTTP and gRPC) across all signal types (traces, metrics, logs)
- When the primary endpoint fails with a transport error (after retries are exhausted), the exporter automatically attempts to send to the fallback endpoint
- Configurable via environment variables (`otel.exporter.otlp.fallback.endpoint`, `otel.exporter.otlp.<signal>.fallback.endpoint`) or programmatically via `setFallbackEndpoint(String)` on all exporter builders

## Motivation
Currently OTLP exporters only support a single endpoint. In production environments, having a fallback collector endpoint improves reliability — if the primary collector goes down, telemetry data is not lost.

## Changes
- **Core**: `HttpExporter` and `GrpcExporter` — failover logic on transport errors
- **Builders**: `HttpExporterBuilder` and `GrpcExporterBuilder` — `setFallbackEndpoint()` creates a secondary sender
- **Config**: `OtlpConfigUtil` — parses `otel.exporter.otlp.fallback.endpoint` and signal-specific variants
- **Public API**: Added `setFallbackEndpoint(String)` to all 6 public exporter builders
- **Providers**: All 3 autoconfigure providers wired up with fallback endpoint support

## Test plan
- [x] `OtlpConfigUtilTest` — fallback endpoint configuration parsing (generic, signal-specific, HTTP path appending, gRPC)
- [x] `HttpExporterTest` — failover on primary transport error, no failover on success, both endpoints fail
- [x] `GrpcExporterTest` — same three failover scenarios
- [x] `./gradlew spotlessApply` passes
- [x] `./gradlew japicmp` — API diff included (additive only)
- [ ] Integration test with real collector failover

🤖 Generated with [Claude Code](https://claude.com/claude-code)