### PR TITLE
fix: enforce last-value-wins in AttributesMap for duplicate keys of different types

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -63,10 +63,27 @@ public final class AttributesMap extends HashMap<AttributeKey<?>, Object> implem
       return null;
     }
     totalAddedValues++;
+    AttributeKey<?> existingKey = null;
+    for (AttributeKey<?> k : keySet()) {
+      if (k.getKey().equals(key.getKey())) {
+        existingKey = k;
+        break;
+      }
+    }
+    if (existingKey != null && !existingKey.equals(key)) {
+      super.remove(existingKey);
+    }
     if (size() >= capacity && !containsKey(key)) {
       return null;
     }
     return super.put(key, AttributeUtil.applyAttributeLengthLimit(value, lengthLimit));
+  }
+
+  @Override
+  public void putAll(Map<? extends AttributeKey<?>, ?> m) {
+    for (Map.Entry<? extends AttributeKey<?>, ?> entry : m.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
   }
 
   /** Generic overload of {@link #put(AttributeKey, Object)}. */

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.sdk.common.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -21,5 +23,14 @@ class AttributesMapTest {
 
     assertThat(attributesMap.asMap())
         .containsOnly(entry(longKey("one"), 1L), entry(longKey("two"), 2L));
+  }
+
+  @Test
+  void put_lastValueWins_differentTypes() {
+    AttributesMap attributesMap = AttributesMap.create(10, Integer.MAX_VALUE);
+    attributesMap.put(stringKey("key"), "value");
+    attributesMap.put(booleanKey("key"), false);
+
+    assertThat(attributesMap.asMap()).containsOnly(entry(booleanKey("key"), false));
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -11,6 +11,9 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class AttributesMapTest {
@@ -32,5 +35,26 @@ class AttributesMapTest {
     attributesMap.put(booleanKey("key"), false);
 
     assertThat(attributesMap.asMap()).containsOnly(entry(booleanKey("key"), false));
+  }
+
+  @Test
+  void put_lastValueWins_sameType() {
+    AttributesMap attributesMap = AttributesMap.create(10, Integer.MAX_VALUE);
+    attributesMap.put(stringKey("key"), "value1");
+    attributesMap.put(stringKey("key"), "value2");
+
+    assertThat(attributesMap.asMap()).containsOnly(entry(stringKey("key"), "value2"));
+  }
+
+  @Test
+  void putAll() {
+    AttributesMap attributesMap = AttributesMap.create(10, Integer.MAX_VALUE);
+    Map<AttributeKey<?>, Object> newAttrs = new HashMap<>();
+    newAttrs.put(stringKey("key1"), "value1");
+    newAttrs.put(booleanKey("key2"), true);
+    attributesMap.putAll(newAttrs);
+
+    assertThat(attributesMap.asMap())
+        .containsOnly(entry(stringKey("key1"), "value1"), entry(booleanKey("key2"), true));
   }
 }


### PR DESCRIPTION
Resolves #7897

### Changes
Fixes inconsistent last-value-wins behavior in `AttributesMap`.

Previously, `AttributesMap` stored attributes directly in a `HashMap<AttributeKey<?>, Object>`. Since `AttributeKey` equals/hashCode includes the type, adding two attributes with the same raw string name but different types would result in both being kept, violating the OpenTelemetry specification requirement that setting the same key SHOULD overwrite the existing value.

This PR modifies `AttributesMap.put` to search for any existing key with the same string representation and remove it before inserting the new key/value. It also overrides `putAll` to ensure all entries are processed through `put` to correctly deduplicate and respect the capacity limits.

### Checklist
- [x] Added unit tests verifying last-value-wins behavior with different types in `AttributesMapTest`
- [x] Code formatted using spotlessApply
