### PR TITLE
Increase HTTP connectTimeout test threshold to match gRPC

### DIFF
--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -501,8 +501,9 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
               });
 
       // Assert that the export request fails well before the default connect timeout of 10s
+      // Note: Connection failures to non-routable IPs can take 1-5 seconds depending on OS/network
       assertThat(System.currentTimeMillis() - startTimeMillis)
-          .isLessThan(TimeUnit.SECONDS.toMillis(1));
+          .isLessThan(TimeUnit.SECONDS.toMillis(6));
     }
   }
 


### PR DESCRIPTION
<!-- No issue closed: flaky-test hardening; see #7827 for context. Human updates `Fixes #` if applicable. -->

## Description

- `AbstractHttpTelemetryExporterTest.connectTimeout()` asserts the failed export returns in `<1s`. That is flaky: connection failures to a non-routable IP take 1-5s depending on OS/network.
- The sibling gRPC base `AbstractGrpcTelemetryExporterTest` was already relaxed `<1s`→`<6s` in PR #7840, but the HTTP base was missed — an incomplete fix.
- This mirrors that change with the same comment. Intent is unchanged — the export must still fail well before the default 10s connect timeout.
- Related: PR #7840 (commit 92d23b2b2), issue #7827.

## Testing done

- No new test — this is a test-only change to the shared abstract base; the assertion itself is the test.
- `./gradlew :exporters:otlp:testing-internal:check` passed (module has no own tests).
- `./gradlew :exporters:otlp:all:testOkHttpVersionLATEST :exporters:otlp:all:testJdkHttpSender` passed; all six `connectTimeout()` cases (span/metric/log × OkHttp/JdkSender) green.
- No public API change (internal test package); no CHANGELOG, no apidiff.
