### PR TITLE
Use GraphQL to find the existing dashboard issue

### DIFF
--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DASHBOARD_TITLE: "Pull Request Dashboard"
+      DASHBOARD_LABEL: "dashboard"
       DASHBOARD_OUTPUT: pull-request-dashboard.md
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,15 +45,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find the open issue with an exact title match. The search API
-          # does not support exact phrases, so filter the results in jq.
-          number=$(gh issue list \
-            --search "in:title $DASHBOARD_TITLE" \
-            --state open \
-            --limit 20 \
-            --json number,title \
-            --jq ".[] | select(.title == \"$DASHBOARD_TITLE\") | .number" \
-            | head -1)
+          set -euo pipefail
+
+          # Use GraphQL instead of `gh issue list --search` because the
+          # search index has been observed to omit issues, which would
+          # cause this step to create a duplicate dashboard issue instead
+          # of updating the existing one.
+          owner="${GITHUB_REPOSITORY%/*}"
+          name="${GITHUB_REPOSITORY#*/}"
+          number=$(gh api graphql --paginate \
+            -F owner="$owner" -F name="$name" -F label="$DASHBOARD_LABEL" \
+            -f query='
+              query ($owner: String!, $name: String!, $label: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  issues(
+                    first: 100
+                    after: $endCursor
+                    states: OPEN
+                    filterBy: { labels: [$label] }
+                    orderBy: { field: CREATED_AT, direction: ASC }
+                  ) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes { number title }
+                  }
+                }
+              }' \
+            --jq ".data.repository.issues.nodes[] | select(.title == \"$DASHBOARD_TITLE\") | .number" \
+            | sed -n '1p')
 
           if [[ -n "$number" ]]; then
             echo "Updating existing issue #$number"
@@ -61,5 +80,6 @@ jobs:
             echo "Creating new dashboard issue"
             gh issue create \
               --title "$DASHBOARD_TITLE" \
+              --label "$DASHBOARD_LABEL" \
               --body-file "$DASHBOARD_OUTPUT"
           fi


### PR DESCRIPTION
The `gh issue list --search` lookup relies on the GitHub search index, which has been observed to omit issues. When that happens, the publish step finds no existing dashboard issue and creates a duplicate instead of updating the existing one.

Switch the lookup to a paginated GraphQL query filtered by the `dashboard` label, and tag newly created dashboard issues with that label so they remain discoverable.

Ported from https://github.com/open-telemetry/semantic-conventions-genai/pull/199