### PR TITLE
Fix incorrect Javadoc in DeclarativeConfigProperties

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigProperties.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigProperties.java
@@ -160,8 +160,8 @@ public interface DeclarativeConfigProperties {
   <T> List<T> getScalarList(String name, Class<T> scalarType);
 
   /**
-   * Returns a {@link List} configuration property. Entries which are not strings are converted to
-   * their string representation.
+   * Returns a {@link List} configuration property. Empty values and values which do not map to the
+   * {@code scalarType} will be removed.
    *
    * @param name the property name
    * @param scalarType the scalar type, one of {@link String}, {@link Boolean}, {@link Long} or
@@ -183,7 +183,7 @@ public interface DeclarativeConfigProperties {
   DeclarativeConfigProperties getStructured(String name);
 
   /**
-   * Returns a list of {@link DeclarativeConfigProperties} configuration property.
+   * Returns a {@link DeclarativeConfigProperties} configuration property.
    *
    * @return a map-valued configuration property, or {@code defaultValue} if {@code name} has not
    *     been configured or is not a mapping


### PR DESCRIPTION
## Summary
- `getScalarList(name, scalarType, defaultValue)` summary claimed non-string entries are converted to a string, but they are removed (along with empty values) when they do not map to `scalarType`.
- `getStructured(name, defaultValue)` summary said "list of" but the method returns a single mapping.
- Both now match their non-default siblings (`getScalarList(name, scalarType)`, `getStructured(name)`); filtering happens in `YamlDeclarativeConfigProperties#getScalarList` via `.filter(Objects::nonNull)` (sdk-extensions/declarative-config).

## Testing done

- Javadoc-only change; no behavior change, no new tests.
- `./gradlew :api:incubator:check` passed.
- No signature change → no apidiff. Not user-facing → no CHANGELOG entry.
