### PR TITLE
Fix ResourceBuilder class Javadoc grammar

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourceBuilder.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/ResourceBuilder.java
@@ -12,8 +12,8 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
- * A builder of {@link Resource} that allows to add key-value pairs and copy attributes from other
- * {@link Attributes} or {@link Resource}.
+ * A builder for {@link Resource} that allows adding key-value pairs and copying attributes from
+ * other {@link Attributes} or {@link Resource} instances.
  *
  * @since 1.1.0
  */


### PR DESCRIPTION
just a little grammatical nitpick that I noticed (fixed by codex).