### PR TITLE
Assert single-arg Logger.isEnabled overload in shared default logger test

### DIFF
--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultLoggerTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultLoggerTest.java
@@ -48,6 +48,7 @@ public abstract class AbstractDefaultLoggerTest {
   @Test
   void defaultIsEnabled() {
     assertThat(getLogger().isEnabled(Severity.ERROR, Context.root())).isFalse();
+    assertThat(getLogger().isEnabled(Severity.ERROR)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `Logger` has two stable overloads (since 1.61.0): `isEnabled(Severity, Context)` and `isEnabled(Severity)`.
- The shared base `AbstractDefaultLoggerTest#defaultIsEnabled` asserted only the 2-arg overload, so the `api/all` `DefaultLogger` 1-arg path was never exercised by any concrete test.
- Add a 1-arg assertion to the base, matching the sibling `api/incubator` `ExtendedDefaultLoggerTest` which already asserts both overloads.
- 1-arg overload introduced in #8200 (Stabilize enabled api).

## Testing done

- `./gradlew :api:testing-internal:check` passed (compile/spotless/errorprone; no concrete tests run there).
- `./gradlew :api:all:test --tests "...DefaultLoggerTest"` passed.
- `./gradlew :api:incubator:test --tests "...ExtendedDefaultLoggerTest"` passed.
- Green before and after (coverage fill, not a behavior change). No public API change (no apidiff), no user-facing change (no CHANGELOG).
