### PR TITLE
profiles: improve JFR export example and align LinkData null-element with spec

### DIFF
--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
@@ -71,6 +71,12 @@ public class JfrExecutionSampleEventConverter {
     }
 
     RecordedThread recordedThread = recordedEvent.getValue("sampledThread");
+    if (recordedThread == null) {
+      // just skip these - it would be spec valid, but practically without Thread metadata
+      // the receiving backend likely won't group and render properly them anyhow.
+      return;
+    }
+
     String threadName = recordedThread.getJavaName();
     int threadNameIndex = profilesDictionaryCompositor.putIfAbsent("thread.name");
     KeyValueAndUnitData threadNameData =

--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
@@ -5,15 +5,17 @@
 
 package io.opentelemetry.sdk.profiles.jfr;
 
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.sdk.profiles.ProfilesDictionaryCompositor;
 import io.opentelemetry.sdk.profiles.SampleCompositionBuilder;
 import io.opentelemetry.sdk.profiles.SampleCompositionKey;
+import io.opentelemetry.sdk.profiles.data.KeyValueAndUnitData;
 import io.opentelemetry.sdk.profiles.data.SampleData;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
 
 /**
  * Converter for batching a steam of recorded jfr.ExecutionSample events into a format suitable for
@@ -68,8 +70,14 @@ public class JfrExecutionSampleEventConverter {
       return;
     }
 
+    RecordedThread recordedThread = recordedEvent.getValue("sampledThread");
+    String threadName = recordedThread.getJavaName();
+    int threadNameIndex = profilesDictionaryCompositor.putIfAbsent("thread.name");
+    KeyValueAndUnitData threadNameData =
+        KeyValueAndUnitData.create(threadNameIndex, Value.of(threadName), 0);
+    int attribIndex = profilesDictionaryCompositor.putIfAbsent(threadNameData);
     int stackIndex = locationCompositor.putIfAbsent(recordedEvent.getStackTrace().getFrames());
-    SampleCompositionKey key = new SampleCompositionKey(stackIndex, Collections.emptyList(), 0);
+    SampleCompositionKey key = new SampleCompositionKey(stackIndex, List.of(attribIndex), 0);
     Instant instant = recordedEvent.getStartTime();
     long epochNanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
     sampleCompositionBuilder.add(key, null, epochNanos);

--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
@@ -5,15 +5,17 @@
 
 package io.opentelemetry.sdk.profiles.jfr;
 
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.sdk.profiles.ProfilesDictionaryCompositor;
 import io.opentelemetry.sdk.profiles.SampleCompositionBuilder;
 import io.opentelemetry.sdk.profiles.SampleCompositionKey;
+import io.opentelemetry.sdk.profiles.data.KeyValueAndUnitData;
 import io.opentelemetry.sdk.profiles.data.SampleData;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
 
 /**
  * Converter for batching a stream of recorded jfr.ExecutionSample events into a format suitable for
@@ -68,8 +70,14 @@ public class JfrExecutionSampleEventConverter {
       return;
     }
 
+    RecordedThread recordedThread = recordedEvent.getValue("sampledThread");
+    String threadName = recordedThread.getJavaName();
+    int threadNameIndex = profilesDictionaryCompositor.putIfAbsent("thread.name");
+    KeyValueAndUnitData threadNameData =
+        KeyValueAndUnitData.create(threadNameIndex, Value.of(threadName), 0);
+    int attribIndex = profilesDictionaryCompositor.putIfAbsent(threadNameData);
     int stackIndex = locationCompositor.putIfAbsent(recordedEvent.getStackTrace().getFrames());
-    SampleCompositionKey key = new SampleCompositionKey(stackIndex, Collections.emptyList(), 0);
+    SampleCompositionKey key = new SampleCompositionKey(stackIndex, List.of(attribIndex), 0);
     Instant instant = recordedEvent.getStartTime();
     long epochNanos = TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
     sampleCompositionBuilder.add(key, null, epochNanos);

--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExportExample.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExportExample.java
@@ -76,11 +76,14 @@ public class JfrExportExample {
             .setSchemaUrl("http://url")
             .build();
 
+    int sampleStringIndex = converter.getProfilesDictionaryCompositor().putIfAbsent("samples");
+    int countStringIndex = converter.getProfilesDictionaryCompositor().putIfAbsent("count");
+
     return ProfileData.create(
         Resource.create(Attributes.empty()),
         scopeInfo,
         converter.getProfilesDictionaryCompositor().getProfileDictionaryData(),
-        ValueTypeData.create(0, 0),
+        ValueTypeData.create(sampleStringIndex, countStringIndex),
         converter.getSamples(),
         0,
         0,

--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrLocationDataCompositor.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrLocationDataCompositor.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.sdk.profiles.jfr;
 
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.sdk.profiles.ProfilesDictionaryCompositor;
 import io.opentelemetry.sdk.profiles.data.FunctionData;
+import io.opentelemetry.sdk.profiles.data.KeyValueAndUnitData;
 import io.opentelemetry.sdk.profiles.data.LineData;
 import io.opentelemetry.sdk.profiles.data.LocationData;
 import io.opentelemetry.sdk.profiles.data.StackData;
-import java.util.Collections;
 import java.util.List;
 import jdk.jfr.consumer.RecordedFrame;
 
@@ -85,8 +86,13 @@ public class JfrLocationDataCompositor {
     int lineNumber = frame.getLineNumber() != -1 ? frame.getLineNumber() : 0;
     LineData lineData = LineData.create(functionIndex, lineNumber, 0);
 
+    // https://opentelemetry.io/docs/specs/semconv/general/profiles/#frame-types
+    int typeKeyIndex = profilesDictionaryCompositor.putIfAbsent("profile.frame.type");
+    KeyValueAndUnitData frameType = KeyValueAndUnitData.create(typeKeyIndex, Value.of("jvm"), 0);
+    int typeAttributeIndex = profilesDictionaryCompositor.putIfAbsent(frameType);
+
     LocationData locationData =
-        LocationData.create(0, 0, List.of(lineData), Collections.emptyList());
+        LocationData.create(0, 0, List.of(lineData), List.of(typeAttributeIndex));
 
     int locationIndex = profilesDictionaryCompositor.putIfAbsent(locationData);
     return locationIndex;

--- a/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/ProfilesDictionaryCompositor.java
+++ b/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/ProfilesDictionaryCompositor.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.sdk.profiles;
 
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.sdk.profiles.data.FunctionData;
 import io.opentelemetry.sdk.profiles.data.KeyValueAndUnitData;
 import io.opentelemetry.sdk.profiles.data.LinkData;
@@ -54,7 +56,9 @@ public class ProfilesDictionaryCompositor {
     locationTable.putIfAbsent(
         LocationData.create(0, 0, Collections.emptyList(), Collections.emptyList()));
     functionTable.putIfAbsent(FunctionData.create(0, 0, 0, 0));
-    linkTable.putIfAbsent(LinkData.create("", ""));
+    // TODO this is, strictly speaking, probably not profile spec compliant at present.
+    // The spec uses "" but the Id encoders don't like that. The alpha spec may need revision...
+    linkTable.putIfAbsent(LinkData.create(TraceId.getInvalid(), SpanId.getInvalid()));
     stringTable.putIfAbsent("");
     attributeTable.putIfAbsent(KeyValueAndUnitData.create(0, Value.of(""), 0));
     stackTable.putIfAbsent(StackData.create(Collections.emptyList()));

--- a/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/ProfilesDictionaryCompositor.java
+++ b/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/ProfilesDictionaryCompositor.java
@@ -56,8 +56,6 @@ public class ProfilesDictionaryCompositor {
     locationTable.putIfAbsent(
         LocationData.create(0, 0, Collections.emptyList(), Collections.emptyList()));
     functionTable.putIfAbsent(FunctionData.create(0, 0, 0, 0));
-    // TODO this is, strictly speaking, probably not profile spec compliant at present.
-    // The spec uses "" but the Id encoders don't like that. The alpha spec may need revision...
     linkTable.putIfAbsent(LinkData.create(TraceId.getInvalid(), SpanId.getInvalid()));
     stringTable.putIfAbsent("");
     attributeTable.putIfAbsent(KeyValueAndUnitData.create(0, Value.of(""), 0));


### PR DESCRIPTION
Add metadata to the OTLP message so as to make it more interpretable by receiving backends.