### PR TITLE
fix: correct condition for recording successful log processing metrics

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LegacyLogRecordProcessorInstrumentation.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LegacyLogRecordProcessorInstrumentation.java
@@ -50,7 +50,7 @@ final class LegacyLogRecordProcessorInstrumentation implements LogRecordProcesso
   @Override
   public void finishLogs(int count, @Nullable String error) {
     // Legacy metrics only record when no error.
-    if (error != null) {
+    if (error == null) {
       processedLogs().add(count, standardAttrs);
     }
   }


### PR DESCRIPTION
## Description
This PR corrects a logical condition in `LegacyLogRecordProcessorInstrumentation.finishLogs`.

## Problem
Previously, the code recorded metrics under the comment:

> Legacy metrics only record when no error.

However, the implementation used:

```java
if (error != null) {
    processedLogs().add(count, standardAttrs);
}
```

This records metrics when an error is present, which is inconsistent with the stated intent.

## Fix
Updated the condition to:

```java
if (error == null) {
    processedLogs().add(count, standardAttrs);
}
```