### PR TITLE
Add jaydeluca as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ For more information about the maintainer role, see the [community repository](h
 
 - [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana Labs
 - [Jason Plumb](https://github.com/breedx-splk), Splunk
+- [Jay DeLuca](https://github.com/jaydeluca), Grafana Labs
 - [Lauri Tulmin](https://github.com/laurit), Splunk
 - [Trask Stalnaker](https://github.com/trask), Microsoft
 


### PR DESCRIPTION
Jay is a long time member of the Java SIG and has contributed several PRs and regularly reviews PRs. I'd like to add him as an approver.

Thanks @jaydeluca!