### PR TITLE
Fix logging-otlp package Javadoc to include logs

### DIFF
--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/package-info.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/package-info.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** OpenTelemetry exporters which writes spans or metrics to log using OTLP JSON format. */
+/** OpenTelemetry exporters which write spans, metrics, or logs to a logger in OTLP JSON format. */
 @ParametersAreNonnullByDefault
 package io.opentelemetry.exporter.logging.otlp;
 


### PR DESCRIPTION
## Description

- The package Javadoc said exporters "writes spans or metrics" — logs omitted, plus a subject-verb mismatch ("exporters ... writes").
- This package ships span, metric, and log exporters: `OtlpJsonLoggingSpanExporter`, `OtlpJsonLoggingMetricExporter`, `OtlpJsonLoggingLogRecordExporter`.
- Reworded to "exporters which write spans, metrics, or logs to a logger in OTLP JSON format", matching the sibling class Javadoc pattern.
- Javadoc-only change: no signature or behavior change, so no apidiff or CHANGELOG entry.

## Testing done

- `./gradlew :exporters:logging-otlp:check` — 77 tests passed, 0 failures (includes spotlessCheck, ErrorProne/NullAway, jApiCmp).
- No new tests added: docs-only change with no behavior change.
- jApiCmp produced no apidiff change (Javadoc only); `docs/apidiffs` unchanged.
