### PR TITLE
Fix gradle warning

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -244,7 +244,7 @@ testing {
     useJUnitJupiter()
 
     dependencies {
-      implementation(project(project.path))
+      implementation(project())
 
       implementation(project(":testing-internal"))
 


### PR DESCRIPTION
```
> Task :buildSrc:compileKotlin
w: file:///Users/ltulmin/dev/opentelemetry-java/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:247:30 'val project: Project' is deprecated. Deprecated in Java.
```