### PR TITLE
Add new *.impl.* package convention, internal code with japicmp compatibility

### DIFF
--- a/custom-checks/src/main/java/io/opentelemetry/gradle/customchecks/OtelImplJavadoc.java
+++ b/custom-checks/src/main/java/io/opentelemetry/gradle/customchecks/OtelImplJavadoc.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.gradle.customchecks;
+
+import static com.google.errorprone.BugPattern.LinkType.NONE;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.doctree.DocCommentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.PackageTree;
+import com.sun.tools.javac.api.JavacTrees;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+
+@BugPattern(
+    summary =
+        "This public impl class is missing the required javadoc disclaimer: \""
+            + OtelImplJavadoc.EXPECTED_IMPL_COMMENT
+            + "\"",
+    severity = WARNING,
+    linkType = NONE)
+public class OtelImplJavadoc extends BugChecker implements BugChecker.ClassTreeMatcher {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final Pattern IMPL_PACKAGE_PATTERN = Pattern.compile("\\bimpl\\b");
+
+  static final String EXPECTED_IMPL_COMMENT =
+      "This class is not intended for use by application developers."
+          + " Its API is stable and will not be changed or removed in a backwards-incompatible"
+          + " manner.";
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    if (!isPublic(tree) || !isImpl(state) || tree.getSimpleName().toString().endsWith("Test")) {
+      return Description.NO_MATCH;
+    }
+    String javadoc = getJavadoc(state);
+    if (javadoc != null && javadoc.contains(EXPECTED_IMPL_COMMENT)) {
+      return Description.NO_MATCH;
+    }
+    return describeMatch(tree);
+  }
+
+  private static boolean isPublic(ClassTree tree) {
+    return tree.getModifiers().getFlags().contains(Modifier.PUBLIC);
+  }
+
+  private static boolean isImpl(VisitorState state) {
+    PackageTree packageTree = state.getPath().getCompilationUnit().getPackage();
+    if (packageTree == null) {
+      return false;
+    }
+    String packageName = state.getSourceForNode(packageTree.getPackageName());
+    return packageName != null && IMPL_PACKAGE_PATTERN.matcher(packageName).find();
+  }
+
+  @Nullable
+  private static String getJavadoc(VisitorState state) {
+    DocCommentTree docCommentTree =
+        JavacTrees.instance(state.context).getDocCommentTree(state.getPath());
+    if (docCommentTree == null) {
+      return null;
+    }
+    return docCommentTree.toString().replace("\n", " ").replace(" * ", " ").replaceAll("\\s+", " ");
+  }
+}

--- a/custom-checks/src/main/resources/META-INF/services/com.google.errorprone.bugpatterns.BugChecker
+++ b/custom-checks/src/main/resources/META-INF/services/com.google.errorprone.bugpatterns.BugChecker
@@ -1,3 +1,4 @@
 io.opentelemetry.gradle.customchecks.OtelDeprecatedApiUsage
+io.opentelemetry.gradle.customchecks.OtelImplJavadoc
 io.opentelemetry.gradle.customchecks.OtelInternalJavadoc
 io.opentelemetry.gradle.customchecks.OtelPrivateConstructorForUtilityClass

--- a/custom-checks/src/test/java/io/opentelemetry/gradle/customchecks/OtelImplJavadocTest.java
+++ b/custom-checks/src/test/java/io/opentelemetry/gradle/customchecks/OtelImplJavadocTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.gradle.customchecks;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+class OtelImplJavadocTest {
+
+  @Test
+  void positiveCases() {
+    CompilationTestHelper.newInstance(OtelImplJavadoc.class, OtelImplJavadocTest.class)
+        .addSourceLines(
+            "impl/ImplJavadocPositiveCases.java",
+            "/*",
+            " * Copyright The OpenTelemetry Authors",
+            " * SPDX-License-Identifier: Apache-2.0",
+            " */",
+            "package io.opentelemetry.gradle.customchecks.impl;",
+            "// BUG: Diagnostic contains: missing the required javadoc disclaimer",
+            "public class ImplJavadocPositiveCases {",
+            "  // BUG: Diagnostic contains: missing the required javadoc disclaimer",
+            "  public static class One {}",
+            "  /** Doesn't have the disclaimer. */",
+            "  // BUG: Diagnostic contains: missing the required javadoc disclaimer",
+            "  public static class Two {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void negativeCases() {
+    CompilationTestHelper.newInstance(OtelImplJavadoc.class, OtelImplJavadocTest.class)
+        .addSourceLines(
+            "impl/ImplJavadocNegativeCases.java",
+            "/*",
+            " * Copyright The OpenTelemetry Authors",
+            " * SPDX-License-Identifier: Apache-2.0",
+            " */",
+            "package io.opentelemetry.gradle.customchecks.impl;",
+            "/**",
+            " * This class is not intended for use by application developers. Its API is stable and",
+            " * will not be changed or removed in a backwards-incompatible manner.",
+            " */",
+            "public class ImplJavadocNegativeCases {",
+            "  /**",
+            "   * This class is not intended for use by application developers. Its API is stable",
+            "   * and will not be changed or removed in a backwards-incompatible manner.",
+            "   */",
+            "  public static class One {}",
+            "  // Non-public class without disclaimer is fine.",
+            "  static class Two {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void nonImplPackageIgnored() {
+    CompilationTestHelper.newInstance(OtelImplJavadoc.class, OtelImplJavadocTest.class)
+        .addSourceLines(
+            "other/NonImplPackageCases.java",
+            "/*",
+            " * Copyright The OpenTelemetry Authors",
+            " * SPDX-License-Identifier: Apache-2.0",
+            " */",
+            "package io.opentelemetry.gradle.customchecks.other;",
+            "public class NonImplPackageCases {",
+            "  public static class One {}",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -11,14 +11,14 @@ is the signal.
 
 ## Topics
 
-| File | Load when |
-| --- | --- |
-| [build.md](build.md) | Always — build requirements and common tasks |
-| [general-patterns.md](general-patterns.md) | Always — style, nullability, visibility, AutoValue, locking, logging |
-| [api-stability.md](api-stability.md) | Public API additions, removals, renames, or deprecations; stable vs alpha compatibility |
-| [gradle-conventions.md](gradle-conventions.md) | `build.gradle.kts` or `settings.gradle.kts` changes; new modules |
-| [testing-patterns.md](testing-patterns.md) | Test files in scope — assertions, test utilities, test suites |
-| [other-tasks.md](other-tasks.md) | Dev environment setup, benchmarks, composite builds, native image tests, OTLP protobuf updates |
+| File                                           | Load when                                                                                      |
+|------------------------------------------------|------------------------------------------------------------------------------------------------|
+| [build.md](build.md)                           | Always — build requirements and common tasks                                                   |
+| [general-patterns.md](general-patterns.md)     | Always — style, nullability, visibility, AutoValue, locking, logging, internal & impl packages |
+| [api-stability.md](api-stability.md)           | Public API additions, removals, renames, or deprecations, stable vs alpha compatibility        |
+| [gradle-conventions.md](gradle-conventions.md) | `build.gradle.kts` or `settings.gradle.kts` changes; new modules                               |
+| [testing-patterns.md](testing-patterns.md)     | Test files in scope — assertions, test utilities, test suites                                  |
+| [other-tasks.md](other-tasks.md)               | Dev environment setup, benchmarks, composite builds, native image tests, OTLP protobuf updates |
 
 ## Conventions
 

--- a/docs/knowledge/general-patterns.md
+++ b/docs/knowledge/general-patterns.md
@@ -64,6 +64,29 @@ most violations automatically.
 - **EditorConfig** (`.editorconfig`) — configures IntelliJ to match project style automatically.
   It doesn't cover all rules, so `spotlessApply` is still required.
 
+## Impl (Implementation) code
+
+Use `*.impl.*` sub-packages for code that must be `public` to be shared across OpenTelemetry
+modules, but is not intended for use by application developers. This is the right choice when
+`*.internal.*` is too restrictive — for example, a utility used by both the API and SDK modules
+that needs a stable contract across module boundaries.
+
+Unlike `*.internal.*` packages, `*.impl.*` packages carry full backwards-compatibility guarantees
+and are included in `japicmp` compatibility checks.
+
+Public classes in `impl` packages must carry the following disclaimer (enforced by the
+`OtelImplJavadoc` Error Prone check in `custom-checks/`):
+
+```java
+/**
+ * This class is not intended for use by application developers. Its API is stable and will not
+ * be changed or removed in a backwards-incompatible manner.
+ */
+```
+
+See also [Internal code](#internal-code) for code that is not for application developers and has
+no stability guarantees.
+
 ## Internal code
 
 Prefer package-private over putting code in an `internal` package. Use `internal` only when the
@@ -92,6 +115,9 @@ check in `custom-checks/`):
 Internal code must not be used across module boundaries — module `foo` must not call internal
 code from module `bar`. Cross-module internal usage is a known issue being tracked and cleaned up
 in open-telemetry/opentelemetry-java#6970.
+
+See also [Impl (Implementation) code](#impl-implementation-code) for cross-module code that is not for application developers but
+requires a stable ABI.
 
 ## Javadoc
 

--- a/docs/knowledge/general-patterns.md
+++ b/docs/knowledge/general-patterns.md
@@ -117,7 +117,7 @@ code from module `bar`. Cross-module internal usage is a known issue being track
 in open-telemetry/opentelemetry-java#6970.
 
 See also [Impl (Implementation) code](#impl-implementation-code) for cross-module code that is not for application developers but
-requires a stable ABI.
+requires a stable API.
 
 ## Javadoc
 


### PR DESCRIPTION
Related to #6970.

We need a new stability tier for code that is public (for cross-module access within the OpenTelemetry project) but not intended for application developers — with full backwards-compatibility guarantees, unlike *.internal.*.                                                                                                                                                                                                          

As discussed in 4/23 java SIG, ApiUsageLogger from #8318 is an early candidate for this.

Others potential candidates:

- [CompoenntId](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/ComponentId.java) and other internal instrumentation utils
- [ComponentRegistry](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/ComponentRegistry.java) and other internal SDK implementation utils (ThrottlingLogger, DaemonThreadfactory, GlobUtil, etc)
- [GrpcExporter](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/GrpcExporter.java), HttpExporter, and other exporter impelemtnation utils
- And more

Options considered:                                                                                                                                                                                                    
                                                                                                                  
* *.util.*: rejected because Java developers associate "util" with user-facing packages (java.util.concurrent, etc.), which may mislead application developers into thinking the code is for them.                  
* *.internal.shared.* / *.internal.stable.*: rejected because these live under *.internal.*, which the project has established as meaning unstable. Carving out a stable sub-package would contradict that convention and require fiddly japicmp exclusion changes. 
* *.moduleinternal.* / *.componentapi.*: considered but rejected as too verbose or without prior art in the Java ecosystem.
* *.impl.* — **chosen** because it is a reasonably well-understood Java idiom signaling "implementation detail, not user-facing API", it does not conflict with any existing OTel package conventions, and it falls outside the current japicmp exclusion patterns (*.internal / *.internal.*) so compatibility checking applies automatically with no build config changes.                                                                           
                                                                                                                                                                                                                         
Classes in *.impl.* packages must include standard javadoc boilerplate:

> This class is not intended for use by application developers. Its API is stable and will not be changed or removed in a backwards-incompatible manner.

