### PR TITLE
Align proto field types, tag names

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AttributeKeyValueStatelessMarshaler.java
@@ -58,8 +58,9 @@ public final class AttributeKeyValueStatelessMarshaler
         byte[] keyUtf8 = ((InternalAttributeKeyImpl<?>) attributeKey).getKeyUtf8();
         size += MarshalerUtil.sizeBytes(KeyValue.KEY, keyUtf8);
       } else {
-        return StatelessMarshalerUtil.sizeStringWithContext(
-            KeyValue.KEY, attributeKey.getKey(), context);
+        size +=
+            StatelessMarshalerUtil.sizeStringWithContext(
+                KeyValue.KEY, attributeKey.getKey(), context);
       }
     }
     size +=

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/metrics/InstrumentationScopeMetricsStatelessMarshaler.java
@@ -12,7 +12,6 @@ import io.opentelemetry.exporter.internal.marshal.StatelessMarshaler2;
 import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import io.opentelemetry.exporter.internal.otlp.InstrumentationScopeMarshaler;
 import io.opentelemetry.proto.metrics.v1.internal.ScopeMetrics;
-import io.opentelemetry.proto.trace.v1.internal.ScopeSpans;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
@@ -59,7 +58,7 @@ final class InstrumentationScopeMetricsStatelessMarshaler
             ScopeMetrics.METRICS, metrics, MetricStatelessMarshaler.INSTANCE, context);
     size +=
         StatelessMarshalerUtil.sizeStringWithContext(
-            ScopeSpans.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
+            ScopeMetrics.SCHEMA_URL, instrumentationScope.getSchemaUrl(), context);
 
     return size;
   }

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/KeyValueAndUnitMarshaler.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/KeyValueAndUnitMarshaler.java
@@ -63,7 +63,7 @@ final class KeyValueAndUnitMarshaler extends MarshalerWithSize {
   protected void writeTo(Serializer output) throws IOException {
     output.serializeInt32(KeyValueAndUnit.KEY_STRINDEX, keyStringIndex);
     output.serializeMessage(KeyValueAndUnit.VALUE, valueMarshaler);
-    output.serializeInt64(KeyValueAndUnit.UNIT_STRINDEX, unitStringIndex);
+    output.serializeInt32(KeyValueAndUnit.UNIT_STRINDEX, unitStringIndex);
   }
 
   private static int calculateSize(

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileMarshaler.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ProfileMarshaler.java
@@ -93,7 +93,7 @@ final class ProfileMarshaler extends MarshalerWithSize {
     output.serializeMessage(Profile.SAMPLE_TYPE, sampleTypeMarshaler);
     output.serializeRepeatedMessage(Profile.SAMPLES, sampleMarshalers);
     output.serializeFixed64(Profile.TIME_UNIX_NANO, timeNanos);
-    output.serializeInt64(Profile.DURATION_NANO, durationNanos);
+    output.serializeUInt64(Profile.DURATION_NANO, durationNanos);
     output.serializeMessage(Profile.PERIOD_TYPE, periodTypeMarshaler);
     output.serializeInt64(Profile.PERIOD, period);
 
@@ -121,12 +121,12 @@ final class ProfileMarshaler extends MarshalerWithSize {
     size += MarshalerUtil.sizeMessage(Profile.SAMPLE_TYPE, sampleTypeMarshaler);
     size += MarshalerUtil.sizeRepeatedMessage(Profile.SAMPLES, sampleMarshalers);
     size += MarshalerUtil.sizeFixed64(Profile.TIME_UNIX_NANO, timeNanos);
-    size += MarshalerUtil.sizeInt64(Profile.DURATION_NANO, durationNanos);
+    size += MarshalerUtil.sizeUInt64(Profile.DURATION_NANO, durationNanos);
     size += MarshalerUtil.sizeMessage(Profile.PERIOD_TYPE, periodTypeMarshaler);
     size += MarshalerUtil.sizeInt64(Profile.PERIOD, period);
 
     size += MarshalerUtil.sizeBytes(Profile.PROFILE_ID, profileId);
-    size += MarshalerUtil.sizeInt32(Profile.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
+    size += MarshalerUtil.sizeUInt32(Profile.DROPPED_ATTRIBUTES_COUNT, droppedAttributesCount);
     size += MarshalerUtil.sizeBytes(Profile.ORIGINAL_PAYLOAD_FORMAT, originalPayloadFormat);
     size += MarshalerUtil.sizeByteBuffer(Profile.ORIGINAL_PAYLOAD, originalPayload);
     size += MarshalerUtil.sizeRepeatedInt32(Profile.ATTRIBUTE_INDICES, attributeIndices);

--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ValueTypeMarshaler.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/ValueTypeMarshaler.java
@@ -51,8 +51,8 @@ final class ValueTypeMarshaler extends MarshalerWithSize {
 
   @Override
   protected void writeTo(Serializer output) throws IOException {
-    output.serializeInt64(ValueType.TYPE_STRINDEX, typeStringIndex);
-    output.serializeInt64(ValueType.UNIT_STRINDEX, unitStringIndex);
+    output.serializeInt32(ValueType.TYPE_STRINDEX, typeStringIndex);
+    output.serializeInt32(ValueType.UNIT_STRINDEX, unitStringIndex);
   }
 
   private static int calculateSize(int typeStringIndex, int unitStringIndex) {


### PR DESCRIPTION
I noticed a case where one of our OTLP marshalers was using a different type for a field than specified in the proto definition. Fixed, then used AI tooling to do a systematic review of all our marshalers to find similar mismatches. Things I looked for:

- Inconsistency between calculateSize and writeTo, i.e. one assumes int32, the other int64
- Correct tag names, i.e. metric scope marshaler referenced ScopeSpans.SCHEMA_URL instead of ScopeMetrics.SCHEMA_URL
- Correct calculation of size and serialization based on type in proto definition, i.e. int64 vs. int32 vs. uint64 vs. uint32