### PR TITLE
Replace ArrayBlockingQueue with park/unpark for BatchSpanProcessor$Worker

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -17,16 +17,16 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.internal.JcTools;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,6 +86,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
             JcTools.newFixedSizeQueue(maxQueueSize),
             maxQueueSize);
     Thread workerThread = new DaemonThreadFactory(WORKER_THREAD_NAME).newThread(worker);
+    this.worker.setWorkerThread(workerThread);
     workerThread.start();
   }
 
@@ -169,6 +170,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private final long exporterTimeoutNanos;
 
     private long nextExportTime;
+    @Nullable private Thread workerThread;
 
     private final Queue<ReadableSpan> queue;
     private final AtomicInteger queueSize = new AtomicInteger();
@@ -178,8 +180,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
     // Integer.MAX_VALUE is used to imply that exporter thread is not expecting any signal. Since
     // exporter thread doesn't expect any signal initially, this value is initialized to
     // Integer.MAX_VALUE.
-    private final AtomicInteger spansNeeded = new AtomicInteger(Integer.MAX_VALUE);
-    private final BlockingQueue<Boolean> signal;
+    private volatile int spansNeeded = Integer.MAX_VALUE;
     private final AtomicReference<CompletableResultCode> flushRequested = new AtomicReference<>();
     private volatile boolean continueWork = true;
     private final ArrayList<SpanData> batch;
@@ -200,7 +201,6 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.maxExportBatchSize = maxExportBatchSize;
       this.exporterTimeoutNanos = exporterTimeoutNanos;
       this.queue = queue;
-      this.signal = new ArrayBlockingQueue<>(1);
 
       spanProcessorInstrumentation =
           SpanProcessorInstrumentation.get(telemetryVersion, COMPONENT_ID, meterProvider);
@@ -209,14 +209,18 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.batch = new ArrayList<>(this.maxExportBatchSize);
     }
 
+    private void setWorkerThread(Thread workerThread) {
+      this.workerThread = workerThread;
+    }
+
     private void addSpan(ReadableSpan span) {
       spanProcessorInstrumentation.buildQueueMetricsOnce(maxQueueSize, queue::size);
       if (!queue.offer(span)) {
         spanProcessorInstrumentation.dropSpans(1);
         droppedSpanCount.incrementAndGet();
       } else {
-        if (queueSize.incrementAndGet() >= spansNeeded.get()) {
-          signal.offer(true);
+        if (workerThread != null && queueSize.incrementAndGet() >= spansNeeded) {
+          LockSupport.unpark(workerThread);
         }
       }
     }
@@ -236,16 +240,11 @@ public final class BatchSpanProcessor implements SpanProcessor {
           updateNextExportTime();
         }
         if (queue.isEmpty()) {
-          try {
-            long pollWaitTime = nextExportTime - System.nanoTime();
-            if (pollWaitTime > 0) {
-              spansNeeded.set(maxExportBatchSize - batch.size());
-              signal.poll(pollWaitTime, TimeUnit.NANOSECONDS);
-              spansNeeded.set(Integer.MAX_VALUE);
-            }
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return;
+          long pollWaitTime = nextExportTime - System.nanoTime();
+          if (pollWaitTime > 0) {
+            spansNeeded = maxExportBatchSize - batch.size();
+            LockSupport.parkNanos(pollWaitTime);
+            spansNeeded = Integer.MAX_VALUE;
           }
         }
       }
@@ -302,8 +301,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private CompletableResultCode forceFlush() {
       CompletableResultCode flushResult = new CompletableResultCode();
       // we set the atomic here to trigger the worker loop to do a flush of the entire queue.
-      if (flushRequested.compareAndSet(null, flushResult)) {
-        signal.offer(true);
+      if (workerThread != null && flushRequested.compareAndSet(null, flushResult)) {
+        LockSupport.unpark(workerThread);
       }
       CompletableResultCode possibleResult = flushRequested.get();
       // there's a race here where the flush happening in the worker loop could complete before we

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -10,7 +10,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.internal.ComponentId;
-import io.opentelemetry.sdk.common.internal.DaemonThreadFactory;
 import io.opentelemetry.sdk.common.internal.ThrowableUtil;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -29,7 +28,6 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link SpanProcessor} that batches spans exported by the SDK then pushes
@@ -85,9 +83,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
             exporterTimeoutNanos,
             JcTools.newFixedSizeQueue(maxQueueSize),
             maxQueueSize);
-    Thread workerThread = new DaemonThreadFactory(WORKER_THREAD_NAME).newThread(worker);
-    this.worker.setWorkerThread(workerThread);
-    workerThread.start();
+
+    worker.start();
   }
 
   @Override
@@ -160,7 +157,7 @@ public final class BatchSpanProcessor implements SpanProcessor {
 
   // Worker is a thread that batches multiple spans and calls the registered SpanExporter to export
   // the data.
-  private static final class Worker implements Runnable {
+  private static final class Worker extends Thread {
 
     private final SpanProcessorInstrumentation spanProcessorInstrumentation;
 
@@ -170,7 +167,6 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private final long exporterTimeoutNanos;
 
     private long nextExportTime;
-    @Nullable private Thread workerThread;
 
     private final Queue<ReadableSpan> queue;
     private final AtomicInteger queueSize = new AtomicInteger();
@@ -196,6 +192,9 @@ public final class BatchSpanProcessor implements SpanProcessor {
         long exporterTimeoutNanos,
         Queue<ReadableSpan> queue,
         long maxQueueSize) {
+      super(WORKER_THREAD_NAME);
+      super.setDaemon(true);
+
       this.spanExporter = spanExporter;
       this.scheduleDelayNanos = scheduleDelayNanos;
       this.maxExportBatchSize = maxExportBatchSize;
@@ -209,18 +208,14 @@ public final class BatchSpanProcessor implements SpanProcessor {
       this.batch = new ArrayList<>(this.maxExportBatchSize);
     }
 
-    private void setWorkerThread(Thread workerThread) {
-      this.workerThread = workerThread;
-    }
-
     private void addSpan(ReadableSpan span) {
       spanProcessorInstrumentation.buildQueueMetricsOnce(maxQueueSize, queue::size);
       if (!queue.offer(span)) {
         spanProcessorInstrumentation.dropSpans(1);
         droppedSpanCount.incrementAndGet();
       } else {
-        if (workerThread != null && queueSize.incrementAndGet() >= spansNeeded) {
-          LockSupport.unpark(workerThread);
+        if (queueSize.incrementAndGet() >= spansNeeded) {
+          LockSupport.unpark(this);
         }
       }
     }
@@ -301,8 +296,8 @@ public final class BatchSpanProcessor implements SpanProcessor {
     private CompletableResultCode forceFlush() {
       CompletableResultCode flushResult = new CompletableResultCode();
       // we set the atomic here to trigger the worker loop to do a flush of the entire queue.
-      if (workerThread != null && flushRequested.compareAndSet(null, flushResult)) {
-        LockSupport.unpark(workerThread);
+      if (flushRequested.compareAndSet(null, flushResult)) {
+        LockSupport.unpark(this);
       }
       CompletableResultCode possibleResult = flushRequested.get();
       // there's a race here where the flush happening in the worker loop could complete before we

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.internal.JcTools;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +29,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link SpanProcessor} that batches spans exported by the SDK then pushes


### PR DESCRIPTION
Browsing through the codebase I saw the ArrayBlockingQueue and thought I could do something better. Running benchmarks locally did produce better results though they weren't as consistent as I would have liked.

The same changes could also be applied to `BatchLogRecordProcessor`.