### PR TITLE
Remove duplicative FINEST-level error logging in GrpcExporter

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java
@@ -133,7 +133,7 @@ public final class GrpcExporter {
             + e.getMessage(),
         e);
     if (logger.isLoggable(Level.FINEST)) {
-      logger.log(Level.FINEST, "Failed to export " + type + "s. Details follow: " + e);
+      logger.log(Level.FINEST, "Failed to export " + type + "s. Details follow:", e);
     }
     result.failExceptionally(FailedExportException.grpcFailedExceptionally(e));
   }


### PR DESCRIPTION
The `onError` method in `GrpcExporter` logged failures twice: once at `SEVERE` (with the exception object) and again at `FINEST`. The `FINEST` log is redundant since anyone who configures their logging framework to display stack traces will get them from the `SEVERE` log's exception parameter.

`HttpExporter` does not have this pattern and required no changes.

Resolves #8098
