### PR TITLE
Suppress noisy test logs from recent changes

### DIFF
--- a/exporters/otlp/all/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
+++ b/exporters/otlp/all/src/testSpanPipeline/java/io/opentelemetry/exporter/otlp/trace/SpanPipelineOtlpBenchmark.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@SuppressLogger(BatchSpanProcessor.class)
 class SpanPipelineOtlpBenchmark {
   private static final Resource RESOURCE =
       Resource.create(

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.internal.testing.CleanupExtension;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.internal.SpiHelper;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.AlwaysOnSamplerModel;
@@ -100,6 +101,7 @@ class OpenTelemetryConfigurationFactoryTest {
 
   @ParameterizedTest
   @MethodSource("fileFormatArgs")
+  @SuppressLogger(OpenTelemetryConfigurationFactory.class)
   void create_FileFormat(String fileFormat, boolean isValid) {
     OpenTelemetryConfigurationModel model =
         new OpenTelemetryConfigurationModel().withFileFormat(fileFormat);

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/fileconfig/SamplerFactoryTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @SuppressLogger(
     loggerName = "io.opentelemetry.sdk.extension.trace.jaeger.sampler.OkHttpGrpcService")
 @SuppressLogger(ParentBasedSamplerBuilder.class)
+@SuppressLogger(JaegerRemoteSampler.class)
 class SamplerFactoryTest {
 
   @RegisterExtension CleanupExtension cleanup = new CleanupExtension();

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderMetricsTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderMetricsTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -708,6 +709,7 @@ class SdkTracerProviderMetricsTest {
   }
 
   @Test
+  @SuppressLogger(BatchSpanProcessor.class)
   void batch() throws Exception {
     InMemoryMetricReader metricReader = InMemoryMetricReader.create();
     MeterProvider meterProvider =

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -240,6 +240,7 @@ class BatchSpanProcessorTest {
   }
 
   @Test
+  @SuppressLogger(BatchSpanProcessor.class)
   void droppedSpanIsLogged() {
     sdkTracerProvider =
         SdkTracerProvider.builder()
@@ -393,6 +394,7 @@ class BatchSpanProcessorTest {
   }
 
   @Test
+  @SuppressLogger(BatchSpanProcessor.class)
   void exportMoreSpansThanTheMaximumLimit() {
     int maxQueuedSpans = 8;
     WaitingSpanExporter waitingSpanExporter =


### PR DESCRIPTION
The build log output from SpanPipelineOtlpBenchmark got wildly verbose after merging #8167.

This suppresses those logs and some others.