### PR TITLE
feat(sdk-logs): add maxConcurrentExports to enable concurrent batch e…

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of opentelemetry-sdk-logs-1.61.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.60.1.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.logs.export.BatchLogRecordProcessorBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.logs.export.BatchLogRecordProcessorBuilder setMaxConcurrentExports(int)

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,6 +69,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       long scheduleDelayNanos,
       int maxQueueSize,
       int maxExportBatchSize,
+      int maxConcurrentExports,
       long exporterTimeoutNanos) {
     this.worker =
         new Worker(
@@ -76,6 +78,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
             telemetryVersion,
             scheduleDelayNanos,
             maxExportBatchSize,
+            maxConcurrentExports,
             exporterTimeoutNanos,
             new ArrayBlockingQueue<>(maxQueueSize),
             maxQueueSize); // TODO: use JcTools.newFixedSizeQueue(..)
@@ -161,6 +164,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     private volatile boolean continueWork = true;
     private final ArrayList<LogRecordData> batch;
     private final long maxQueueSize;
+    private final Semaphore concurrencyLimiter;
 
     private Worker(
         LogRecordExporter logRecordExporter,
@@ -168,6 +172,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
         InternalTelemetryVersion telemetryVersion,
         long scheduleDelayNanos,
         int maxExportBatchSize,
+        int maxConcurrentExports,
         long exporterTimeoutNanos,
         Queue<ReadWriteLogRecord> queue,
         long maxQueueSize) {
@@ -180,6 +185,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       logProcessorInstrumentation =
           LogRecordProcessorInstrumentation.get(telemetryVersion, COMPONENT_ID, meterProvider);
       this.maxQueueSize = maxQueueSize;
+      this.concurrencyLimiter = new Semaphore(maxConcurrentExports - 1, true);
 
       this.batch = new ArrayList<>(this.maxExportBatchSize);
     }
@@ -234,10 +240,10 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
         batch.add(logRecord.toLogRecordData());
         logsToFlush--;
         if (batch.size() >= maxExportBatchSize) {
-          exportCurrentBatch();
+          exportCurrentBatchSync();
         }
       }
-      exportCurrentBatch();
+      exportCurrentBatchSync();
       CompletableResultCode flushResult = flushRequested.get();
       if (flushResult != null) {
         flushResult.succeed();
@@ -284,6 +290,15 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     }
 
     private void exportCurrentBatch() {
+      if (!concurrencyLimiter.tryAcquire()) {
+        exportCurrentBatchSync();
+        return;
+      }
+
+      exportCurrentBatchAsync();
+    }
+
+    private void exportCurrentBatchSync() {
       if (batch.isEmpty()) {
         return;
       }
@@ -308,6 +323,32 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
         logProcessorInstrumentation.finishLogs(batch.size(), error);
         batch.clear();
       }
+    }
+
+    private void exportCurrentBatchAsync() {
+      if (batch.isEmpty()) {
+        return;
+      }
+
+      List<LogRecordData> batchCopy = new ArrayList<>(batch);
+      batch.clear();
+
+      CompletableResultCode result =
+          logRecordExporter.export(Collections.unmodifiableList(batchCopy));
+      result.whenComplete(
+          () -> {
+            String error = null;
+            if (!result.isSuccess()) {
+              logger.log(Level.FINE, "Exporter failed");
+              if (result.getFailureThrowable() != null) {
+                error = result.getFailureThrowable().getClass().getName();
+              } else {
+                error = "export_failed";
+              }
+            }
+            logProcessorInstrumentation.finishLogs(batchCopy.size(), error);
+            concurrencyLimiter.release();
+          });
     }
   }
 }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorBuilder.java
@@ -32,12 +32,15 @@ public final class BatchLogRecordProcessorBuilder {
   // Visible for testing
   static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
   // Visible for testing
+  static final int DEFAULT_MAX_CONCURRENT_EXPORTS = 1;
+  // Visible for testing
   static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
 
   private final LogRecordExporter logRecordExporter;
   private long scheduleDelayNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_SCHEDULE_DELAY_MILLIS);
   private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
   private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
+  private int maxConcurrentExports = DEFAULT_MAX_CONCURRENT_EXPORTS;
   private long exporterTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_EXPORT_TIMEOUT_MILLIS);
   private Supplier<MeterProvider> meterProvider = MeterProvider::noop;
   private InternalTelemetryVersion telemetryVersion = InternalTelemetryVersion.LEGACY;
@@ -136,6 +139,21 @@ public final class BatchLogRecordProcessorBuilder {
   }
 
   /**
+   * Sets the maximum number of concurrent exports.
+   *
+   * <p>Default value is {@code 1}.
+   *
+   * @param maxConcurrentExports the maximum number of concurrent exports.
+   * @return this.
+   * @see BatchLogRecordProcessorBuilder#DEFAULT_MAX_CONCURRENT_EXPORTS
+   */
+  public BatchLogRecordProcessorBuilder setMaxConcurrentExports(int maxConcurrentExports) {
+    checkArgument(maxConcurrentExports > 0, "maxConcurrentExports must be positive.");
+    this.maxConcurrentExports = maxConcurrentExports;
+    return this;
+  }
+
+  /**
    * Sets the {@link MeterProvider} to use to collect metrics related to batch export. If not set,
    * metrics will not be collected.
    */
@@ -174,6 +192,11 @@ public final class BatchLogRecordProcessorBuilder {
     return maxExportBatchSize;
   }
 
+  // Visible for testing
+  int getMaxConcurrentExports() {
+    return maxConcurrentExports;
+  }
+
   /**
    * Returns a new {@link BatchLogRecordProcessor} that batches, then forwards them to the given
    * {@code logRecordExporter}.
@@ -195,6 +218,7 @@ public final class BatchLogRecordProcessorBuilder {
         scheduleDelayNanos,
         maxQueueSize,
         maxExportBatchSize,
+        maxConcurrentExports,
         exporterTimeoutNanos);
   }
 }

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessorTest.java
@@ -78,6 +78,8 @@ class BatchLogRecordProcessorTest {
         .isEqualTo(BatchLogRecordProcessorBuilder.DEFAULT_MAX_QUEUE_SIZE);
     assertThat(builder.getMaxExportBatchSize())
         .isEqualTo(BatchLogRecordProcessorBuilder.DEFAULT_MAX_EXPORT_BATCH_SIZE);
+    assertThat(builder.getMaxConcurrentExports())
+        .isEqualTo(BatchLogRecordProcessorBuilder.DEFAULT_MAX_CONCURRENT_EXPORTS);
     assertThat(builder.getExporterTimeoutNanos())
         .isEqualTo(
             TimeUnit.MILLISECONDS.toNanos(
@@ -119,6 +121,10 @@ class BatchLogRecordProcessorTest {
             () -> BatchLogRecordProcessor.builder(mockLogRecordExporter).setMaxQueueSize(0))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("maxQueueSize must be positive.");
+    assertThatThrownBy(
+            () -> BatchLogRecordProcessor.builder(mockLogRecordExporter).setMaxConcurrentExports(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("maxConcurrentExports must be positive.");
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option `maxConcurrentExports` for `BatchLogRecordProcessor` to allow multiple export operations to run concurrently.

By enabling controlled parallelism, this change improves log export throughput under high load while maintaining backpressure.

---

## Motivation

Currently, `BatchLogRecordProcessor` performs exports sequentially, allowing only a single in-flight export at any given time. While this simplifies flow control, it can become a bottleneck in high-throughput scenarios, especially when:

- Export latency is non-trivial (e.g., network-bound OTLP exporters)
- Log production rate exceeds single-threaded export capacity
- The underlying exporter already supports asynchronous or multi-threaded execution

At the same time, switching to fully asynchronous export without limits can overwhelm downstream systems (e.g., OTLP receivers), leading to errors such as HTTP/2 `REFUSED_STREAM`.

---

## Changes

- Add a new configuration parameter:

  int maxConcurrentExports

- Allow multiple export batches to be processed in parallel, bounded by `maxConcurrentExports`
- Preserve existing behavior by default:
  - `maxConcurrentExports = 1` (sequential export)

---

## Design Considerations

### Controlled Concurrency

Instead of unbounded async exports, this approach ensures:

- Bounded number of in-flight export requests
- Protection against overwhelming downstream systems
- Stable behavior under burst traffic

### Backpressure

When the concurrency limit is reached:

- Additional batches will be processed synchronously
- This maintains backpressure semantics similar to the current implementation

### Executor Utilization

This change allows better utilization of the underlying `LogRecordExporter`, particularly when:

- The exporter uses an internal `ExecutorService`
- The exporter performs non-blocking or async I/O (e.g., OTLP over gRPC)

By enabling concurrent exports at the processor level, we avoid underutilizing available execution resources.

---

## Compatibility

- Default behavior remains unchanged (`maxConcurrentExports = 1`)
- No breaking API changes
- Fully backward compatible