### PR TITLE
docs: add configuration policy guidance

### DIFF
--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -15,7 +15,7 @@ is the signal.
 |------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | [build.md](build.md)                           | Always — build requirements and common tasks                                                                            |
 | [general-patterns.md](general-patterns.md)     | Always — style, nullability, visibility, AutoValue, locking, logging, internal & impl packages                          |
-| [api-design.md](api-design.md)                 | Public API additions, removals, renames, or deprecations or implementations; null guards; stable vs alpha compatibility |
+| [api-design.md](api-design.md)                 | Public API additions, removals, renames, or deprecations or implementations; configuration changes; null guards; stable vs alpha compatibility |
 | [gradle-conventions.md](gradle-conventions.md) | `build.gradle.kts` or `settings.gradle.kts` changes; new modules                                                        |
 | [testing-patterns.md](testing-patterns.md)     | Test files in scope — assertions, test utilities, test suites                                                           |
 | [other-tasks.md](other-tasks.md)               | Dev environment setup, benchmarks, composite builds, native image tests, OTLP protobuf updates                          |

--- a/docs/knowledge/api-design.md
+++ b/docs/knowledge/api-design.md
@@ -19,37 +19,43 @@ enforces this via japicmp — see [japicmp](#japicmp) below.
 
 ## Configuration
 
-### Use judgment
+There are [3 configuration interfaces](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/configuration#configuration-interfaces):
 
-Not every capability needs a new environment variable or system property. Prefer smaller,
-composable configuration surfaces over adding one-off toggles.
+- Programmatic configuration: invoke Java APIs to build components. This is the base of all other
+  configuration interfaces.
+- Env var / system property configuration: set flat env vars / system properties, which are
+  interpreted to equivalent calls to the programmatic configuration interface.
+- Declarative configuration: structured, YAML-based configuration, which is interpreted to
+  equivalent calls to the programmatic configuration interface.
 
-### Adding environment variables and system properties
+As a general rule, all configuration interfaces are bound by the spec. However, we make certain
+exceptions with Java-specific additions in places where the lack of such features is detrimental to
+the OpenTelemetry Java ecosystem. For example:
 
-Be judicious about adding new environment variables or system properties.
+- The OTLP exporters have programmatic proxy configuration options. Despite not being part of the
+  spec, this is a common enough use case that not supporting it would be a glaring oversight.
+- Env var / system property configuration has an `otel.java.metrics.cardinality.limit` property for
+  configuring a global cardinality limit. This is not part of the spec, but it is an important and
+  common enough use case that we added a Java-specific property for it.
 
-- Prefer existing configuration when it can already express the behavior.
-- Include a clear justification for any new config key, including why existing configuration is not
-  sufficient.
-- Treat new config keys as a long-term compatibility and maintenance commitment.
+Configuration options outside the spec are added at maintainers' discretion. If proposing an
+option outside the spec, start with programmatic configuration, which we are much more likely to
+accept.
 
-### Declarative config parity
+Declarative configuration is stable at the spec level and was designed to solve the expressiveness
+shortcomings of env var / system property configuration. It is the priority interface for current
+and future configuration enhancements. By default, new non-programmatic configuration options
+should target declarative configuration. This means:
 
-Declarative config should remain a strict superset of environment variable and system property
-configuration.
+- We are judicious about extending the env var / system property configuration interface with new
+  options. Additions are at maintainers' discretion.
+- Declarative configuration must be a strict superset of env var / system property configuration.
+  In the event new env var / system properties are added, there must be equivalent capabilities in
+  declarative config, with the caveat that naming and structure do not need to be identical.
 
-If a change adds a new environment variable or system property, it **must** also add equivalent
-declarative config support. Equivalent does not require identical naming, but it must allow users
-to express the same capability through declarative config.
-
-### PR expectations for configuration changes
-
-PRs that introduce new configuration options should include:
-
-- The motivation for introducing new configuration.
-- The environment variable and system property names.
-- The equivalent declarative config form.
-- Tests and documentation updates covering the new configuration path.
+Configuration is part of our public API surface area, subject to our
+[versioning policy](../../VERSIONING.md) unless explicitly marked unstable (for example,
+`*.experimental.*` for env vars / system properties and `*/development` for declarative config).
 
 ## Deprecating API
 

--- a/docs/knowledge/api-design.md
+++ b/docs/knowledge/api-design.md
@@ -48,7 +48,8 @@ and future configuration enhancements. By default, new non-programmatic configur
 should target declarative configuration. This means:
 
 - We are judicious about extending the env var / system property configuration interface with new
-  options. Additions are at maintainers' discretion.
+  options. Additions are at maintainers' discretion. When proposing such an addition, also open a
+  corresponding issue or discussion post describing the use-case and justification.
 - Declarative configuration must be a strict superset of env var / system property configuration.
   In the event new env var / system properties are added, there must be equivalent capabilities in
   declarative config, with the caveat that naming and structure do not need to be identical.

--- a/docs/knowledge/api-design.md
+++ b/docs/knowledge/api-design.md
@@ -17,6 +17,40 @@ Breaking changes are allowed in alpha modules but should still be approached car
 Breaking changes are not allowed in stable modules outside of a major version bump. The build
 enforces this via japicmp — see [japicmp](#japicmp) below.
 
+## Configuration
+
+### Use judgment
+
+Not every capability needs a new environment variable or system property. Prefer smaller,
+composable configuration surfaces over adding one-off toggles.
+
+### Adding environment variables and system properties
+
+Be judicious about adding new environment variables or system properties.
+
+- Prefer existing configuration when it can already express the behavior.
+- Include a clear justification for any new config key, including why existing configuration is not
+  sufficient.
+- Treat new config keys as a long-term compatibility and maintenance commitment.
+
+### Declarative config parity
+
+Declarative config should remain a strict superset of environment variable and system property
+configuration.
+
+If a change adds a new environment variable or system property, it **must** also add equivalent
+declarative config support. Equivalent does not require identical naming, but it must allow users
+to express the same capability through declarative config.
+
+### PR expectations for configuration changes
+
+PRs that introduce new configuration options should include:
+
+- The motivation for introducing new configuration.
+- The environment variable and system property names.
+- The equivalent declarative config form.
+- Tests and documentation updates covering the new configuration path.
+
 ## Deprecating API
 
 Applies to both stable and alpha modules. Use plain `@Deprecated` — do **not** use


### PR DESCRIPTION
Fixes #8300.

## Why
- We have an established convention around adding sys props / env vars and keeping declarative config aligned, but it is not documented in the knowledge base.
- Contributors need a clear place to look when proposing configuration changes.

## What
- add `docs/knowledge/configuration-policy.md` documenting the configuration policy
- document that new env vars / sys props should be added judiciously
- document that declarative config should remain a strict superset of env/sysprop configuration
- add the new guidance to `docs/knowledge/README.md` so it is discoverable from the knowledge index

## Testing
- `./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs="-Xmx512m -XX:MaxMetaspaceSize=192m" spotlessCheck`