### PR TITLE
Fix Groovy OpenTelemetrySdk builder loading

### DIFF
--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
   testAnnotationProcessor("com.google.auto.value:auto-value")
 
+  testImplementation("org.apache.groovy:groovy:4.0.25")
   testImplementation(project(":sdk:testing"))
 
   jmh(project(":sdk:testing"))

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -167,13 +167,13 @@ public final class OpenTelemetrySdkBuilder {
   private static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
       OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
     return createExtendedOpenTelemetrySdk(
-        requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD), openTelemetrySdk, configProvider);
+        openTelemetrySdk, configProvider, requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD));
   }
 
   static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
-      Method createExtendedOpenTelemetrySdkMethod,
       OpenTelemetrySdk openTelemetrySdk,
-      @Nullable Object configProvider) {
+      @Nullable Object configProvider,
+      Method createExtendedOpenTelemetrySdkMethod) {
     try {
       return (OpenTelemetrySdk)
           createExtendedOpenTelemetrySdkMethod.invoke(null, openTelemetrySdk, configProvider);

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -107,6 +107,9 @@ public final class OpenTelemetrySdkBuilder {
    * <p>This method is experimental so not public. You may reflectively call it using {@link
    * OpenTelemetrySdkBuilderUtil#setConfigProvider(OpenTelemetrySdkBuilder,
    * io.opentelemetry.sdk.internal.SdkConfigProvider)}.
+   *
+   * <p>The parameter type is {@link Object} to avoid introducing another direct incubator-linked
+   * method signature in the path Groovy eagerly inspects.
    */
   OpenTelemetrySdkBuilder setConfigProvider(Object configProvider) {
     this.configProvider = requireNonNull(configProvider);
@@ -172,8 +175,15 @@ public final class OpenTelemetrySdkBuilder {
           "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked."
               + " This is a bug in OpenTelemetry.",
           e);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException(
+          "IncubatingUtil.createExtendedOpenTelemetrySdk could not be called with the expected"
+              + " arguments. This is a bug in OpenTelemetry.",
+          e);
     } catch (InvocationTargetException e) {
       Throwable cause = e.getTargetException();
+      // Preserve the original application behavior rather than wrapping runtime failures emitted
+      // by the incubator path in a reflective InvocationTargetException.
       if (cause instanceof RuntimeException) {
         throw (RuntimeException) cause;
       }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -167,7 +167,9 @@ public final class OpenTelemetrySdkBuilder {
   private static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
       OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
     return createExtendedOpenTelemetrySdk(
-        openTelemetrySdk, configProvider, requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD));
+        openTelemetrySdk,
+        configProvider,
+        requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD));
   }
 
   static OpenTelemetrySdk createExtendedOpenTelemetrySdk(

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -166,10 +166,17 @@ public final class OpenTelemetrySdkBuilder {
 
   private static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
       OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
+    return createExtendedOpenTelemetrySdk(
+        requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD), openTelemetrySdk, configProvider);
+  }
+
+  static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
+      Method createExtendedOpenTelemetrySdkMethod,
+      OpenTelemetrySdk openTelemetrySdk,
+      @Nullable Object configProvider) {
     try {
       return (OpenTelemetrySdk)
-          requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD)
-              .invoke(null, openTelemetrySdk, configProvider);
+          createExtendedOpenTelemetrySdkMethod.invoke(null, openTelemetrySdk, configProvider);
     } catch (IllegalAccessException e) {
       throw new IllegalStateException(
           "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked."

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdkBuilder.java
@@ -10,12 +10,13 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.internal.OpenTelemetrySdkBuilderUtil;
-import io.opentelemetry.sdk.internal.SdkConfigProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 
 /** A builder for configuring an {@link OpenTelemetrySdk}. */
@@ -28,16 +29,28 @@ public final class OpenTelemetrySdkBuilder {
   @Nullable private Object configProvider;
 
   private static final boolean INCUBATOR_AVAILABLE;
+  @Nullable private static final Method CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD;
 
   static {
     boolean incubatorAvailable = false;
+    Method createExtendedOpenTelemetrySdk = null;
     try {
       Class.forName("io.opentelemetry.api.incubator.ExtendedOpenTelemetry");
+      createExtendedOpenTelemetrySdk =
+          Class.forName("io.opentelemetry.sdk.IncubatingUtil")
+              .getDeclaredMethod(
+                  "createExtendedOpenTelemetrySdk", OpenTelemetrySdk.class, Object.class);
       incubatorAvailable = true;
     } catch (ClassNotFoundException e) {
       // Not available
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(
+          "IncubatingUtil.createExtendedOpenTelemetrySdk could not be found."
+              + " This is a bug in OpenTelemetry.",
+          e);
     }
     INCUBATOR_AVAILABLE = incubatorAvailable;
+    CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD = createExtendedOpenTelemetrySdk;
   }
 
   /**
@@ -89,12 +102,13 @@ public final class OpenTelemetrySdkBuilder {
   }
 
   /**
-   * Sets the {@link SdkConfigProvider} to use.
+   * Sets the SDK config provider to use.
    *
    * <p>This method is experimental so not public. You may reflectively call it using {@link
-   * OpenTelemetrySdkBuilderUtil#setConfigProvider(OpenTelemetrySdkBuilder, SdkConfigProvider)}.
+   * OpenTelemetrySdkBuilderUtil#setConfigProvider(OpenTelemetrySdkBuilder,
+   * io.opentelemetry.sdk.internal.SdkConfigProvider)}.
    */
-  OpenTelemetrySdkBuilder setConfigProvider(SdkConfigProvider configProvider) {
+  OpenTelemetrySdkBuilder setConfigProvider(Object configProvider) {
     this.configProvider = requireNonNull(configProvider);
     return this;
   }
@@ -143,7 +157,33 @@ public final class OpenTelemetrySdkBuilder {
     OpenTelemetrySdk openTelemetrySdk =
         new OpenTelemetrySdk(tracerProvider, meterProvider, loggerProvider, propagators);
     return INCUBATOR_AVAILABLE
-        ? IncubatingUtil.createExtendedOpenTelemetrySdk(openTelemetrySdk, configProvider)
+        ? createExtendedOpenTelemetrySdk(openTelemetrySdk, configProvider)
         : openTelemetrySdk;
+  }
+
+  private static OpenTelemetrySdk createExtendedOpenTelemetrySdk(
+      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
+    try {
+      return (OpenTelemetrySdk)
+          requireNonNull(CREATE_EXTENDED_OPEN_TELEMETRY_SDK_METHOD)
+              .invoke(null, openTelemetrySdk, configProvider);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(
+          "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked."
+              + " This is a bug in OpenTelemetry.",
+          e);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getTargetException();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IllegalStateException(
+          "IncubatingUtil.createExtendedOpenTelemetrySdk failed."
+              + " This is a bug in OpenTelemetry.",
+          cause);
+    }
   }
 }

--- a/sdk/all/src/main/java/io/opentelemetry/sdk/internal/OpenTelemetrySdkBuilderUtil.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/internal/OpenTelemetrySdkBuilderUtil.java
@@ -27,8 +27,7 @@ public final class OpenTelemetrySdkBuilderUtil {
       OpenTelemetrySdkBuilder builder, SdkConfigProvider configProvider) {
     try {
       Method method =
-          OpenTelemetrySdkBuilder.class.getDeclaredMethod(
-              "setConfigProvider", SdkConfigProvider.class);
+          OpenTelemetrySdkBuilder.class.getDeclaredMethod("setConfigProvider", Object.class);
       method.setAccessible(true);
       method.invoke(builder, configProvider);
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -39,6 +39,7 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import groovy.lang.GroovyClassLoader;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -136,6 +137,24 @@ class OpenTelemetrySdkTest {
         .isEqualTo(meterProvider);
     assertThat(openTelemetry.getSdkLoggerProvider()).isEqualTo(loggerProvider);
     assertThat(openTelemetry.getPropagators()).isEqualTo(propagators);
+  }
+
+  @Test
+  void builder_fromGroovyWithoutIncubator() throws Exception {
+    try (GroovyClassLoader groovyClassLoader =
+        new GroovyClassLoader(getClass().getClassLoader())) {
+      Class<?> groovyClass =
+          groovyClassLoader.parseClass(
+              "import io.opentelemetry.sdk.OpenTelemetrySdk\n"
+                  + "class GroovyBuilderCaller {\n"
+                  + "  static Object buildSdk() {\n"
+                  + "    OpenTelemetrySdk.builder().build()\n"
+                  + "  }\n"
+                  + "}\n");
+
+      assertThat(groovyClass.getMethod("buildSdk").invoke(null))
+          .isInstanceOf(OpenTelemetrySdk.class);
+    }
   }
 
   @Test

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -141,8 +141,7 @@ class OpenTelemetrySdkTest {
 
   @Test
   void builder_fromGroovyWithoutIncubator() throws Exception {
-    try (GroovyClassLoader groovyClassLoader =
-        new GroovyClassLoader(getClass().getClassLoader())) {
+    try (GroovyClassLoader groovyClassLoader = new GroovyClassLoader(getClass().getClassLoader())) {
       Class<?> groovyClass =
           groovyClassLoader.parseClass(
               "import io.opentelemetry.sdk.OpenTelemetrySdk\n"

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -220,23 +220,6 @@ class OpenTelemetrySdkTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
-  @Test
-  void createExtendedOpenTelemetrySdk_wrapsIllegalAccessException() throws Exception {
-    Method method =
-        OpenTelemetrySdkTest.class.getDeclaredMethod(
-            "privateNoAccess", OpenTelemetrySdk.class, Object.class);
-
-    assertThatThrownBy(
-            () ->
-                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    OpenTelemetrySdk.builder().build(), null, method))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked. This is a bug in OpenTelemetry.")
-        .cause()
-        .isInstanceOf(IllegalAccessException.class);
-  }
-
   static OpenTelemetrySdk throwRuntimeException(
       OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
     throw new IllegalStateException("runtime boom");
@@ -254,11 +237,6 @@ class OpenTelemetrySdkTest {
 
   static OpenTelemetrySdk wrongSignature(String ignored) {
     return null;
-  }
-
-  private static OpenTelemetrySdk privateNoAccess(
-      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
-    return openTelemetrySdk;
   }
 
   @Test

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import groovy.lang.GroovyClassLoader;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -39,7 +40,6 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
-import groovy.lang.GroovyClassLoader;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -140,7 +140,7 @@ class OpenTelemetrySdkTest {
   }
 
   @Test
-  void builder_fromGroovyWithoutIncubator() throws Exception {
+  void buildFromGroovyWithoutIncubator() throws Exception {
     try (GroovyClassLoader groovyClassLoader = new GroovyClassLoader(getClass().getClassLoader())) {
       Class<?> groovyClass =
           groovyClassLoader.parseClass(

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -167,7 +167,7 @@ class OpenTelemetrySdkTest {
     assertThatThrownBy(
             () ->
                 OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    method, OpenTelemetrySdk.builder().build(), null))
+                    OpenTelemetrySdk.builder().build(), null, method))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("runtime boom");
   }
@@ -181,7 +181,7 @@ class OpenTelemetrySdkTest {
     assertThatThrownBy(
             () ->
                 OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    method, OpenTelemetrySdk.builder().build(), null))
+                    OpenTelemetrySdk.builder().build(), null, method))
         .isInstanceOf(AssertionError.class)
         .hasMessage("error boom");
   }
@@ -195,7 +195,7 @@ class OpenTelemetrySdkTest {
     assertThatThrownBy(
             () ->
                 OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    method, OpenTelemetrySdk.builder().build(), null))
+                    OpenTelemetrySdk.builder().build(), null, method))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "IncubatingUtil.createExtendedOpenTelemetrySdk failed. This is a bug in OpenTelemetry.")
@@ -211,7 +211,7 @@ class OpenTelemetrySdkTest {
     assertThatThrownBy(
             () ->
                 OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    method, OpenTelemetrySdk.builder().build(), null))
+                    OpenTelemetrySdk.builder().build(), null, method))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "IncubatingUtil.createExtendedOpenTelemetrySdk could not be called with the expected"
@@ -229,7 +229,7 @@ class OpenTelemetrySdkTest {
     assertThatThrownBy(
             () ->
                 OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
-                    method, OpenTelemetrySdk.builder().build(), null))
+                    OpenTelemetrySdk.builder().build(), null, method))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked. This is a bug in OpenTelemetry.")

--- a/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
+++ b/sdk/all/src/test/java/io/opentelemetry/sdk/OpenTelemetrySdkTest.java
@@ -40,8 +40,10 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -154,6 +156,109 @@ class OpenTelemetrySdkTest {
       assertThat(groovyClass.getMethod("buildSdk").invoke(null))
           .isInstanceOf(OpenTelemetrySdk.class);
     }
+  }
+
+  @Test
+  void createExtendedOpenTelemetrySdk_rethrowsRuntimeException() throws Exception {
+    Method method =
+        OpenTelemetrySdkTest.class.getDeclaredMethod(
+            "throwRuntimeException", OpenTelemetrySdk.class, Object.class);
+
+    assertThatThrownBy(
+            () ->
+                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
+                    method, OpenTelemetrySdk.builder().build(), null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("runtime boom");
+  }
+
+  @Test
+  void createExtendedOpenTelemetrySdk_rethrowsError() throws Exception {
+    Method method =
+        OpenTelemetrySdkTest.class.getDeclaredMethod(
+            "throwError", OpenTelemetrySdk.class, Object.class);
+
+    assertThatThrownBy(
+            () ->
+                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
+                    method, OpenTelemetrySdk.builder().build(), null))
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("error boom");
+  }
+
+  @Test
+  void createExtendedOpenTelemetrySdk_wrapsCheckedException() throws Exception {
+    Method method =
+        OpenTelemetrySdkTest.class.getDeclaredMethod(
+            "throwCheckedException", OpenTelemetrySdk.class, Object.class);
+
+    assertThatThrownBy(
+            () ->
+                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
+                    method, OpenTelemetrySdk.builder().build(), null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "IncubatingUtil.createExtendedOpenTelemetrySdk failed. This is a bug in OpenTelemetry.")
+        .cause()
+        .isInstanceOf(Exception.class)
+        .hasMessage("checked boom");
+  }
+
+  @Test
+  void createExtendedOpenTelemetrySdk_wrapsIllegalArgumentException() throws Exception {
+    Method method = OpenTelemetrySdkTest.class.getDeclaredMethod("wrongSignature", String.class);
+
+    assertThatThrownBy(
+            () ->
+                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
+                    method, OpenTelemetrySdk.builder().build(), null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "IncubatingUtil.createExtendedOpenTelemetrySdk could not be called with the expected"
+                + " arguments. This is a bug in OpenTelemetry.")
+        .cause()
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void createExtendedOpenTelemetrySdk_wrapsIllegalAccessException() throws Exception {
+    Method method =
+        OpenTelemetrySdkTest.class.getDeclaredMethod(
+            "privateNoAccess", OpenTelemetrySdk.class, Object.class);
+
+    assertThatThrownBy(
+            () ->
+                OpenTelemetrySdkBuilder.createExtendedOpenTelemetrySdk(
+                    method, OpenTelemetrySdk.builder().build(), null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "IncubatingUtil.createExtendedOpenTelemetrySdk could not be invoked. This is a bug in OpenTelemetry.")
+        .cause()
+        .isInstanceOf(IllegalAccessException.class);
+  }
+
+  static OpenTelemetrySdk throwRuntimeException(
+      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
+    throw new IllegalStateException("runtime boom");
+  }
+
+  static OpenTelemetrySdk throwError(
+      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
+    throw new AssertionError("error boom");
+  }
+
+  static OpenTelemetrySdk throwCheckedException(
+      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) throws Exception {
+    throw new Exception("checked boom");
+  }
+
+  static OpenTelemetrySdk wrongSignature(String ignored) {
+    return null;
+  }
+
+  private static OpenTelemetrySdk privateNoAccess(
+      OpenTelemetrySdk openTelemetrySdk, @Nullable Object configProvider) {
+    return openTelemetrySdk;
   }
 
   @Test


### PR DESCRIPTION
Fixes #8198

This avoids eager Groovy linkage of incubator-dependent SDK code by resolving IncubatingUtil.createExtendedOpenTelemetrySdk(...) reflectively in OpenTelemetrySdkBuilder instead of calling it directly.

Also adds a Groovy regression test covering OpenTelemetrySdk.builder().build() without incubator classes on the runtime classpath.
