### PR TITLE
Change benchmark timeout to 120 minutes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:26.04@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4
-    timeout-minutes: 20 # since there is only a single bare metal runner across all repos
+    timeout-minutes: 120 # since there is only a single bare metal runner across all repos
     steps:
       - name: Install Git
         run: |


### PR DESCRIPTION
Followup to #8308. Benchmark hasn't been running successfully since making that change because it never finishes in time. I don't think we need 120 minutes, but I don't know how much we'll need. Can tune it back down after finding out.