### PR TITLE
Fix stale api-stability.md reference in knowledge README

### DIFF
--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -23,6 +23,6 @@ is the signal.
 ## Conventions
 
 - File names are kebab-cased and topic-oriented. Most follow a `<domain>-<focus>.md` pattern
-  (e.g. `api-stability.md`, `testing-patterns.md`).
+  (e.g. `api-design.md`, `testing-patterns.md`).
 - Sections within each document are ordered alphabetically, with the exception of any
   introductory content placed directly under the document title.


### PR DESCRIPTION
<!-- No issue: docs incomplete-fix, PR-only — no open issue on this topic. -->

## Description

- `docs/knowledge/README.md` line 26 cites a deleted file `api-stability.md` as the filename-pattern example.
- PR #8318 (commit 3f3780ca4) merged `api-stability.md` into `api-design.md` and updated the topics table link (line 18) but missed this prose example in the same file — an incomplete fix.
- Replaces the single stale token `api-stability.md` with `api-design.md`; `testing-patterns.md` still exists and is left unchanged.
- Restores consistency within the file: the table and the prose example now both point to `api-design.md`.
- Related: open-telemetry/opentelemetry-java#8318

## Testing done

- Docs-only change; no behavior change, so build/test verification is exempt (Gradle skipped per docs-only policy).
- Verified zero residual references: `grep -rn "api-stability" docs/` returns no matches.
- Confirmed `docs/knowledge/api-design.md` exists.
- No public API change (no apidiff) and not user-facing (contributor docs), so no CHANGELOG entry.
