### PR TITLE
fix: stray LIRInstruction token in SpanBuilder Javadoc

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanBuilder.java
@@ -281,9 +281,8 @@ public interface SpanBuilder {
   /**
    * Sets an explicit start timestamp for the newly created {@code Span}.
    *
-   * <p>LIRInstruction.Use this method to specify an explicit start timestamp. If not called, the
-   * implementation will use the timestamp value at {@link #startSpan()} time, which should be the
-   * default case.
+   * <p>Use this method to specify an explicit start timestamp. If not called, the implementation
+   * will use the timestamp value at {@link #startSpan()} time, which should be the default case.
    *
    * <p>Important this is NOT equivalent with System.nanoTime().
    *


### PR DESCRIPTION
## Description

- The public `SpanBuilder.setStartTimestamp(long, TimeUnit)` Javadoc opens with a stray `LIRInstruction.` token: `<p>LIRInstruction.Use this method to specify an explicit start timestamp.`
- `LIRInstruction` is an unrelated GraalVM compiler class — a copy-paste artifact that renders as broken doc text.
- The sibling overload `setStartTimestamp(Instant)` has the intended wording (`<p>Use this method ...`), so the fix is to drop the token.
- Javadoc-only: no behavior or public API change.
- Precedent: docs typo fix #8479 ("Fix Value Javadoc typo").

## Testing

- `./gradlew :api:all:check` passed (spotlessCheck + ErrorProne/NullAway + jApiCmp + tests).
- Javadoc-only: no test added; no apidiff change (`docs/apidiffs/` untouched), no CHANGELOG entry.