### PR TITLE
Fix W3CBaggagePropagator to allow empty baggage values per W3C spec

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -32,7 +32,6 @@ class Element {
 
   private final BitSet excluded;
   private final boolean allowEmpty;
-  private boolean seenWhitespace;
 
   private boolean leadingSpace;
   private boolean readingValue;
@@ -71,7 +70,6 @@ class Element {
     readingValue = false;
     trailingSpace = false;
     value = null;
-    seenWhitespace = false;
   }
 
   boolean tryTerminating(int index, String header) {
@@ -81,11 +79,11 @@ class Element {
     if (this.trailingSpace) {
       setValue(header);
       return true;
-    } else if (allowEmpty && !seenWhitespace) {
+    } else if (allowEmpty) {
+      // no content: empty value is valid (e.g. "key=" or "key=   "), empty key is not
       this.value = "";
       return true;
     } else {
-      // leading spaces - no content, invalid
       return false;
     }
   }
@@ -117,8 +115,6 @@ class Element {
   private boolean tryNextWhitespace(int index) {
     if (readingValue) {
       markEnd(index);
-    } else {
-      seenWhitespace = true;
     }
     return true;
   }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -31,7 +31,7 @@ class Element {
   }
 
   private final BitSet excluded;
-  private boolean allowEmpty;
+  private final boolean allowEmpty;
   private boolean seenWhitespace;
 
   private boolean leadingSpace;
@@ -42,13 +42,11 @@ class Element {
   @Nullable private String value;
 
   static Element createKeyElement() {
-    return new Element(EXCLUDED_KEY_CHARS);
+    return new Element(EXCLUDED_KEY_CHARS, /* allowEmpty= */ false);
   }
 
   static Element createValueElement() {
-    Element element = new Element(EXCLUDED_VALUE_CHARS);
-    element.allowEmpty = true;
-    return element;
+    return new Element(EXCLUDED_VALUE_CHARS, /* allowEmpty= */ true);
   }
 
   /**
@@ -56,9 +54,9 @@ class Element {
    *
    * @param excluded characters that are not allowed for this type of an element
    */
-  private Element(BitSet excluded) {
+  private Element(BitSet excluded, boolean allowEmpty) {
     this.excluded = excluded;
-    this.allowEmpty = false;
+    this.allowEmpty = allowEmpty;
     reset(0);
   }
 

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Element.java
@@ -31,6 +31,8 @@ class Element {
   }
 
   private final BitSet excluded;
+  private boolean allowEmpty;
+  private boolean seenWhitespace;
 
   private boolean leadingSpace;
   private boolean readingValue;
@@ -44,7 +46,9 @@ class Element {
   }
 
   static Element createValueElement() {
-    return new Element(EXCLUDED_VALUE_CHARS);
+    Element element = new Element(EXCLUDED_VALUE_CHARS);
+    element.allowEmpty = true;
+    return element;
   }
 
   /**
@@ -54,6 +58,7 @@ class Element {
    */
   private Element(BitSet excluded) {
     this.excluded = excluded;
+    this.allowEmpty = false;
     reset(0);
   }
 
@@ -68,6 +73,7 @@ class Element {
     readingValue = false;
     trailingSpace = false;
     value = null;
+    seenWhitespace = false;
   }
 
   boolean tryTerminating(int index, String header) {
@@ -76,6 +82,9 @@ class Element {
     }
     if (this.trailingSpace) {
       setValue(header);
+      return true;
+    } else if (allowEmpty && !seenWhitespace) {
+      this.value = "";
       return true;
     } else {
       // leading spaces - no content, invalid
@@ -110,6 +119,8 @@ class Element {
   private boolean tryNextWhitespace(int index) {
     if (readingValue) {
       markEnd(index);
+    } else {
+      seenWhitespace = true;
     }
     return true;
   }

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -232,7 +232,8 @@ class W3CBaggagePropagatorTest {
     Context result =
         propagator.extract(Context.root(), ImmutableMap.of("baggage", "key1=     "), getter);
 
-    assertThat(Baggage.fromContext(result)).isEqualTo(Baggage.empty());
+    Baggage expectedBaggage = Baggage.builder().put("key1", "").build();
+    assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
   }
 
   @Test

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -208,7 +208,8 @@ class W3CBaggagePropagatorTest {
     Context result =
         propagator.extract(Context.root(), ImmutableMap.of("baggage", "key1="), getter);
 
-    assertThat(Baggage.fromContext(result)).isEqualTo(Baggage.empty());
+    Baggage expectedBaggage = Baggage.builder().put("key1", "").build();
+    assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
   }
 
   @Test
@@ -219,7 +220,9 @@ class W3CBaggagePropagatorTest {
         propagator.extract(
             Context.root(), ImmutableMap.of("baggage", "key1=;metakey=metaval"), getter);
 
-    assertThat(Baggage.fromContext(result)).isEqualTo(Baggage.empty());
+    Baggage expectedBaggage =
+        Baggage.builder().put("key1", "", BaggageEntryMetadata.create("metakey=metaval")).build();
+    assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
   }
 
   @Test


### PR DESCRIPTION
Fixes #8465

`W3CBaggagePropagator` drops baggage entries with empty values like `key1=`, but the W3C spec defines `value = *baggage-octet`, meaning zero characters is valid.

.NET, Go, and Rust implementations already accept empty values — Java was the only outlier.

## Changes
- Added `allowEmpty` flag to `Element.createValueElement()` to permit empty string values
- Added `seenWhitespace` tracking to distinguish `key=` (valid) from `key=   ` (invalid)
- Updated tests accordingly