### PR TITLE
Fix dead API reference in rationale.md try-with-resources example

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -13,7 +13,7 @@ which try-with-resources does not allow. Take this example:
 
 ```java
 Span span = tracer.spanBuilder("someWork").startSpan();
-try (Scope scope = TracingContextUtils.currentContextWith(span)) {
+try (Scope scope = span.makeCurrent()) {
     // Do things.
 } catch (Exception ex) {
     span.recordException(ex);


### PR DESCRIPTION
<!-- No issue: minor docs fix, issue not required -->

## Description

- The "Span not `Closeable`" example in `docs/rationale.md` calls `TracingContextUtils.currentContextWith(span)`. Neither that class nor the `currentContextWith` method exists in the codebase (confirmed via `grep`), so copy-pasting the example does not compile.
- Since `Span extends ImplicitContextKeyed`, `span.makeCurrent()` returns a `Scope` — the current API that fits try-with-resources directly.
- The sibling doc `docs/sdk-configuration-design.md` already uses the `try (Scope ignored = span.makeCurrent())` pattern; this PR aligns the example with it.

## Testing done

- Docs-only change (1 line in `docs/rationale.md`). No behavior change → no new tests, not a Gradle build target.
- Confirmed in `context/.../ImplicitContextKeyed.java` that `span.makeCurrent()` returns `Scope`, matching the example's `try (Scope scope = ...)`.
- No apidiff / CHANGELOG change (not a public API or user-facing behavior change).
