### PR TITLE
add IncludeExcludePredicate test when value matches both include and exclude

### DIFF
--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/IncludeExcludePredicateTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/IncludeExcludePredicateTest.java
@@ -162,4 +162,19 @@ class IncludeExcludePredicateTest {
                   .isEqualTo("IncludeExcludePredicate{globMatchingEnabled=true}");
             });
   }
+
+  @Test
+  void shouldExcludeWhenValueMatchesBothIncludeAndExclude() {
+    String value = "a";
+    Collection<String> exactMatchingArg = Collections.singletonList("a");
+
+    Predicate<String> exactMatching =
+        IncludeExcludePredicate.createExactMatching(exactMatchingArg, exactMatchingArg);
+    assertThat(exactMatching.test(value)).isFalse();
+
+    Collection<String> patternMatchingArg = Collections.singletonList("*");
+    Predicate<String> patternMatching =
+        IncludeExcludePredicate.createPatternMatching(patternMatchingArg, patternMatchingArg);
+    assertThat(patternMatching.test(value)).isFalse();
+  }
 }


### PR DESCRIPTION
From https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2802#pullrequestreview-4223799470 : add explicit test when both include and exclude are matching the provided value.

The implementation already fits [the current spec](https://github.com/open-telemetry/opentelemetry-configuration/blob/804c36185ee9e6e12c61e889e49eb9487568a568/CONTRIBUTING.md#properties-requiring-pattern-matching), when value matches both include and exclude, then it's excluded by default.