### PR TITLE
Fix typo in ApiUsageLogger warning message

### DIFF
--- a/common/src/main/java/io/opentelemetry/common/impl/ApiUsageLogger.java
+++ b/common/src/main/java/io/opentelemetry/common/impl/ApiUsageLogger.java
@@ -61,7 +61,7 @@ public final class ApiUsageLogger {
   public static void logUsageIssue(Class<?> apiClass, String methodName, String message) {
     if (WARN_ONCE.compareAndSet(false, true)) {
       LOGGER.warning(
-          "OpenTelemetry API usage issue detected. To see more details, enable FINEST logging for io.opentelemetry.usage. Stacktraces are includes to identify the offending call site.");
+          "OpenTelemetry API usage issue detected. To see more details, enable FINEST logging for io.opentelemetry.usage. Stacktraces are included to identify the offending call site.");
     }
     if (LOGGER.isLoggable(Level.FINEST)) {
       LOGGER.log(


### PR DESCRIPTION
## Description

- `ApiUsageLogger.logUsageIssue` emits a one-time `WARNING`, visible under default logging, reading "Stacktraces are includes to identify the offending call site" — "are includes" is ungrammatical.
- Changed "are includes" to "are included", matching the same class Javadoc, which already phrases it correctly ("includes a Throwable").

## Testing done

- `./gradlew :common:check` — full check (test + spotlessCheck + ErrorProne/NullAway + jApiCmp) BUILD SUCCESSFUL; existing `ApiUsageLoggerTest` confirms no regression.
- String-literal change only: no `docs/apidiffs` diff and no `CHANGELOG.md` entry (not a user-facing config/feature/default change).