### PR TITLE
Fix OtlpGrpcProfileExporter toString class name

### DIFF
--- a/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/OtlpGrpcProfileExporter.java
+++ b/exporters/otlp/profiles/src/main/java/io/opentelemetry/exporter/otlp/profiles/OtlpGrpcProfileExporter.java
@@ -89,7 +89,7 @@ public class OtlpGrpcProfileExporter implements ProfileExporter {
 
   @Override
   public String toString() {
-    StringJoiner joiner = new StringJoiner(", ", "OtlpGrpcProfilesExporter{", "}");
+    StringJoiner joiner = new StringJoiner(", ", "OtlpGrpcProfileExporter{", "}");
     joiner.add(builder.toString(false));
     return joiner.toString();
   }

--- a/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/OtlpGrpcProfileExporterTest.java
+++ b/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/OtlpGrpcProfileExporterTest.java
@@ -40,6 +40,13 @@ class OtlpGrpcProfileExporterTest
   }
 
   @Test
+  void stringRepresentationClassName() {
+    try (OtlpGrpcProfileExporter exporter = OtlpGrpcProfileExporter.builder().build()) {
+      assertThat(exporter.toString()).startsWith("OtlpGrpcProfileExporter{");
+    }
+  }
+
+  @Test
   @Override // whilst profile signal type is in development it uses a different error message
   @SuppressLogger(GrpcExporter.class)
   protected void testExport_Unimplemented() {


### PR DESCRIPTION
<!-- No issue: minor bug fix, issue not required -->

## Description

- `OtlpGrpcProfileExporter.toString()` used the prefix `OtlpGrpcProfilesExporter{` (plural "Profiles"), which does not match the class name. Changed the `StringJoiner` literal to `OtlpGrpcProfileExporter{`.
- The sibling gRPC exporters (`OtlpGrpcSpanExporter`, `OtlpGrpcMetricExporter`, `OtlpGrpcLogRecordExporter`) already use their own class name as the prefix; this restores that consistency.
- The shared `AbstractGrpcTelemetryExporterTest.stringRepresentation()` regex `OtlpGrpc[a-zA-Z]*Exporter\{` matches both singular and plural, so it never caught this; hence a profiles-specific assertion.
- Signature unchanged (no apidiff); alpha-module diagnostic string, not user-facing (no CHANGELOG).

## Testing done

- Added `OtlpGrpcProfileExporterTest#stringRepresentationClassName` asserting `toString()` starts with `OtlpGrpcProfileExporter{`. Fails before the fix (prefix was `OtlpGrpcProfiles...`), passes after.
- `./gradlew :exporters:otlp:profiles:check` passed, including jApiCmp.
