### PR TITLE
Fix race condition causing flaky PeriodicMetricReaderTest

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -214,8 +214,8 @@ public final class PeriodicMetricReader implements MetricReader {
           }
           if (metricData.isEmpty()) {
             logger.log(Level.FINE, "No metric data to export - skipping export.");
-            flushResult.succeed();
             exportAvailable.set(true);
+            flushResult.succeed();
           } else {
             CompletableResultCode result = exporter.export(metricData);
             result.whenComplete(
@@ -223,8 +223,8 @@ public final class PeriodicMetricReader implements MetricReader {
                   if (!result.isSuccess()) {
                     logger.log(Level.FINE, "Exporter failed");
                   }
-                  flushResult.succeed();
                   exportAvailable.set(true);
+                  flushResult.succeed();
                 });
           }
         } catch (Throwable t) {


### PR DESCRIPTION
Fixes #8306

Race:

1. forceFlush() calls doRun(), which sets exportAvailable = false and assigns flushInProgress = flushResult                                                                                                                            
2. shutdown() calls flushInProgress.join() — waiting for the in-flight export                                                                                                                                                          
3. The blocking export completes → whenComplete fires: flushResult.succeed() (line 226) → shutdown() unblocks                                                                                                                          
4. Race: exportAvailable.set(true) (line 227) hasn't run yet                                                                                                                                                                           
5. shutdown() calls the final doRun() → CAS exportAvailable true→false fails (still false), so the export is dropped

cc @trask 