### PR TITLE
Rework benchmark display

### DIFF
--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -53,7 +53,6 @@
 
     button:hover {
       background-color: #2793da;
-      flex: none;
     }
 
     .spacer {
@@ -70,35 +69,25 @@
       align-items: center;
     }
 
-    .header-label {
-      margin-right: 4px;
-    }
-
-    .benchmark-set {
-      margin: 8px 0;
-      width: 100%;
+    #date-filter {
       display: flex;
-      flex-direction: column;
-    }
-
-    .benchmark-title {
-      font-size: 3rem;
-      font-weight: 600;
-      word-break: break-word;
-      text-align: center;
-    }
-
-    .benchmark-graphs {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-around;
       align-items: center;
+      gap: 12px;
+      margin: 12px 0;
       flex-wrap: wrap;
-      width: 100%;
+      font-size: 0.9rem;
     }
 
-    .benchmark-chart {
-      max-width: 1000px;
+    #date-filter label {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    #date-filter button {
+      font-size: 0.85rem;
+      padding: 3px 10px;
+      border-radius: 3px;
     }
 
     header nav {
@@ -127,11 +116,107 @@
       margin-right: auto;
       margin-left: auto;
     }
+
+    .benchmark-set {
+      margin: 8px 0;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .benchmark-graphs {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+    }
+
+    .chart-wrapper {
+      width: 100%;
+      max-width: 1000px;
+      margin-bottom: 48px;
+    }
+
+    .chart-header {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+
+    .chart-header h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 600;
+      word-break: break-all;
+    }
+
+    .source-link {
+      font-size: 0.8em;
+      white-space: nowrap;
+    }
+
+    .custom-legend {
+      margin-top: 8px;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+      padding: 8px 12px;
+      background: #fafafa;
+    }
+
+    .legend-controls {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 8px;
+    }
+
+    .legend-controls button {
+      font-size: 0.75rem;
+      padding: 2px 10px;
+      border-radius: 3px;
+      line-height: 1.6;
+    }
+
+    .legend-items {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      cursor: pointer;
+      font-size: 0.82rem;
+      user-select: none;
+      white-space: nowrap;
+      padding: 2px 0;
+    }
+
+    .legend-item.inactive {
+      opacity: 0.4;
+    }
+
+    .legend-swatch {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+
+    .legend-item input[type="checkbox"] {
+      cursor: pointer;
+      margin: 0;
+    }
   </style>
   <title>Java SDK Benchmarks</title>
 </head>
 <body>
-<header id="header">
+<header>
   <nav>
     <div class="header-item logo">
       <a href="https://opentelemetry.io">
@@ -160,6 +245,12 @@
     <strong>Repository:</strong>
     <a id="repository-link" rel="noopener"></a>
   </div>
+  <div id="date-filter">
+    <strong>Date range:</strong>
+    <label>From <input type="date" id="range-start"></label>
+    <label>to <input type="date" id="range-end"></label>
+    <button id="range-reset">Reset</button>
+  </div>
   <main id="main"></main>
 </div>
 <footer>
@@ -170,9 +261,11 @@
   </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@3.7.2/build/global/luxon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js"></script>
 <script src="data.js"></script>
-<script id="main-script">
+<script>
   'use strict';
   (function () {
     const COLORS = [
@@ -189,58 +282,282 @@
       "#410472",
     ];
 
-    function init() {
-      function collectBenchesPerTestCase(entries) {
-        const byGroup = new Map();
-        const commitIds = [];
-        for (const entry of entries) {
-          const {commit, date, tool, benches} = entry;
-          const commitId = commit.id.slice(0, 7);
-          commitIds.push(commitId);
-          for (const bench of benches) {
-            const result = {commit, date, tool, bench};
-            let index = bench.name.lastIndexOf(".");
-            const benchName = bench.name.substring(0, index)
-            const testName = bench.name.substring(index + 1) + ` (${bench.extra})`;
-            let byName = byGroup.get(benchName);
-            if (byName === undefined) {
-              byName = new Map();
-              byGroup.set(benchName, byName);
-            }
-            let byCommitId = byName.get(testName);
-            if (byCommitId === undefined) {
-              byCommitId = new Map();
-              byCommitId.set(commitId, result)
-              byName.set(testName, byCommitId);
-            } else {
-              byCommitId.set(commitId, result);
-            }
-          }
+    // "2026-01-26T14:19:25-06:00" → "2026-01-26"
+    function formatCommitDate(isoTimestamp) {
+      return isoTimestamp.slice(0, 10);
+    }
+
+    // Parse "methodName ( {json} )" into a compact label like "methodName [val1, val2]".
+    function formatSeriesLabel(nameAfterClass) {
+      const jsonMatch = nameAfterClass.match(/\(\s*(\{[\s\S]*?\})\s*\)/);
+      const methodName = nameAfterClass.replace(/\s*\([\s\S]*?\)\s*$/, '').trim();
+      if (jsonMatch) {
+        try {
+          const params = JSON.parse(jsonMatch[1]);
+          const values = Object.values(params).map(v => String(v));
+          return methodName + ' [' + values.join(', ') + ']';
+        } catch (e) {
+          // fall through
         }
-        return {
-          commitIds,
-          byGroup
-        };
+      }
+      return methodName;
+    }
+
+    function collectBenchesPerTestCase(entries) {
+      // byGroup: Map<className, Map<seriesKey, {label, byCommitId: Map<commitId, result>}>>
+      const byGroup = new Map();
+      const commitIds = [];
+      const commitLabels = []; // x-axis labels: YYYY-MM-DD dates
+
+      for (const entry of entries) {
+        const {commit, benches} = entry;
+        const commitId = commit.id.slice(0, 7);
+        commitIds.push(commitId);
+        commitLabels.push(formatCommitDate(commit.timestamp));
+
+        for (const bench of benches) {
+          const result = {commit, bench};
+          const lastDot = bench.name.lastIndexOf('.');
+          const className = bench.name.substring(0, lastDot);
+          const nameAfterClass = bench.name.substring(lastDot + 1);
+
+          let byName = byGroup.get(className);
+          if (!byName) {
+            byName = new Map();
+            byGroup.set(className, byName);
+          }
+
+          let seriesEntry = byName.get(nameAfterClass);
+          if (!seriesEntry) {
+            seriesEntry = {
+              label: formatSeriesLabel(nameAfterClass),
+              byCommitId: new Map(),
+            };
+            byName.set(nameAfterClass, seriesEntry);
+          }
+          seriesEntry.byCommitId.set(commitId, result);
+        }
       }
 
+      return {commitIds, commitLabels, byGroup};
+    }
+
+    function getSourceUrl(repoUrl, className) {
+      const path = className.replace(/\./g, '/');
+      return `${repoUrl}/blob/main/sdk/all/src/jmh/java/${path}.java`;
+    }
+
+    function renderGraph(parent, className, commitIds, commitLabels, seriesMap, repoUrl) {
+      const header = document.createElement('div');
+      header.className = 'chart-header';
+
+      const title = document.createElement('h3');
+      const simpleClassName = className.substring(className.lastIndexOf('.') + 1);
+      title.textContent = simpleClassName;
+      title.title = className;
+      header.appendChild(title);
+
+      const sourceLink = document.createElement('a');
+      sourceLink.href = getSourceUrl(repoUrl, className);
+      sourceLink.textContent = '[source]';
+      sourceLink.rel = 'noopener';
+      sourceLink.target = '_blank';
+      sourceLink.className = 'source-link';
+      header.appendChild(sourceLink);
+
+      parent.appendChild(header);
+
+      const canvas = document.createElement('canvas');
+      parent.appendChild(canvas);
+
+      const results = [];
+      for (const [, {label, byCommitId}] of seriesMap.entries()) {
+        results.push({
+          label,
+          dataset: commitIds.map(commitId => byCommitId.get(commitId) ?? null),
+        });
+      }
+      results.sort((a, b) => a.label.localeCompare(b.label));
+
+      const unit = results.flatMap(r => r.dataset).find(d => d !== null)?.bench.unit ?? '';
+
+      // currentIndices maps filtered dataIndex → original commitIds index, kept in sync by applyFilter.
+      let currentIndices = commitIds.map((_, i) => i);
+
+      const chart = new Chart(canvas, {
+        type: 'line',
+        data: {
+          labels: commitLabels,
+          datasets: results.map(({label, dataset}, index) => {
+            const color = COLORS[index % COLORS.length];
+            return {
+              label,
+              data: dataset.map(d => d?.bench.value ?? null),
+              fill: false,
+              borderColor: color,
+              backgroundColor: color,
+              pointRadius: 3,
+              pointHoverRadius: 5,
+              spanGaps: false,
+            };
+          }),
+        },
+        options: {
+          responsive: true,
+          onClick: (event, elements) => {
+            if (!elements.length) return;
+            const {datasetIndex, index: dataIndex} = elements[0];
+            const d = results[datasetIndex].dataset[currentIndices[dataIndex]];
+            if (d) window.open(`${repoUrl}/tree/${d.commit.id}`, '_blank', 'noopener');
+          },
+          onHover: (event, elements) => {
+            event.native.target.style.cursor = elements.length ? 'pointer' : 'default';
+          },
+          scales: {
+            x: {
+              type: 'time',
+              time: {
+                tooltipFormat: 'yyyy-MM-dd',
+                displayFormats: {day: 'MMM d', week: 'MMM d', month: 'MMM yyyy', year: 'yyyy'},
+              },
+              ticks: {maxTicksLimit: 8, maxRotation: 45},
+              title: {display: true, text: 'date'},
+            },
+            y: {
+              beginAtZero: true,
+              title: {display: true, text: unit},
+              ticks: {
+                callback: (value) => {
+                  if (value >= 1_000_000) return (value / 1_000_000).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'M';
+                  if (value >= 1_000) return (value / 1_000).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'K';
+                  return value;
+                },
+              },
+            },
+          },
+          plugins: {
+            legend: {display: false},
+            tooltip: {
+              callbacks: {
+                afterTitle: (items) => {
+                  if (!items.length) return '';
+                  const item = items[0];
+                  const d = results[item.datasetIndex].dataset[currentIndices[item.dataIndex]];
+                  if (!d) return '';
+                  const sha = d.commit.id.slice(0, 7);
+                  const ts = new Date(d.commit.timestamp).toLocaleString(undefined, {
+                    year: 'numeric', month: 'short', day: 'numeric',
+                    hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+                  });
+                  return '\n' + sha + ' — ' + d.commit.message + '\n\n' + ts + ' by @' + d.commit.author.username + '\n';
+                },
+                label: (item) => {
+                  const d = results[item.datasetIndex].dataset[currentIndices[item.dataIndex]];
+                  if (!d) return item.dataset.label;
+                  const {range, unit} = d.bench;
+                  let text = `${item.dataset.label}: ${item.formattedValue} ${unit}`;
+                  if (range) text += ' (' + range + ')';
+                  return text;
+                },
+              },
+            },
+          },
+        },
+      });
+
+      // Custom legend with per-series toggles and All/None controls.
+      const legendDiv = document.createElement('div');
+      legendDiv.className = 'custom-legend';
+
+      const controls = document.createElement('div');
+      controls.className = 'legend-controls';
+
+      const itemEls = [];
+
+      const allBtn = document.createElement('button');
+      allBtn.textContent = 'All';
+      allBtn.onclick = () => {
+        results.forEach((_, i) => {
+          chart.setDatasetVisibility(i, true);
+          itemEls[i].classList.remove('inactive');
+          itemEls[i].querySelector('input').checked = true;
+        });
+        chart.update();
+      };
+
+      const noneBtn = document.createElement('button');
+      noneBtn.textContent = 'None';
+      noneBtn.onclick = () => {
+        results.forEach((_, i) => {
+          chart.setDatasetVisibility(i, false);
+          itemEls[i].classList.add('inactive');
+          itemEls[i].querySelector('input').checked = false;
+        });
+        chart.update();
+      };
+
+      controls.append(allBtn, noneBtn);
+      legendDiv.appendChild(controls);
+
+      const itemsContainer = document.createElement('div');
+      itemsContainer.className = 'legend-items';
+
+      results.forEach(({label}, i) => {
+        const color = COLORS[i % COLORS.length];
+
+        const itemEl = document.createElement('label');
+        itemEl.className = 'legend-item';
+        itemEl.title = label;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = true;
+        checkbox.onchange = () => {
+          chart.setDatasetVisibility(i, checkbox.checked);
+          itemEl.classList.toggle('inactive', !checkbox.checked);
+          chart.update();
+        };
+
+        const swatch = document.createElement('span');
+        swatch.className = 'legend-swatch';
+        swatch.style.backgroundColor = color;
+
+        itemEl.append(checkbox, swatch, document.createTextNode(' ' + label));
+        itemsContainer.appendChild(itemEl);
+        itemEls.push(itemEl);
+      });
+
+      legendDiv.appendChild(itemsContainer);
+      parent.appendChild(legendDiv);
+
+      return {
+        applyFilter(indices, labels) {
+          currentIndices = indices;
+          chart.data.labels = labels;
+          chart.data.datasets.forEach((ds, di) => {
+            ds.data = indices.map(i => results[di].dataset[i]?.bench.value ?? null);
+          });
+          chart.update();
+        },
+      };
+    }
+
+    function init() {
       const data = window.BENCHMARK_DATA;
 
-      data.entries.Benchmark.sort(function (a, b) {
+      data.entries.Benchmark.sort((a, b) => {
         const keyA = new Date(a.commit.timestamp);
         const keyB = new Date(b.commit.timestamp);
         if (keyA < keyB) return -1;
         if (keyA > keyB) return 1;
-        // if same commit time sort by execution time.
         return a.date - b.date;
       });
 
-      // Render header
       document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
       const repoLink = document.getElementById('repository-link');
       repoLink.href = data.repoUrl;
       repoLink.textContent = data.repoUrl;
 
-      // Render footer
       document.getElementById('dl-button').onclick = () => {
         const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
         const a = document.createElement('a');
@@ -249,130 +566,70 @@
         a.click();
       };
 
-      // Prepare data points for charts
-      return Object.keys(data.entries).map(name => ({
-        name,
-        dataSet: collectBenchesPerTestCase(data.entries[name]),
-      }));
-    }
-
-    function renderAllChars(dataSets) {
-
-      function renderGraph(parent, name, commitIds, byName) {
-        const chartTitle = document.createElement('h3');
-        chartTitle.textContent = name;
-        parent.append(chartTitle);
-
-        const canvas = document.createElement('canvas');
-        canvas.className = 'benchmark-chart';
-        parent.appendChild(canvas);
-
-        const results = [];
-        for (const [name, byCommitId] of byName.entries()) {
-          results.push({
-            name,
-            dataset: commitIds.map(commitId => byCommitId.get(commitId) ?? null)
-          });
-        }
-        results.sort((a, b) => a.name.localeCompare(b.name));
-
-        const data = {
-          labels: commitIds,
-          datasets: results.map(({name, dataset}, index) => {
-            const color = COLORS[index % COLORS.length];
-
-            return {
-              label: name,
-              data: dataset.map(d => d?.bench.value ?? null),
-              fill: false,
-              borderColor: color,
-              backgroundColor: color,
-            };
-          }),
-        };
-
-        const options = {
-          scales: {
-            xAxes: [
-              {
-                scaleLabel: {
-                  display: true,
-                  labelString: 'commit',
-                },
-              }
-            ],
-            yAxes: [
-              {
-                scaleLabel: {
-                  display: true,
-                  labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
-                },
-                ticks: {
-                  beginAtZero: true,
-                }
-              }
-            ],
-          },
-          tooltips: {
-            callbacks: {
-              afterTitle: items => {
-                const {datasetIndex, index} = items[0];
-                const data = results[datasetIndex].dataset[index];
-                return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
-              },
-              label: item => {
-                const {datasetIndex, index, value} = item;
-                const {name, dataset} = results[datasetIndex];
-                const {range, unit} = dataset[index].bench;
-                let label = `${name}: ${value}`;
-                label += unit;
-                if (range) {
-                  label += ' (' + range + ')';
-                }
-                return label;
-              },
-            }
-          },
-          legend: {
-            display: !name.includes('MetricRecordBenchmark')
-          }
-        };
-
-        new Chart(canvas, {
-          type: 'line',
-          data,
-          options,
-        });
-      }
-
-      function renderBenchSet(name, benchSet, main) {
-        const setElem = document.createElement('div');
-        setElem.className = 'benchmark-set';
-        main.appendChild(setElem);
-
-        const graphsElem = document.createElement('div');
-        graphsElem.className = 'benchmark-graphs';
-        setElem.appendChild(graphsElem);
-
-        const {commitIds, byGroup} = benchSet;
-        const groups = [];
-        for (const [name, byName] of byGroup.entries()) {
-          groups.push({name, byName});
-        }
-        groups.sort((a, b) => a.name.localeCompare(b.name));
-
-        for (const {name, byName} of groups) {
-          renderGraph(graphsElem, name, commitIds, byName);
-        }
-      }
+      const {commitIds, commitLabels, byGroup} = collectBenchesPerTestCase(data.entries.Benchmark);
 
       const main = document.getElementById('main');
-      for (const {name, dataSet} of dataSets) {
-        renderBenchSet(name, dataSet, main);
+      const setElem = document.createElement('div');
+      setElem.className = 'benchmark-set';
+      const graphsElem = document.createElement('div');
+      graphsElem.className = 'benchmark-graphs';
+      setElem.appendChild(graphsElem);
+      main.appendChild(setElem);
+
+      const groups = [];
+      for (const [name, seriesMap] of byGroup.entries()) {
+        groups.push({name, seriesMap});
       }
+      groups.sort((a, b) => a.name.localeCompare(b.name));
+
+      const chartInstances = [];
+      for (const {name, seriesMap} of groups) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'chart-wrapper';
+        graphsElem.appendChild(wrapper);
+        chartInstances.push(renderGraph(wrapper, name, commitIds, commitLabels, seriesMap, data.repoUrl));
+      }
+
+      // Global date range picker
+      const minDate = commitLabels.reduce((a, b) => a < b ? a : b);
+      const maxDate = commitLabels.reduce((a, b) => a > b ? a : b);
+
+      const rangeStart = document.getElementById('range-start');
+      const rangeEnd = document.getElementById('range-end');
+      rangeStart.value = minDate;
+      rangeStart.min = minDate;
+      rangeStart.max = maxDate;
+      rangeEnd.value = maxDate;
+      rangeEnd.min = minDate;
+      rangeEnd.max = maxDate;
+
+      function applyDateFilter(start, end) {
+        const indices = commitLabels.reduce((acc, label, i) => {
+          if (label >= start && label <= end) acc.push(i);
+          return acc;
+        }, []);
+        const labels = indices.map(i => commitLabels[i]);
+        for (const instance of chartInstances) {
+          instance.applyFilter(indices, labels);
+        }
+      }
+
+      rangeStart.addEventListener('input', () => {
+        if (rangeStart.value && rangeEnd.value && rangeStart.value <= rangeEnd.value)
+          applyDateFilter(rangeStart.value, rangeEnd.value);
+      });
+      rangeEnd.addEventListener('input', () => {
+        if (rangeStart.value && rangeEnd.value && rangeStart.value <= rangeEnd.value)
+          applyDateFilter(rangeStart.value, rangeEnd.value);
+      });
+      document.getElementById('range-reset').onclick = () => {
+        rangeStart.value = minDate;
+        rangeEnd.value = maxDate;
+        applyDateFilter(minDate, maxDate);
+      };
     }
 
-    renderAllChars(init()); // Start
+    init();
   })();
 </script>
 </body>

--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -287,6 +287,12 @@
       return isoTimestamp.slice(0, 10);
     }
 
+    function formatValue(value) {
+      if (value >= 1_000_000) return (value / 1_000_000).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'M';
+      if (value >= 1_000) return (value / 1_000).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'K';
+      return value.toLocaleString(undefined, {maximumFractionDigits: 2});
+    }
+
     // Parse "methodName ( {json} )" into a compact label like "methodName [val1, val2]".
     function formatSeriesLabel(nameAfterClass) {
       const jsonMatch = nameAfterClass.match(/\(\s*(\{[\s\S]*?\})\s*\)/);
@@ -426,13 +432,7 @@
             y: {
               beginAtZero: true,
               title: {display: true, text: unit},
-              ticks: {
-                callback: (value) => {
-                  if (value >= 1_000_000) return (value / 1_000_000).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'M';
-                  if (value >= 1_000) return (value / 1_000).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'K';
-                  return value;
-                },
-              },
+              ticks: {callback: formatValue},
             },
           },
           plugins: {
@@ -455,7 +455,7 @@
                   const d = results[item.datasetIndex].dataset[currentIndices[item.dataIndex]];
                   if (!d) return item.dataset.label;
                   const {range, unit} = d.bench;
-                  let text = `${item.dataset.label}: ${item.formattedValue} ${unit}`;
+                  let text = `${item.dataset.label}: ${formatValue(d.bench.value)} ${unit}`;
                   if (range) text += ' (' + range + ')';
                   return text;
                 },


### PR DESCRIPTION
Rework benchmark display:

- Update to latest version of chart.js, 4.5.1
- Switched x-axis to a time scale (via Luxon adapter) for calendar-aligned weekly/monthly ticks
- Added a global date range picker (From / To / Reset) that filters all charts
- Replaced the built-in Chart.js legend with a custom per-chart scrollable, sorted, toggleable list with All/None buttons
- Added a [source] link per chart to the benchmark class on GitHub (main)
- Made data points clickable — opens the repo file tree at that commit SHA
- Formatted y-axis values, tooptips as 23.1M / 351k
- Shortened chart titles to simple class name; full FQCN on hover

Much more usable / useful experience.

Screenshot of new ([existing for reference](https://open-telemetry.github.io/opentelemetry-java/benchmarks/)):

<img width="1200" height="1913" alt="Screenshot 2026-04-24 at 2 14 25 PM" src="https://github.com/user-attachments/assets/d73547e8-8f48-4284-8a4e-6f7f523b4b33" />
