### PR TITLE
Fix baggage parsing for invalid percent-encoded members

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -8,6 +8,8 @@ package io.opentelemetry.api.baggage.propagation;
 import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -19,6 +21,8 @@ import javax.annotation.Nullable;
  * anything besides element terminator (comma).
  */
 class Parser {
+
+  private static final Logger LOGGER = Logger.getLogger(Parser.class.getName());
 
   private enum State {
     KEY,
@@ -140,8 +144,14 @@ class Parser {
     if (entriesAdded >= maxEntries) {
       return;
     }
-    String decodedValue = decodeValue(value);
-    metadataValue = decodeValue(metadataValue);
+    String decodedValue;
+    try {
+      decodedValue = decodeValue(value);
+      metadataValue = decodeValue(metadataValue);
+    } catch (IllegalArgumentException e) {
+      LOGGER.log(Level.WARNING, "Skipping invalid baggage member", e);
+      return;
+    }
     BaggageEntryMetadata baggageEntryMetadata =
         metadataValue != null
             ? BaggageEntryMetadata.create(metadataValue)

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.baggage.BaggageBuilder;
 import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -437,6 +438,41 @@ class W3CBaggagePropagatorTest {
             .put("key3", "value3")
             .build();
     assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  @SuppressLogger(Parser.class)
+  void extract_member_invalidPercentEncoding_preservesValidMembers(
+      String header, Baggage expectedBaggage) {
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
+
+    Context result = propagator.extract(Context.root(), ImmutableMap.of("baggage", header), getter);
+    assertThat(Baggage.fromContext(result)).isEqualTo(expectedBaggage);
+  }
+
+  static Stream<Arguments> extract_member_invalidPercentEncoding_preservesValidMembers() {
+    return Stream.of(
+        Arguments.argumentSet(
+            "invalid entry at beginning",
+            "bad=va%lue,key1=value1,encoded=value%202",
+            Baggage.builder().put("key1", "value1").put("encoded", "value 2").build()),
+        Arguments.argumentSet(
+            "invalid entry in middle",
+            "key1=value1,bad=va%lue,encoded=value%202,key2=value2",
+            Baggage.builder()
+                .put("key1", "value1")
+                .put("encoded", "value 2")
+                .put("key2", "value2")
+                .build()),
+        Arguments.argumentSet(
+            "invalid entry at end",
+            "key1=value1,encoded=value%202,bad=va%lue",
+            Baggage.builder().put("key1", "value1").put("encoded", "value 2").build()),
+        Arguments.argumentSet(
+            "multiple invalid entries",
+            "bad1=va%lue,key1=value1,bad2=value%GG,encoded=value%202,bad3=value;meta=%GG",
+            Baggage.builder().put("key1", "value1").put("encoded", "value 2").build()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Currently, an invalid percent-encoded baggage member can cause parsing of the remaining members in the same baggage header to abort.

For example:

```text
baggage: key1=value1,bad=va%lue,key2=value2
```

When parsing `bad=va%lue`, percent decoding throws an `IllegalArgumentException`, preventing subsequent valid members from being processed.

This change skips only the invalid member and continues processing the remaining members in the header.

A regression test has been added to verify that valid members are preserved when another member contains invalid percent encoding.

## Testing

```bash
./gradlew :api:all:test --tests io.opentelemetry.api.baggage.propagation.W3CBaggagePropagatorTest
```
