### PR TITLE
Add hasValueSatisfying to LongPointAssert and DoublePointAssert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### SDK
+
+#### Testing
+
+* Add `hasValueSatisfying` to `LongPointAssert` and `DoublePointAssert` for fuzzy value matching
+
 ## Version 1.61.0 (2026-04-10)
 
 ### API

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,7 @@
 Comparing source compatibility of opentelemetry-sdk-testing-1.62.0-SNAPSHOT.jar against opentelemetry-sdk-testing-1.61.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.DoublePointAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoublePointAssert hasValueSatisfying(java.util.function.Consumer<org.assertj.core.api.AbstractDoubleAssert<?>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.LongPointAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongPointAssert hasValueSatisfying(java.util.function.Consumer<org.assertj.core.api.AbstractLongAssert<?>>)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
@@ -34,9 +34,7 @@ public final class DoublePointAssert
     return this;
   }
 
-  /**
-   * Asserts the point's value satisfies the given assertion.
-   */
+  /** Asserts the point's value satisfies the given assertion. */
   public DoublePointAssert hasValueSatisfying(Consumer<AbstractDoubleAssert<?>> valueAssertion) {
     isNotNull();
     valueAssertion.accept(Assertions.assertThat(actual.getValue()).as("value"));

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoublePointAssert.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -30,6 +31,15 @@ public final class DoublePointAssert
   public DoublePointAssert hasValue(double expected) {
     isNotNull();
     Assertions.assertThat(actual.getValue()).as("value").isEqualTo(expected);
+    return this;
+  }
+
+  /**
+   * Asserts the point's value satisfies the given assertion.
+   */
+  public DoublePointAssert hasValueSatisfying(Consumer<AbstractDoubleAssert<?>> valueAssertion) {
+    isNotNull();
+    valueAssertion.accept(Assertions.assertThat(actual.getValue()).as("value"));
     return this;
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
@@ -12,6 +12,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import org.assertj.core.api.AbstractLongAssert;
 
 /**
  * Assertions for an exported {@link LongPointData}.
@@ -28,6 +29,15 @@ public final class LongPointAssert extends AbstractPointAssert<LongPointAssert, 
   public LongPointAssert hasValue(long expected) {
     isNotNull();
     assertThat(actual.getValue()).as("value").isEqualTo(expected);
+    return this;
+  }
+
+  /**
+   * Asserts the point's value satisfies the given assertion.
+   */
+  public LongPointAssert hasValueSatisfying(Consumer<AbstractLongAssert<?>> valueAssertion) {
+    isNotNull();
+    valueAssertion.accept(assertThat(actual.getValue()).as("value"));
     return this;
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongPointAssert.java
@@ -32,9 +32,7 @@ public final class LongPointAssert extends AbstractPointAssert<LongPointAssert, 
     return this;
   }
 
-  /**
-   * Asserts the point's value satisfies the given assertion.
-   */
+  /** Asserts the point's value satisfies the given assertion. */
   public LongPointAssert hasValueSatisfying(Consumer<AbstractLongAssert<?>> valueAssertion) {
     isNotNull();
     valueAssertion.accept(assertThat(actual.getValue()).as("value"));

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -352,6 +352,7 @@ class MetricAssertionsTest {
                             .hasEpochNanos(4)
                             .hasAttributes(Attributes.empty())
                             .hasValue(3.0)
+                            .hasValueSatisfying(val -> val.isEqualTo(3.0))
                             .hasExemplars(DOUBLE_EXEMPLAR2, DOUBLE_EXEMPLAR1)
                             .hasExemplarsSatisfying(
                                 exemplar ->
@@ -857,6 +858,7 @@ class MetricAssertionsTest {
                     point ->
                         point
                             .hasValue(Long.MAX_VALUE)
+                            .hasValueSatisfying(val -> val.isEqualTo(Long.MAX_VALUE))
                             .hasExemplarsSatisfying(
                                 exemplar -> exemplar.hasValue(2),
                                 exemplar ->
@@ -902,6 +904,15 @@ class MetricAssertionsTest {
                         gauge ->
                             gauge.hasPointsSatisfying(
                                 point -> point.hasValue(2), point -> point.hasValue(1))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(LONG_GAUGE_METRIC)
+                    .hasLongGaugeSatisfying(
+                        gauge ->
+                            gauge.hasPointsSatisfying(
+                                point -> point.hasValueSatisfying(val -> val.isNegative()),
+                                point -> point.hasValueSatisfying(val -> val.isNegative()))))
         .isInstanceOf(AssertionError.class);
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
This would help simplify a few metric assertions in the instrumentation repo and feels like a pretty natural addition.