### PR TITLE
Use explicit Renovate Tuesday morning schedules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
         'patch',
       ],
       schedule: [
-        'before 8am on Tuesday',
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
     },
     {
@@ -30,8 +30,8 @@
         'github-actions',
         'dockerfile',
       ],
-      extends: [
-        'schedule:weekly',
+      schedule: [
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
       groupName: 'weekly update',
     },


### PR DESCRIPTION
This switches Renovate scheduling to an explicit Tuesday morning cron schedule:

`* 0-7 * * 2`

The goal is to preserve the existing weekly timing while moving away from deprecated older schedule syntax and reducing repeated same-day Renovate churn.

Ported from https://github.com/open-telemetry/semantic-conventions/pull/3576