### PR TITLE
Use HTTP error bodies in HttpExporter warnings

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.otlp.internal;
 
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.FailedExportException;
+import io.opentelemetry.exporter.internal.grpc.GrpcExporterUtil;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.metrics.ExporterInstrumentation;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -18,6 +19,7 @@ import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -32,6 +34,8 @@ import javax.annotation.Nullable;
  */
 @SuppressWarnings("checkstyle:JavadocMethod")
 public final class HttpExporter {
+  // Limit logged response body text to avoid flooding warnings with large payloads.
+  private static final int MAX_RESPONSE_BODY_LOG_LENGTH = 1024;
 
   private static final Logger internalLogger = Logger.getLogger(HttpExporter.class.getName());
 
@@ -132,10 +136,23 @@ public final class HttpExporter {
     if (responseBody == null) {
       return "Response body missing, HTTP status message: " + statusMessage;
     }
+    if (responseBody.length == 0) {
+      return "Response body has 0 length, HTTP status message: " + statusMessage;
+    }
     try {
       return GrpcExporterUtil.getStatusMessage(responseBody);
     } catch (IOException e) {
-      return "Unable to parse response body, HTTP status message: " + statusMessage;
+      return extractResponseBodyMessage(responseBody, statusMessage);
     }
+  }
+
+  private static String extractResponseBodyMessage(byte[] responseBody, String statusMessage) {
+    int lengthToRead = Math.min(responseBody.length, MAX_RESPONSE_BODY_LOG_LENGTH);
+    String responseBodyText =
+        new String(responseBody, 0, lengthToRead, StandardCharsets.UTF_8).trim();
+    if (responseBodyText.isEmpty()) {
+      return "HTTP status message: " + statusMessage;
+    }
+    return "Response body: " + responseBodyText + ", HTTP status message: " + statusMessage;
   }
 }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.exporter.otlp.internal;
 
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.FailedExportException;
-import io.opentelemetry.exporter.internal.grpc.GrpcExporterUtil;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.exporter.internal.metrics.ExporterInstrumentation;
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
@@ -238,6 +238,81 @@ class HttpExporterTest {
     logs.assertDoesNotContain("Unable to parse response body");
   }
 
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_nullErrorBodyUsesMissingBodyMessage() {
+    HttpSender mockSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockSender,
+            MeterProvider::noop,
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://testing:1234"),
+            false);
+
+    doAnswer(
+            invoc -> {
+              Consumer<HttpResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(
+                  new HttpResponse() {
+                    @Override
+                    public int getStatusCode() {
+                      return 500;
+                    }
+
+                    @Override
+                    public String getStatusMessage() {
+                      return "Internal Server Error";
+                    }
+
+                    @Override
+                    public byte[] getResponseBody() {
+                      return null;
+                    }
+                  });
+              return null;
+            })
+        .when(mockSender)
+        .send(any(), any(), any());
+
+    assertThat(exporter.export(mockMarshaller, 1).join(10, TimeUnit.SECONDS).isSuccess()).isFalse();
+
+    logs.assertContains("Response body missing, HTTP status message: Internal Server Error");
+  }
+
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_whitespaceErrorBodyFallsBackToStatusMessage() {
+    HttpSender mockSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockSender,
+            MeterProvider::noop,
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://testing:1234"),
+            false);
+
+    doAnswer(
+            invoc -> {
+              Consumer<HttpResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(
+                  new FakeHttpResponse(
+                      500, "Internal Server Error", "   ".getBytes(StandardCharsets.UTF_8)));
+              return null;
+            })
+        .when(mockSender)
+        .send(any(), any(), any());
+
+    assertThat(exporter.export(mockMarshaller, 1).join(10, TimeUnit.SECONDS).isSuccess()).isFalse();
+
+    logs.assertContains("HTTP status message: Internal Server Error");
+    logs.assertDoesNotContain("Response body:");
+  }
+
   private static class FakeHttpResponse implements HttpResponse {
 
     final int statusCode;

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
@@ -6,10 +6,13 @@
 package io.opentelemetry.exporter.otlp.internal;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
@@ -22,12 +25,32 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 class HttpExporterTest {
+
+  @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(HttpExporter.class);
+
+  @Test
+  void build_NoHttpSenderProvider() {
+    assertThatThrownBy(
+            () ->
+                new HttpExporterBuilder(
+                        StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER,
+                        "http://localhost")
+                    .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "No HttpSenderProvider found on classpath. Please add dependency on "
+                + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-jdk");
+  }
 
   @ParameterizedTest
   @EnumSource
@@ -197,14 +220,53 @@ class HttpExporterTest {
     }
   }
 
+  @Test
+  @SuppressLogger(HttpExporter.class)
+  void export_httpJsonErrorBodyUsesBodyTextWithoutGrpcParseWarning() {
+    HttpSender mockSender = Mockito.mock(HttpSender.class);
+    Marshaler mockMarshaller = Mockito.mock(Marshaler.class);
+    HttpExporter exporter =
+        new HttpExporter(
+            ComponentId.generateLazy(StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER),
+            mockSender,
+            MeterProvider::noop,
+            InternalTelemetryVersion.LATEST,
+            URI.create("http://testing:1234"),
+            false);
+
+    doAnswer(
+            invoc -> {
+              Consumer<HttpResponse> onResponse = invoc.getArgument(1);
+              onResponse.accept(
+                  new FakeHttpResponse(
+                      500,
+                      "Internal Server Error",
+                      "{\"error\":\"grpc not supported\"}".getBytes(StandardCharsets.UTF_8)));
+              return null;
+            })
+        .when(mockSender)
+        .send(any(), any(), any());
+
+    assertThat(exporter.export(mockMarshaller, 1).join(10, TimeUnit.SECONDS).isSuccess()).isFalse();
+
+    logs.assertContains("Response body: {\"error\":\"grpc not supported\"}");
+    logs.assertDoesNotContain("Unable to parse response body");
+  }
+
   private static class FakeHttpResponse implements HttpResponse {
 
     final int statusCode;
     final String statusMessage;
+    final byte[] responseBody;
 
     FakeHttpResponse(int statusCode, String statusMessage) {
+      this(statusCode, statusMessage, new byte[0]);
+    }
+
+    FakeHttpResponse(int statusCode, String statusMessage, byte[] responseBody) {
       this.statusCode = statusCode;
       this.statusMessage = statusMessage;
+      this.responseBody = responseBody;
     }
 
     @Override
@@ -219,7 +281,7 @@ class HttpExporterTest {
 
     @Override
     public byte[] getResponseBody() {
-      return new byte[0];
+      return responseBody;
     }
   }
 }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.exporter.otlp.internal;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 
@@ -37,20 +36,6 @@ import org.mockito.Mockito;
 class HttpExporterTest {
 
   @RegisterExtension LogCapturer logs = LogCapturer.create().captureForType(HttpExporter.class);
-
-  @Test
-  void build_NoHttpSenderProvider() {
-    assertThatThrownBy(
-            () ->
-                new HttpExporterBuilder(
-                        StandardComponentId.ExporterType.OTLP_HTTP_SPAN_EXPORTER,
-                        "http://localhost")
-                    .build())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "No HttpSenderProvider found on classpath. Please add dependency on "
-                + "opentelemetry-exporter-sender-okhttp or opentelemetry-exporter-sender-jdk");
-  }
 
   @ParameterizedTest
   @EnumSource

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/HttpExporterTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -255,23 +256,7 @@ class HttpExporterTest {
     doAnswer(
             invoc -> {
               Consumer<HttpResponse> onResponse = invoc.getArgument(1);
-              onResponse.accept(
-                  new HttpResponse() {
-                    @Override
-                    public int getStatusCode() {
-                      return 500;
-                    }
-
-                    @Override
-                    public String getStatusMessage() {
-                      return "Internal Server Error";
-                    }
-
-                    @Override
-                    public byte[] getResponseBody() {
-                      return null;
-                    }
-                  });
+              onResponse.accept(new FakeHttpResponse(500, "Internal Server Error", null));
               return null;
             })
         .when(mockSender)
@@ -317,13 +302,13 @@ class HttpExporterTest {
 
     final int statusCode;
     final String statusMessage;
-    final byte[] responseBody;
+    @Nullable final byte[] responseBody;
 
     FakeHttpResponse(int statusCode, String statusMessage) {
       this(statusCode, statusMessage, new byte[0]);
     }
 
-    FakeHttpResponse(int statusCode, String statusMessage, byte[] responseBody) {
+    FakeHttpResponse(int statusCode, String statusMessage, @Nullable byte[] responseBody) {
       this.statusCode = statusCode;
       this.statusMessage = statusMessage;
       this.responseBody = responseBody;
@@ -340,6 +325,7 @@ class HttpExporterTest {
     }
 
     @Override
+    @Nullable
     public byte[] getResponseBody() {
       return responseBody;
     }


### PR DESCRIPTION
Refs #7704.

## Why
- `HttpExporter` currently tries to parse every non-success HTTP response body as a serialized gRPC status.
- When a custom server returns a JSON error body instead, export failure is reported correctly, but the warning text degrades to `Unable to parse response body`, which is noisy and hides the actual server response.

## What
- keep gRPC status parsing for responses that contain a serialized gRPC status body
- fall back to logging the UTF-8 response body text when parsing fails
- fall back to the HTTP status message when the body is empty
- add a targeted test covering a JSON error response body

## Testing
- `./gradlew :exporters:otlp:all:test --tests "*HttpExporterTest"`
- `./gradlew :exporters:common:spotlessCheck :exporters:otlp:all:spotlessCheck`
- `./gradlew jApiCmp`