### PR TITLE
Reject host-less endpoints in EndpointUtil.validateEndpoint

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/EndpointUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/EndpointUtil.java
@@ -30,6 +30,10 @@ public final class EndpointUtil {
       throw new IllegalArgumentException(
           "Invalid endpoint, must start with http:// or https://: " + uri);
     }
+    if (uri.getHost() == null) {
+      throw new IllegalArgumentException(
+          "Invalid endpoint, must start with http:// or https://: " + uri);
+    }
     return uri;
   }
 

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EndpointUtilTest {
+
+  @ParameterizedTest
+  @MethodSource("validEndpoints")
+  void validateEndpoint_valid(String endpoint) {
+    assertThat(EndpointUtil.validateEndpoint(endpoint)).isEqualTo(URI.create(endpoint));
+  }
+
+  private static Stream<Arguments> validEndpoints() {
+    return Stream.of(
+        Arguments.argumentSet("http", "http://localhost:4318"),
+        Arguments.argumentSet("https", "https://localhost:4317"),
+        Arguments.argumentSet("path", "http://localhost:4318/v1/traces"),
+        Arguments.argumentSet("userinfo", "http://foo:bar@localhost:4317/path"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http:localhost:4317", // opaque, no host
+        "https:/foo", // single slash, no host
+        "localhost", // no scheme
+        "gopher://localhost" // wrong scheme
+      })
+  void validateEndpoint_invalid(String endpoint) {
+    assertThatThrownBy(() -> EndpointUtil.validateEndpoint(endpoint))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must start with http:// or https://");
+  }
+}

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class EndpointUtilTest {
 
@@ -32,16 +31,18 @@ class EndpointUtilTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "http:localhost:4317", // opaque, no host
-        "https:/foo", // single slash, no host
-        "localhost", // no scheme
-        "gopher://localhost" // wrong scheme
-      })
+  @MethodSource("invalidEndpoints")
   void validateEndpoint_invalid(String endpoint) {
     assertThatThrownBy(() -> EndpointUtil.validateEndpoint(endpoint))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must start with http:// or https://");
+  }
+
+  private static Stream<Arguments> invalidEndpoints() {
+    return Stream.of(
+        Arguments.argumentSet("opaque, no host", "http:localhost:4317"),
+        Arguments.argumentSet("single slash, no host", "https:/foo"),
+        Arguments.argumentSet("no scheme", "localhost"),
+        Arguments.argumentSet("wrong scheme", "gopher://localhost"));
   }
 }


### PR DESCRIPTION
<!-- No issue: minor bug fix, issue not required -->

## Description

- `EndpointUtil.validateEndpoint` accepts host-less URIs such as `http:localhost:4317` (opaque) and `https:/foo` (single slash): they have an http/https scheme but no host, so export only fails later at connection time.
- Add a `uri.getHost() == null` guard after the scheme check, reusing the existing "must start with http:// or https://" message.
- The sibling validator `OtlpConfigUtil.validateEndpoint` (exporters/otlp/all) uses `new URL()` and already rejects these; this fills the missing case in `EndpointUtil`'s equivalent contract.
- Behavior change: host-less endpoints that previously passed scheme validation are now rejected.

## Testing done

- Added `EndpointUtilTest` with valid endpoints (http, https, path, userinfo+host) and invalid ones (opaque `http:localhost:4317`, single-slash `https:/foo`, no-scheme `localhost`, wrong-scheme `gopher://localhost`).
- `./gradlew :exporters:common:check` — passed; `EndpointUtilTest` ran 8 tests.
- `internal` package, signature unchanged: no apidiff; not user-facing, so no CHANGELOG.