### PR TITLE
Directly expose noop exporters for spans and logs.

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-logs.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of opentelemetry-sdk-logs-1.63.0-SNAPSHOT.jar against opentelemetry-sdk-logs-1.62.0.jar
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.logs.export.LogRecordExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.logs.export.LogRecordExporter noop()

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of opentelemetry-sdk-trace-1.63.0-SNAPSHOT.jar against opentelemetry-sdk-trace-1.62.0.jar
-No changes.
+***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.sdk.trace.export.SpanExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.SpanExporter noop()

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
@@ -57,6 +57,13 @@ public interface LogRecordExporter extends Closeable {
   }
 
   /**
+   * Returns a {@link LogRecordExporter} that does nothing. All exported LogRecordData are ignored.
+   */
+  static LogRecordExporter noop(){
+    return NoopLogRecordExporter.getInstance();
+  }
+
+  /**
    * Exports the collections of given {@link LogRecordData}.
    *
    * @param logs the collection of {@link LogRecordData} to be exported

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
@@ -59,7 +59,7 @@ public interface LogRecordExporter extends Closeable {
   /**
    * Returns a {@link LogRecordExporter} that does nothing. All exported LogRecordData are ignored.
    */
-  static LogRecordExporter noop(){
+  static LogRecordExporter noop() {
     return NoopLogRecordExporter.getInstance();
   }
 

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/LogRecordExporterTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/export/LogRecordExporterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.logs.export;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LogRecordExporterTest {
+
+  @Test
+  void testNoop() {
+    LogRecordExporter noop = LogRecordExporter.noop();
+    assertNotNull(noop);
+    assertSame(NoopLogRecordExporter.getInstance(), noop);
+  }
+
+  @Test
+  void testComposite() {
+    LogRecordExporter exp1 = mock();
+    LogRecordExporter exp2 = mock();
+    List<LogRecordData> logs = Collections.singletonList(mock());
+
+    when(exp1.export(logs)).thenReturn(CompletableResultCode.ofSuccess());
+    when(exp2.export(logs)).thenReturn(CompletableResultCode.ofSuccess());
+
+    LogRecordExporter exporter = LogRecordExporter.composite(exp1, exp2);
+
+    exporter.export(logs);
+
+    verify(exp1).export(logs);
+    verify(exp2).export(logs);
+  }
+}

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -56,6 +56,13 @@ public interface SpanExporter extends Closeable {
   }
 
   /**
+   * Returns a {@link SpanExporter} that does nothing. All exported Spans are ignored.
+   */
+  static SpanExporter noop(){
+    return NoopSpanExporter.getInstance();
+  }
+
+  /**
    * Called to export sampled {@code Span}s. Note that export operations can be performed
    * simultaneously depending on the type of span processor being used. However, the {@link
    * BatchSpanProcessor} will ensure that only one export can occur at a time.

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -55,10 +55,8 @@ public interface SpanExporter extends Closeable {
     return MultiSpanExporter.create(exportersList);
   }
 
-  /**
-   * Returns a {@link SpanExporter} that does nothing. All exported Spans are ignored.
-   */
-  static SpanExporter noop(){
+  /** Returns a {@link SpanExporter} that does nothing. All exported Spans are ignored. */
+  static SpanExporter noop() {
     return NoopSpanExporter.getInstance();
   }
 

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SpanExporterTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/SpanExporterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.trace.export;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class SpanExporterTest {
+
+  @Test
+  void testNoop() {
+    SpanExporter exporter = SpanExporter.noop();
+    assertNotNull(exporter);
+    assertSame(exporter, NoopSpanExporter.getInstance());
+  }
+
+  @Test
+  void testComposite() {
+    SpanExporter exp1 = mock();
+    SpanExporter exp2 = mock();
+
+    Collection<SpanData> spans = Collections.singletonList(mock(SpanData.class));
+
+    when(exp1.export(spans)).thenReturn(CompletableResultCode.ofSuccess());
+    when(exp2.export(spans)).thenReturn(CompletableResultCode.ofSuccess());
+
+    SpanExporter exporter = SpanExporter.composite(exp1, exp2);
+
+    exporter.export(spans);
+    verify(exp1).export(spans);
+    verify(exp2).export(spans);
+  }
+}


### PR DESCRIPTION
Right now, there's a silly workaround for users that want to disable exporters -- they can simply use `SpanExporter.composite(emptyList())` to get the `NoOpSpanExporter.INSTANCE` implementation. Sure, this is an implementation detail, but its also pretty obvious that when you composite nothing you get nothing. And that just reads clunky.

Since we already have these NoOp implementations, let's just expose them more directly. The implementation is still completely internal, and yes, this does very slightly increase the api surface area, but I think it's within reason and should be an improvement over the composite hack.

Why not metrics? Welp, we don't have an existing NoOpMetricExporter. I'm not entirely sure why, but it might be due to the spec requiring the NoOp API implementation for metrics? 🤷🏻 