### PR TITLE
Tune benchmark params to reduce variance

### DIFF
--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/LogRecordBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/LogRecordBenchmark.java
@@ -112,9 +112,9 @@ public class LogRecordBenchmark {
   @Benchmark
   @Group("threads1")
   @GroupThreads(1)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_SingleThread(BenchmarkState benchmarkState) {
     record(benchmarkState);
@@ -123,9 +123,9 @@ public class LogRecordBenchmark {
   @Benchmark
   @Group("threads" + MAX_THREADS)
   @GroupThreads(MAX_THREADS)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_MultipleThreads(BenchmarkState benchmarkState) {
     record(benchmarkState);

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/MetricRecordBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/MetricRecordBenchmark.java
@@ -96,7 +96,7 @@ public class MetricRecordBenchmark {
 
     @Param AggregationTemporality aggregationTemporality;
 
-    @Param({"1", "100"})
+    @Param({"1", "128"})
     int cardinality;
 
     // The following parameters are excluded from the benchmark to reduce combinatorial explosion

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/MetricRecordBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/MetricRecordBenchmark.java
@@ -187,9 +187,9 @@ public class MetricRecordBenchmark {
   @Benchmark
   @Group("threads1")
   @GroupThreads(1)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_SingleThread(BenchmarkState benchmarkState) {
     record(benchmarkState);
@@ -198,9 +198,9 @@ public class MetricRecordBenchmark {
   @Benchmark
   @Group("threads" + MAX_THREADS)
   @GroupThreads(MAX_THREADS)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_MultipleThreads(BenchmarkState benchmarkState) {
     record(benchmarkState);

--- a/sdk/all/src/jmh/java/io/opentelemetry/sdk/SpanRecordBenchmark.java
+++ b/sdk/all/src/jmh/java/io/opentelemetry/sdk/SpanRecordBenchmark.java
@@ -123,9 +123,9 @@ public class SpanRecordBenchmark {
   @Benchmark
   @Group("threads1")
   @GroupThreads(1)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_SingleThread(BenchmarkState benchmarkState) {
     record(benchmarkState);
@@ -134,9 +134,9 @@ public class SpanRecordBenchmark {
   @Benchmark
   @Group("threads" + MAX_THREADS)
   @GroupThreads(MAX_THREADS)
-  @Fork(1)
-  @Warmup(iterations = 5, time = 1)
-  @Measurement(iterations = 5, time = 1)
+  @Fork(3)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 10, time = 1)
   @OperationsPerInvocation(RECORDS_PER_INVOCATION)
   public void record_MultipleThreads(BenchmarkState benchmarkState) {
     record(benchmarkState);


### PR DESCRIPTION
Despite bare metal runners, the variance for the benchmarks we publish is unacceptably high, with CV's regularly well above 10% and sometimes exceeding 20%: https://open-telemetry.github.io/opentelemetry-java/benchmarks/

I've been doing some experimenting and unfortunately, it seems like in order to get the variance down, we need to increase the JMH forks, and iteration count. I tried to minimize the run time while keeping CV <5%, and landed on:

- Forks: increase from 1 to 3
- Warmup iterations: reduce from 5 to 3
- Measurement iterations: increase from 5 to 10

Runtime change:

- Previous: 1 fork x 5 warmup x 5 measurement x 1s = 10s per case
- New: 3 forks x 3 warmup x 10 measurements x1s = 39s per case
- Cases: 40 metric + 6 log + 6 span = 52
- Expected run time change = 8.6min to 33.8min (in practice, the runtimes are longer)

@trask I know we run on shared hardware. Wondering if we can afford to reduce the variance without impacting other SIGs. If not, we could make up for the increased time by switching from running on every commit to main to running daily.
