### PR TITLE
Add containsPointsSatisfying to metric data asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### SDK
+
+#### Testing
+
+* Add `containsPointsSatisfying` to metric data asserts for "each given assertion must be
+  satisfied by at least one point, extras allowed" checks on sum, gauge, histogram, exponential
+  histogram, and summary data
+
 ## Version 1.61.0 (2026-04-10)
 
 ### API

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-testing.txt
@@ -1,2 +1,36 @@
 Comparing source compatibility of opentelemetry-sdk-testing-1.62.0-SNAPSHOT.jar against opentelemetry-sdk-testing-1.61.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.DoublePointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleGaugeAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.DoublePointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.DoubleSumAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.DoublePointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.DoubleSumAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.DoublePointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.ExponentialHistogramAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.ExponentialHistogramAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.ExponentialHistogramPointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.ExponentialHistogramAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.ExponentialHistogramPointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.HistogramAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.HistogramPointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.HistogramAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.HistogramPointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.LongGaugeAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.LongPointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongGaugeAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.LongPointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.LongSumAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.LongPointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.LongSumAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.LongPointAssert>>)
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.testing.assertj.SummaryAssert  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) FINAL(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert containsPointsSatisfying(java.util.function.Consumer[]<io.opentelemetry.sdk.testing.assertj.SummaryPointAssert>)
+		+++  NEW ANNOTATION: java.lang.SafeVarargs
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.testing.assertj.SummaryAssert containsPointsSatisfying(java.lang.Iterable<? extends java.util.function.Consumer<? extends io.opentelemetry.sdk.testing.assertj.SummaryPointAssert>>)

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleGaugeAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleGaugeAssert.java
@@ -45,4 +45,31 @@ public final class DoubleGaugeAssert
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the gauge satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final DoubleGaugeAssert containsPointsSatisfying(
+      Consumer<DoublePointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the gauge satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public DoubleGaugeAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<DoublePointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<DoublePointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new DoublePointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/DoubleSumAssert.java
@@ -88,4 +88,30 @@ public final class DoubleSumAssert
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, DoublePointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the sum satisfies it. Extra points
+   * that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final DoubleSumAssert containsPointsSatisfying(Consumer<DoublePointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the sum satisfies it. Extra points
+   * that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public DoubleSumAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<DoublePointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<DoublePointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new DoublePointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExponentialHistogramAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/ExponentialHistogramAssert.java
@@ -74,4 +74,31 @@ public final class ExponentialHistogramAssert
             AssertUtil.toConsumers(assertions, ExponentialHistogramPointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the exponential histogram
+   * satisfies it. Extra points that match none of the assertions are allowed, and a single point
+   * may satisfy multiple assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final ExponentialHistogramAssert containsPointsSatisfying(
+      Consumer<ExponentialHistogramPointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the exponential histogram
+   * satisfies it. Extra points that match none of the assertions are allowed, and a single point
+   * may satisfy multiple assertions.
+   */
+  public ExponentialHistogramAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<ExponentialHistogramPointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<ExponentialHistogramPointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new ExponentialHistogramPointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/HistogramAssert.java
@@ -72,4 +72,31 @@ public final class HistogramAssert extends AbstractAssert<HistogramAssert, Histo
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, HistogramPointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the histogram satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final HistogramAssert containsPointsSatisfying(
+      Consumer<HistogramPointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the histogram satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public HistogramAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<HistogramPointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<HistogramPointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new HistogramPointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongGaugeAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongGaugeAssert.java
@@ -44,4 +44,30 @@ public final class LongGaugeAssert
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the gauge satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final LongGaugeAssert containsPointsSatisfying(Consumer<LongPointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the gauge satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public LongGaugeAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<LongPointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<LongPointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new LongPointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/LongSumAssert.java
@@ -87,4 +87,30 @@ public final class LongSumAssert extends AbstractAssert<LongSumAssert, SumData<L
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, LongPointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the sum satisfies it. Extra points
+   * that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final LongSumAssert containsPointsSatisfying(Consumer<LongPointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the sum satisfies it. Extra points
+   * that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public LongSumAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<LongPointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<LongPointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new LongPointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryAssert.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/SummaryAssert.java
@@ -52,4 +52,30 @@ public final class SummaryAssert extends AbstractAssert<SummaryAssert, SummaryDa
         .satisfiesExactlyInAnyOrder(AssertUtil.toConsumers(assertions, SummaryPointAssert::new));
     return this;
   }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the summary satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final SummaryAssert containsPointsSatisfying(Consumer<SummaryPointAssert>... assertions) {
+    return containsPointsSatisfying(Arrays.asList(assertions));
+  }
+
+  /**
+   * Asserts that for each given assertion, at least one point in the summary satisfies it. Extra
+   * points that match none of the assertions are allowed, and a single point may satisfy multiple
+   * assertions.
+   */
+  public SummaryAssert containsPointsSatisfying(
+      Iterable<? extends Consumer<SummaryPointAssert>> assertions) {
+    isNotNull();
+    for (Consumer<SummaryPointAssert> assertion : assertions) {
+      assertThat(actual.getPoints())
+          .anySatisfy(point -> assertion.accept(new SummaryPointAssert(point)));
+    }
+    return this;
+  }
 }

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/MetricAssertionsTest.java
@@ -1288,4 +1288,70 @@ class MetricAssertionsTest {
                                 point -> point.hasValuesSatisfying(value -> value.hasValue(3.0)))))
         .isInstanceOf(AssertionError.class);
   }
+
+  @Test
+  void containsPointsSatisfying() {
+    assertThat(DOUBLE_GAUGE_METRIC)
+        .hasDoubleGaugeSatisfying(
+            gauge -> gauge.containsPointsSatisfying(point -> point.hasValue(3.0)));
+    assertThat(LONG_GAUGE_METRIC)
+        .hasLongGaugeSatisfying(
+            gauge ->
+                gauge.containsPointsSatisfying(
+                    point -> point.hasValue(Long.MAX_VALUE), point -> point.hasValue(1)));
+    assertThat(DOUBLE_SUM_METRIC)
+        .hasDoubleSumSatisfying(sum -> sum.containsPointsSatisfying(point -> point.hasValue(3.0)));
+    assertThat(LONG_SUM_METRIC)
+        .hasLongSumSatisfying(
+            sum -> sum.containsPointsSatisfying(point -> point.hasValue(Long.MAX_VALUE)));
+    assertThat(HISTOGRAM_METRIC)
+        .hasHistogramSatisfying(
+            histogram -> histogram.containsPointsSatisfying(point -> point.hasSum(15)));
+    assertThat(EXPONENTIAL_HISTOGRAM_METRIC)
+        .hasExponentialHistogramSatisfying(
+            histogram -> histogram.containsPointsSatisfying(point -> point.hasSum(10.0)));
+    assertThat(SUMMARY_METRIC)
+        .hasSummarySatisfying(
+            summary -> summary.containsPointsSatisfying(point -> point.hasSum(2.0)));
+  }
+
+  @Test
+  void containsPointsSatisfyingFailure() {
+    // single assertion that matches no point
+    assertThatThrownBy(
+            () ->
+                assertThat(DOUBLE_GAUGE_METRIC)
+                    .hasDoubleGaugeSatisfying(
+                        gauge -> gauge.containsPointsSatisfying(point -> point.hasValue(42.0))))
+        .isInstanceOf(AssertionError.class);
+    // one of multiple assertions unmatched
+    assertThatThrownBy(
+            () ->
+                assertThat(LONG_GAUGE_METRIC)
+                    .hasLongGaugeSatisfying(
+                        gauge ->
+                            gauge.containsPointsSatisfying(
+                                point -> point.hasValue(Long.MAX_VALUE),
+                                point -> point.hasValue(42))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(HISTOGRAM_METRIC)
+                    .hasHistogramSatisfying(
+                        histogram -> histogram.containsPointsSatisfying(point -> point.hasSum(42))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(EXPONENTIAL_HISTOGRAM_METRIC)
+                    .hasExponentialHistogramSatisfying(
+                        histogram ->
+                            histogram.containsPointsSatisfying(point -> point.hasSum(42.0))))
+        .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(
+            () ->
+                assertThat(SUMMARY_METRIC)
+                    .hasSummarySatisfying(
+                        summary -> summary.containsPointsSatisfying(point -> point.hasSum(42.0))))
+        .isInstanceOf(AssertionError.class);
+  }
 }


### PR DESCRIPTION
Unfortunately, we can't follow `hasAttributesSatisfying` / `hasAttributesSatisfyingExactly` pattern, since `hasPointsSatisfying` is doing the "Exactly" behavior already.

`containsPointsSatisfying` is the best name I could come up with to differentiate with `hasPointsSatisfying`.

Demonstration of this new method at https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18263