### PR TITLE
Fix PooledHashMap dropping live entries when an entry is removed during forEach

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMap.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMap.java
@@ -222,12 +222,14 @@ public final class PooledHashMap<K, V> implements Map<K, V> {
     size = 0;
   }
 
+  // Walks each bucket back-to-front so the action can remove the entry it's currently on (as metric
+  // collection does to drop stale series) without the next entry being skipped.
   @Override
   public void forEach(BiConsumer<? super K, ? super V> action) {
     for (int j = 0; j < table.length; j++) {
       ArrayList<Entry<K, V>> bucket = table[j];
       if (bucket != null) {
-        for (int i = 0; i < bucket.size(); i++) {
+        for (int i = bucket.size() - 1; i >= 0; i--) {
           Entry<K, V> entry = bucket.get(i);
           action.accept(entry.key, entry.value);
         }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
@@ -421,7 +421,8 @@ class AsynchronousMetricStorageTest {
   void collect_CumulativeRetainsLiveSeriesWhenStaleSeriesAreRemoved(MemoryMode memoryMode) {
     setup(memoryMode);
 
-    // Enough series to share buckets, but under the cardinality limit so there's no overflow series.
+    // Enough series to share buckets, but under the cardinality limit so there's no overflow
+    // series.
     int seriesCount = 20;
 
     // First collection reports everything.

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorageTest.java
@@ -39,6 +39,9 @@ import io.opentelemetry.sdk.testing.time.TestClock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -411,6 +414,41 @@ class AsynchronousMetricStorageTest {
                                 .hasStartEpochNanos(collectTime2)
                                 .hasAttributes(attrB)
                                 .hasValue(7)));
+  }
+
+  @ParameterizedTest
+  @EnumSource(MemoryMode.class)
+  void collect_CumulativeRetainsLiveSeriesWhenStaleSeriesAreRemoved(MemoryMode memoryMode) {
+    setup(memoryMode);
+
+    // Enough series to share buckets, but under the cardinality limit so there's no overflow series.
+    int seriesCount = 20;
+
+    // First collection reports everything.
+    testClock.advance(Duration.ofSeconds(10));
+    for (int i = 0; i < seriesCount; i++) {
+      longCounterStorage.record(Attributes.builder().put("key", "v" + i).build(), 1);
+    }
+    longCounterStorage.collect(resource, scope, testClock.now());
+    registeredReader.setLastCollectEpochNanos(testClock.now());
+
+    // Next time only the even series report; the odd ones go stale and get removed while iterating.
+    // None of the live series should be skipped.
+    testClock.advance(Duration.ofSeconds(10));
+    Set<Attributes> expected = new LinkedHashSet<>();
+    for (int i = 0; i < seriesCount; i += 2) {
+      Attributes attributes = Attributes.builder().put("key", "v" + i).build();
+      longCounterStorage.record(attributes, 2);
+      expected.add(attributes);
+    }
+
+    MetricData metricData = longCounterStorage.collect(resource, scope, testClock.now());
+    Set<Attributes> collected =
+        metricData.getLongSumData().getPoints().stream()
+            .map(PointData::getAttributes)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+    assertThat(collected).isEqualTo(expected);
   }
 
   @ParameterizedTest

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMapTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMapTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,12 +77,15 @@ class PooledHashMapTest {
 
   @Test
   void forEachAllowsRemovalOfCurrentEntry() {
-    // 1 and 17 land in the same bucket, like collection removing a stale series mid-iteration.
-    PooledHashMap<Integer, Integer> collidingMap = new PooledHashMap<>();
-    collidingMap.put(1, 1);
-    collidingMap.put(17, 17);
+    // Keys with the same hashcode always share a bucket (independent of capacity), mirroring
+    // collection removing a stale series while iterating the others.
+    PooledHashMap<SameBucketKey, Integer> collidingMap = new PooledHashMap<>();
+    SameBucketKey first = new SameBucketKey("first");
+    SameBucketKey second = new SameBucketKey("second");
+    collidingMap.put(first, 1);
+    collidingMap.put(second, 2);
 
-    Map<Integer, Integer> visited = new HashMap<>();
+    Map<SameBucketKey, Integer> visited = new HashMap<>();
     collidingMap.forEach(
         (key, value) -> {
           visited.put(key, value);
@@ -90,7 +94,26 @@ class PooledHashMapTest {
           }
         });
 
-    assertThat(visited).containsOnlyKeys(1, 17).containsValues(1, 17);
+    assertThat(visited).containsOnlyKeys(first, second).containsValues(1, 2);
     assertThat(collidingMap.size()).isEqualTo(1);
+  }
+
+  /** Key whose hashcode is constant, so all instances fall in the same bucket. */
+  private static final class SameBucketKey {
+    private final String name;
+
+    SameBucketKey(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      return o instanceof SameBucketKey && name.equals(((SameBucketKey) o).name);
+    }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMapTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/state/PooledHashMapTest.java
@@ -73,4 +73,24 @@ class PooledHashMapTest {
 
     assertThat(actualMap).containsOnlyKeys("One", "Two").containsValues(1, 2);
   }
+
+  @Test
+  void forEachAllowsRemovalOfCurrentEntry() {
+    // 1 and 17 land in the same bucket, like collection removing a stale series mid-iteration.
+    PooledHashMap<Integer, Integer> collidingMap = new PooledHashMap<>();
+    collidingMap.put(1, 1);
+    collidingMap.put(17, 17);
+
+    Map<Integer, Integer> visited = new HashMap<>();
+    collidingMap.forEach(
+        (key, value) -> {
+          visited.put(key, value);
+          if (visited.size() == 1) {
+            collidingMap.remove(key); // drop the first one we see
+          }
+        });
+
+    assertThat(visited).containsOnlyKeys(1, 17).containsValues(1, 17);
+    assertThat(collidingMap.size()).isEqualTo(1);
+  }
 }


### PR DESCRIPTION
Noticed `PooledHashMap.forEach` can skip an entry if the callback removes the one it's currently on. It walks each bucket by index, so `remove()` shifts the next entry into the current slot and `i++` jumps over it

This bites `AsynchronousMetricStorage` in REUSABLE_DATA mode: during collection it removes stale series while iterating, so a live series sharing a bucket with a stale one can get dropped from that cycle. For cumulative async that shows up as a gap then a jump in the output. (IMMUTABLE_DATA uses `ConcurrentHashMap` and was fine. The code comment even says the map was picked to allow removal during iteration, it just wasn't holding up)

Fix: iterate each bucket back-to-front so removing the current entry only shifts already-visited ones. Added tests at the map level (collision plus remove-while-iterating) and the storage level (live series survive when stale ones drop)