### PR TITLE
Fix dead references in Context module javadoc

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/Context.java
+++ b/context/src/main/java/io/opentelemetry/context/Context.java
@@ -112,8 +112,9 @@ public interface Context {
    *
    * <p>This is generally used to create an {@link Executor} which will forward the {@link Context}
    * during an invocation to another thread. For example, you may use something like {@code Executor
-   * dbExecutor = Context.wrapTasks(threadPool)} to ensure calls like {@code dbExecutor.execute(()
-   * -> database.query())} have {@link Context} available on the thread executing database queries.
+   * dbExecutor = Context.taskWrapping(threadPool)} to ensure calls like {@code
+   * dbExecutor.execute(() -> database.query())} have {@link Context} available on the thread
+   * executing database queries.
    *
    * @since 1.1.0
    */
@@ -129,7 +130,7 @@ public interface Context {
    *
    * <p>This is generally used to create an {@link ExecutorService} which will forward the {@link
    * Context} during an invocation to another thread. For example, you may use something like {@code
-   * ExecutorService dbExecutor = Context.wrapTasks(threadPool)} to ensure calls like {@code
+   * ExecutorService dbExecutor = Context.taskWrapping(threadPool)} to ensure calls like {@code
    * dbExecutor.execute(() -> database.query())} have {@link Context} available on the thread
    * executing database queries.
    *
@@ -150,7 +151,7 @@ public interface Context {
    *
    * <p>This is generally used to create an {@link ScheduledExecutorService} which will forward the
    * {@link Context} during an invocation to another thread. For example, you may use something like
-   * {@code ScheduledExecutorService dbExecutor = Context.wrapTasks(threadPool)} to ensure calls
+   * {@code ScheduledExecutorService dbExecutor = Context.taskWrapping(threadPool)} to ensure calls
    * like {@code dbExecutor.execute(() -> database.query())} have {@link Context} available on the
    * thread executing database queries.
    *

--- a/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -82,7 +82,7 @@ public interface TextMapPropagator {
 
   /**
    * The propagation fields defined. If your carrier is reused, you should delete the fields here
-   * before calling {@link #inject(Context, Object, TextMapSetter)} )}.
+   * before calling {@link #inject(Context, Object, TextMapSetter)}.
    *
    * <p>For example, if the carrier is a single-use or immutable request object, you don't need to
    * clear fields as they couldn't have been set before. If it is a mutable, retryable object,


### PR DESCRIPTION
## Description

- `Context` javadoc shows `Context.wrapTasks(threadPool)` in three examples, but no such method exists — the declared method is `taskWrapping`, so copying the example does not compile.
- Fixed all three examples to `Context.taskWrapping(threadPool)`. The wrong name dates to #2988, which declared `taskWrapping` but wrote `wrapTasks` in its example.
- `TextMapPropagator#fields` javadoc had a stray ` )}` after a closed `{@link #inject(...)}`; removed it.
- Javadoc-only: no signature or behavior change, so no apidiff or CHANGELOG entry.

## Testing done

- `./gradlew :context:check` — passed (test + spotlessCheck + ErrorProne/NullAway + jApiCmp).
- No new tests added: docs-only change, test-exempt.
