### PR TITLE
Fix OTLP handling of identity content-encoding

### DIFF
--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -131,6 +131,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
   private static final AtomicInteger grpcEncodingServerAttempts = new AtomicInteger();
 
+  private static volatile String grpcEncodingServerEncoding = "brotli";
+
   @RegisterExtension
   @Order(1)
   static final SelfSignedCertificateExtension certificate = new SelfSignedCertificateExtension();
@@ -243,7 +245,8 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     }
   }
 
-  // A minimal server that returns grpc-encoding: brotli to test unsupported encoding handling.
+  // A minimal server that returns a configurable grpc-encoding to test encoding handling.
+  // The encoding is controlled via grpcEncodingServerEncoding (defaults to "brotli").
   // Both OkHttpGrpcSender (our code) and UpstreamGrpcSender (grpc-java framework) reject unknown
   // encodings and fail the export with INTERNAL status.
   @RegisterExtension
@@ -261,7 +264,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
                 return HttpResponse.of(
                     ResponseHeaders.builder(HttpStatus.OK)
                         .contentType(MediaType.parse("application/grpc+proto"))
-                        .add("grpc-encoding", "brotli")
+                        .add("grpc-encoding", grpcEncodingServerEncoding)
                         .add("grpc-status", "0")
                         .build(),
                     HttpData.wrap(frame));
@@ -329,6 +332,7 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
     attempts.set(0);
     httpRequests.clear();
     grpcEncodingServerAttempts.set(0);
+    grpcEncodingServerEncoding = "brotli";
   }
 
   @Test
@@ -438,6 +442,36 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
   @Test
   @SuppressLogger(GrpcExporter.class)
   void unsupportedGrpcMessageEncoding() {
+    try (TelemetryExporter<T> testExporter =
+        exporterBuilder()
+            .setEndpoint(grpcEncodingServer.httpUri().toString())
+            .setRetryPolicy(null)
+            .build()) {
+      CompletableResultCode result =
+          testExporter
+              .export(Collections.singletonList(generateFakeTelemetry()))
+              .join(10, TimeUnit.SECONDS);
+      assertThat(result.isSuccess()).isFalse();
+      assertThat(grpcEncodingServerAttempts).hasValue(1);
+      assertThat(result.getFailureThrowable())
+          .isInstanceOfSatisfying(
+              FailedExportException.GrpcExportException.class,
+              ex ->
+                  assertThat(requireNonNull(ex.getResponse()))
+                      .satisfies(
+                          grpcResponse ->
+                              assertThat(grpcResponse.getStatusCode())
+                                  .isEqualTo(GrpcStatusCode.INTERNAL)));
+    }
+  }
+
+  // Verifies that a response with flag=1 and grpc-encoding: identity is rejected with INTERNAL.
+  // Although identity is advertised in grpc-accept-encoding (meaning "no encoding applied"),
+  // a server setting the compressed flag to 1 is contradictory and should not be accepted.
+  @Test
+  @SuppressLogger(GrpcExporter.class)
+  void identityGrpcMessageEncodingWithCompressedFlagRejected() {
+    grpcEncodingServerEncoding = "identity";
     try (TelemetryExporter<T> testExporter =
         exporterBuilder()
             .setEndpoint(grpcEncodingServer.httpUri().toString())

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -652,6 +652,25 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
   }
 
   @Test
+  void identityResponseContentEncoding() {
+    // Server responds with Content-Encoding: identity, which means no encoding. The export should
+    // succeed just like a response with no Content-Encoding header.
+    AbstractMessageLite<?, ?> responseBody = exporter.exportResponse(0);
+    httpErrors.add(
+        HttpResponse.of(
+            ResponseHeaders.builder(HttpStatus.OK)
+                .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                .add("Content-Encoding", "identity")
+                .build(),
+            HttpData.wrap(responseBody.toByteArray())));
+    CompletableResultCode result =
+        exporter
+            .export(Collections.singletonList(generateFakeTelemetry()))
+            .join(10, TimeUnit.SECONDS);
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
   @SuppressLogger(HttpExporter.class)
   void unsupportedResponseContentEncoding() {
     // Server responds with a Content-Encoding that we don't support. The export should fail

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -350,7 +350,9 @@ public final class JdkHttpSender implements HttpSender {
             : (int) (maxResponseBodySize + 1);
 
     String contentEncoding = response.headers().firstValue("Content-Encoding").orElse(null);
-    if (contentEncoding != null && !"gzip".equalsIgnoreCase(contentEncoding)) {
+    if (contentEncoding != null
+        && !"gzip".equalsIgnoreCase(contentEncoding)
+        && !"identity".equalsIgnoreCase(contentEncoding)) {
       throw new UnsupportedContentEncodingException(
           "Unsupported Content-Encoding: " + contentEncoding);
     }

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
@@ -160,7 +160,9 @@ public final class OkHttpHttpSender implements HttpSender {
       Response response, Consumer<HttpResponse> onResponse, Consumer<Throwable> onError) {
     try (ResponseBody body = response.body()) {
       String contentEncoding = response.header("Content-Encoding");
-      if (contentEncoding != null && !"gzip".equalsIgnoreCase(contentEncoding)) {
+      if (contentEncoding != null
+          && !"gzip".equalsIgnoreCase(contentEncoding)
+          && !"identity".equalsIgnoreCase(contentEncoding)) {
         onError.accept(new IOException("Unsupported Content-Encoding: " + contentEncoding));
         return;
       }


### PR DESCRIPTION
Resolves the issue noted by @jackshirazi  here: https://github.com/open-telemetry/opentelemetry-java/pull/8224#discussion_r3063811935