### PR TITLE
Fix flaky jaeger test by fully closing managed channel to isolate tests

### DIFF
--- a/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSampler.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/main/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSampler.java
@@ -185,6 +185,6 @@ public final class JaegerRemoteSampler implements Sampler, Closeable {
   public void close() {
     pollFuture.cancel(true);
     pollExecutor.shutdownNow();
-    grpcSender.shutdown();
+    grpcSender.shutdown().join(10, TimeUnit.SECONDS);
   }
 }

--- a/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/test/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerTest.java
@@ -103,9 +103,10 @@ class JaegerRemoteSamplerTest {
                                     io.opentelemetry.sdk.extension.trace.jaeger.proto.api_v2
                                         .Sampling.SamplingStrategyResponse>
                                 responseObserver) {
-                          ArmeriaStatusException grpcError = grpcErrors.peek();
+                          ArmeriaStatusException grpcError = grpcErrors.poll();
                           if (grpcError != null) {
                             responseObserver.onError(grpcError);
+                            return;
                           }
                           Sampling.SamplingStrategyResponse response = responses.poll();
                           // use default

--- a/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
+++ b/sdk-extensions/jaeger-remote-sampler/src/testGrpcNetty/java/io/opentelemetry/sdk/extension/trace/jaeger/sampler/JaegerRemoteSamplerGrpcNettyTest.java
@@ -112,7 +112,21 @@ class JaegerRemoteSamplerGrpcNettyTest {
   private ManagedChannel managedChannel() {
     ManagedChannel channel =
         ManagedChannelBuilder.forTarget(server.httpUri().getAuthority()).usePlaintext().build();
-    cleanup.addCloseable(channel::shutdownNow);
+    cleanup.addCloseable(
+        () -> {
+          // Graceful shutdown ensures the server has processed all in-flight requests before
+          // the next test starts, preventing stale requests from consuming errors added to the
+          // queue by a subsequent test.
+          channel.shutdown();
+          try {
+            if (!channel.awaitTermination(10, TimeUnit.SECONDS)) {
+              channel.shutdownNow();
+            }
+          } catch (InterruptedException e) {
+            channel.shutdownNow();
+            Thread.currentThread().interrupt();
+          }
+        });
     return channel;
   }
 


### PR DESCRIPTION
The JaegerRemoteSamplerGrpcNettyTest.unimplemented_error_server_response test fails 57% of the time: https://develocity.opentelemetry.io/scans/tests?search.timeZoneId=America%2FChicago&tests.container=io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSamplerGrpcNettyTest

Right now the theory is:

- Other tests configure tiny polling intervals (1ms), queueing up lots of requests to the shared armeria test server
- unimplemented_error_server_response starts, queues up a mock UNIMPLEMENTED error resposne, waits for a log to assert the jaeger sampler received and handled it correctly, but...
- the sampler never receives that error response because queued up requests from the jaeger samplers of other tests get served the response from the queue, leaving the jaeger sampler under test to get the default ok response

Solution is to try to isolate tests better by making sure requests from tests don't leak into each other. Accomplish this by a more thorough managed channel shutdown routine.