### PR TITLE
Don't allocate for parentContext on span start for the common case

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java
@@ -45,6 +45,10 @@ class SdkSpanBuilder implements SpanBuilder {
               TraceFlags.builder().setRandomTraceId(true).build(),
               TraceState.getDefault()));
 
+  // Pre-built for the common case where parentContext is root (no extra context to preserve).
+  private static final Context ROOT_CONTEXT_WITH_RANDOM_TRACE_ID_BIT =
+      Context.root().with(RANDOM_TRACE_ID_PRIMORDIAL_SPAN);
+
   private final String spanName;
   private final InstrumentationScopeInfo instrumentationScopeInfo;
   private final TracerSharedState tracerSharedState;
@@ -190,8 +194,13 @@ class SdkSpanBuilder implements SpanBuilder {
       traceId = idGenerator.generateTraceId();
       if (idGenerator.generatesRandomTraceIds()) {
         isTraceIdRandom = true;
-        // Replace parentContext for sampling with one with RANDOM_TRACE_ID bit set
-        parentContextForSampler = parentContext.with(RANDOM_TRACE_ID_PRIMORDIAL_SPAN);
+        // Replace parentContext for sampling with one with RANDOM_TRACE_ID bit set.
+        // Use the pre-built singleton when parentContext is root to avoid an allocation;
+        // otherwise graft onto parentContext to preserve any extra context values.
+        parentContextForSampler =
+            parentContext == Context.root()
+                ? ROOT_CONTEXT_WITH_RANDOM_TRACE_ID_BIT
+                : parentContext.with(RANDOM_TRACE_ID_PRIMORDIAL_SPAN);
       } else {
         isTraceIdRandom = false;
       }

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -980,6 +980,47 @@ class SdkSpanBuilderTest {
   }
 
   @Test
+  void samplerReceivesRootContextWithRandomTraceIdWhenNoExtraContext() {
+    Sampler mockSampler = Mockito.mock(Sampler.class);
+    Mockito.when(
+            mockSampler.shouldSample(
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(),
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyList()))
+        .thenReturn(SamplingResult.recordAndSample());
+
+    SdkTracerProvider provider = SdkTracerProvider.builder().setSampler(mockSampler).build();
+
+    // setNoParent() explicitly sets parentContext to Context.root(), exercising the singleton path.
+    // Start two spans and assert the sampler received the exact same Context instance both times,
+    // proving the pre-built singleton is reused rather than a new object allocated each call.
+    provider.get("test").spanBuilder(SPAN_NAME).setNoParent().startSpan().end();
+    provider.get("test").spanBuilder(SPAN_NAME).setNoParent().startSpan().end();
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    Mockito.verify(mockSampler, Mockito.times(2))
+        .shouldSample(
+            contextCaptor.capture(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.anyList());
+
+    List<Context> samplerContexts = contextCaptor.getAllValues();
+    assertThat(samplerContexts.get(0)).isSameAs(samplerContexts.get(1));
+    assertThat(
+            Span.fromContext(samplerContexts.get(0))
+                .getSpanContext()
+                .getTraceFlags()
+                .isTraceIdRandom())
+        .isTrue();
+  }
+
+  @Test
   void startTimestamp_numeric() {
     SdkSpan span =
         (SdkSpan)


### PR DESCRIPTION
#8263 fixed a bug where parentContext wasn't properly being passed to shouldSample for the root case. Its correct, but the code calls `parentContext.with(RANDOM_TRACE_ID_PRIMORDIAL_SPAN)`, which allocates to store the RANDOM_TRACE_ID_PRIMORDIAL_SPAN in context every time a root span is started.

But its common (I would say the majority of the time) for parent context to be `Context.root()` in this case. Therefore, we can avoid allocating by keeping a constant `Context.root().with(RANDOM_TRACE_ID_PRIMORDIAL_SPAN)` and always returning that when `parentContext == Context.root()`.

Followup to https://github.com/open-telemetry/opentelemetry-java/pull/8263#discussion_r3111541266

cc @PeterF778 