### PR TITLE
docs: clarify View attribute filtering interaction with Exemplars

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/View.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/View.java
@@ -17,6 +17,10 @@ import javax.annotation.concurrent.Immutable;
  * <p>Views are registered with the SDK {@link
  * SdkMeterProviderBuilder#registerView(InstrumentSelector, View)}.
  *
+ * <p><b>Note:</b> When a view filters out attributes, the dropped attributes may still appear on
+ * recorded exemplars. If you need to remove sensitive data from exemplars, you must configure a
+ * custom {@link ExemplarFilter} or disable exemplars entirely.
+ *
  * @since 1.14.0
  */
 @AutoValue

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/View.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/View.java
@@ -17,10 +17,6 @@ import javax.annotation.concurrent.Immutable;
  * <p>Views are registered with the SDK {@link
  * SdkMeterProviderBuilder#registerView(InstrumentSelector, View)}.
  *
- * <p><b>Note:</b> When a view filters out attributes, the dropped attributes may still appear on
- * recorded exemplars. If you need to remove sensitive data from exemplars, you must configure a
- * custom {@link ExemplarFilter} or disable exemplars entirely.
- *
  * @since 1.14.0
  */
 @AutoValue

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
@@ -71,6 +71,10 @@ public final class ViewBuilder {
   /**
    * Sets a filter which retains attribute keys included in {@code keysToRetain}.
    *
+   * <p><b>Note:</b> Attributes dropped by this filter may still appear on recorded exemplars. If
+   * you need to remove sensitive data from exemplars, you must configure a custom {@link
+   * ExemplarFilter} or disable exemplars entirely.
+   *
    * @since 1.30.0
    */
   public ViewBuilder setAttributeFilter(Set<String> keysToRetain) {
@@ -88,6 +92,10 @@ public final class ViewBuilder {
    * Sets a filter for attributes keys.
    *
    * <p>Only attribute keys that pass the supplied {@link Predicate} will be included in the output.
+   *
+   * <p><b>Note:</b> Attributes dropped by this filter may still appear on recorded exemplars. If
+   * you need to remove sensitive data from exemplars, you must configure a custom {@link
+   * ExemplarFilter} or disable exemplars entirely.
    *
    * @param keyFilter filter for attribute keys to include.
    */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
@@ -72,8 +72,10 @@ public final class ViewBuilder {
    * Sets a filter which retains attribute keys included in {@code keysToRetain}.
    *
    * <p>Note: Attributes dropped by this filter may still appear on recorded exemplars. If you need
-   * to remove sensitive data from exemplars, you must configure a custom {@link ExemplarFilter} or
-   * disable exemplars entirely.
+   * to remove sensitive data from exemplars, you must disable exemplars entirely (e.g., using
+   * {@link SdkMeterProviderBuilder#setExemplarFilter(ExemplarFilter)} with {@link
+   * ExemplarFilter#alwaysOff()}), filter them using a delegating exporter, or filter them in the
+   * OpenTelemetry Collector.
    *
    * @since 1.30.0
    */
@@ -94,8 +96,10 @@ public final class ViewBuilder {
    * <p>Only attribute keys that pass the supplied {@link Predicate} will be included in the output.
    *
    * <p>Note: Attributes dropped by this filter may still appear on recorded exemplars. If you need
-   * to remove sensitive data from exemplars, you must configure a custom {@link ExemplarFilter} or
-   * disable exemplars entirely.
+   * to remove sensitive data from exemplars, you must disable exemplars entirely (e.g., using
+   * {@link SdkMeterProviderBuilder#setExemplarFilter(ExemplarFilter)} with {@link
+   * ExemplarFilter#alwaysOff()}), filter them using a delegating exporter, or filter them in the
+   * OpenTelemetry Collector.
    *
    * @param keyFilter filter for attribute keys to include.
    */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/ViewBuilder.java
@@ -71,9 +71,9 @@ public final class ViewBuilder {
   /**
    * Sets a filter which retains attribute keys included in {@code keysToRetain}.
    *
-   * <p><b>Note:</b> Attributes dropped by this filter may still appear on recorded exemplars. If
-   * you need to remove sensitive data from exemplars, you must configure a custom {@link
-   * ExemplarFilter} or disable exemplars entirely.
+   * <p>Note: Attributes dropped by this filter may still appear on recorded exemplars. If you need
+   * to remove sensitive data from exemplars, you must configure a custom {@link ExemplarFilter} or
+   * disable exemplars entirely.
    *
    * @since 1.30.0
    */
@@ -93,9 +93,9 @@ public final class ViewBuilder {
    *
    * <p>Only attribute keys that pass the supplied {@link Predicate} will be included in the output.
    *
-   * <p><b>Note:</b> Attributes dropped by this filter may still appear on recorded exemplars. If
-   * you need to remove sensitive data from exemplars, you must configure a custom {@link
-   * ExemplarFilter} or disable exemplars entirely.
+   * <p>Note: Attributes dropped by this filter may still appear on recorded exemplars. If you need
+   * to remove sensitive data from exemplars, you must configure a custom {@link ExemplarFilter} or
+   * disable exemplars entirely.
    *
    * @param keyFilter filter for attribute keys to include.
    */


### PR DESCRIPTION
Resolves #8391

### Changes
Adds Javadoc notices to `View` and `ViewBuilder.setAttributeFilter` methods, clarifying that attributes filtered out by a View may still appear on recorded exemplars. 

This behavior is non-obvious (measurement attributes are retained on Exemplars even if filtered by View/aggregation) and was resolved in the spec (#5073) and documented similarly in .NET (#7270).

### Checklist
- [x] Javadoc added/updated
- [x] Code formatted using spotlessApply
