### PR TITLE
Add class Javadoc to LoggingMetricExporter

### DIFF
--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
@@ -16,6 +16,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/** A Metric Exporter that logs every metric at INFO level using java.util.logging. */
 public final class LoggingMetricExporter implements MetricExporter {
   private static final Logger logger = Logger.getLogger(LoggingMetricExporter.class.getName());
 


### PR DESCRIPTION
<!-- No issue: minor docs/parity fix, issue not required -->

## Description

- Adds a class-level Javadoc to `LoggingMetricExporter`, which was the only one of the three sibling logging exporters missing one.
- Matches the existing pattern in `LoggingSpanExporter` and `SystemOutLogRecordExporter`.
- The wording reflects the actual `export()` behavior: every metric is logged at INFO level via `java.util.logging`.

## Testing done

- `./gradlew :exporters:logging:check` — 15 tests passed.
- Javadoc-only change with no behavior change, so no new tests were added.
- Signature unchanged, so no apidiff update; not user-visible, so no CHANGELOG entry.