### PR TITLE
Fix Value Javadoc typo

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/common/Value.java
+++ b/api/all/src/main/java/io/opentelemetry/api/common/Value.java
@@ -22,7 +22,7 @@ import java.util.Map;
  *   <li>String-keyed maps (i.e. associative arrays, dictionaries) via {@link #of(KeyValue...)},
  *       {@link #of(Map)}. Note, because map values are type {@link Value}, maps can be nested
  *       within other maps.
- *   <li>Arrays (heterogeneous or homogenous) via {@link #of(Value[])}. Note, because array values
+ *   <li>Arrays (heterogeneous or homogeneous) via {@link #of(Value[])}. Note, because array values
  *       are type {@link Value}, arrays can contain primitives, complex types like maps or arrays,
  *       or any combination.
  *   <li>Raw bytes via {@link #of(byte[])}


### PR DESCRIPTION
## Description

Fixes a typo in the `Value` Javadoc.

* `homogenous` → `homogeneous`

## Testing

Not run; this is a documentation-only change.
