### PR TITLE
Fix MarshalerUtil sizeRepeatedString calculation per issue#8272

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -115,7 +115,8 @@ public final class MarshalerUtil {
   public static int sizeRepeatedString(ProtoFieldInfo field, byte[][] utf8Bytes) {
     int size = 0;
     for (byte[] i : utf8Bytes) {
-      size += MarshalerUtil.sizeBytes(field, i);
+      int s = field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(i);
+      size += s;
     }
     return size;
   }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/MarshalerUtil.java
@@ -115,8 +115,7 @@ public final class MarshalerUtil {
   public static int sizeRepeatedString(ProtoFieldInfo field, byte[][] utf8Bytes) {
     int size = 0;
     for (byte[] i : utf8Bytes) {
-      int s = field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(i);
-      size += s;
+      size += sizeBytes(field, i, /* skipEmpty= */ false);
     }
     return size;
   }
@@ -385,7 +384,12 @@ public final class MarshalerUtil {
 
   /** Returns the size of a bytes field. */
   public static int sizeBytes(ProtoFieldInfo field, byte[] message) {
-    if (message.length == 0) {
+    return sizeBytes(field, message, /* skipEmpty= */ true);
+  }
+
+  /** Returns the size of a bytes field. */
+  public static int sizeBytes(ProtoFieldInfo field, byte[] message, boolean skipEmpty) {
+    if (message.length == 0 && skipEmpty) {
       return 0;
     }
     return field.getTagSize() + CodedOutputStream.computeByteArraySizeNoTag(message);


### PR DESCRIPTION
The encoding of a zero length String as a single element is zero length (i.e. elided), but when encoded as an element of an array (i.e. 'repeated bytes' protobuf field) it's non-zero length, as space on the wire must still be used for the tag to denote the unoccupied location in the array.