### PR TITLE
[doc] fix sonatype link and token generation instruction

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,9 +79,9 @@ The following credentials are required for building or publishing (and automatic
   * [Register to publish](https://central.sonatype.org/register/central-portal/#publishing)
     and comment on [OSSRH-63768](https://issues.sonatype.org/browse/OSSRH-63768) with confirmation
     from another maintainer.
-  * To obtain `SONATYPE_USER` and `SONATYPE_KEY` for your account, login
-    to [oss.sonatype.org](https://oss.sonatype.org/) and navigate to Profile -> User Token -> Access
-    User Token.
+  * To obtain `SONATYPE_USER` and `SONATYPE_KEY` for your account, log in
+    to [central.sonatype.com](https://central.sonatype.com/) and navigate to Profile -> View User Tokens
+    (see [detailed instructions](https://central.sonatype.org/publish/generate-portal-token/)).
 
 Additionally, credentials are stored with maintainers via
 the [OpenTelemetry 1Password](https://opentelemetry.1password.com/signin) account. The following


### PR DESCRIPTION
RELEASING.md still points to decommissioned OSSRH. Fixing the URL as well as the instructions. Addresses build(daily) failure 185 in issue #8447

Error details for lychee in [Build (daily) #185](https://github.com/open-telemetry/opentelemetry-java/actions/runs/26996167983), `lint-check`

```bash
[RELEASING.md]:
[404] https://oss.sonatype.org/ (at 83:8) | Rejected status code: 404 Not Found

🔍 1021 Total (in 11s 48ms) 🔗 960 Unique ✅ 278 OK 🚫 1 Error 👻 742 Excluded 🔀 10 Redirects

Hint: Followed 10 redirects. You might want to consider replacing redirecting URLs with the resolved URLs. Use verbose mode (`-v`/`-vv`) to see redirection details.
Hint: You can configure accepted/rejected response codes with `-a` or `--accept`

flint: 1 check failed (lychee)
💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
[lint:links] ERROR task failed
Error: Process completed with exit code 1.
```