### PR TITLE
Fix Javadoc and comment in OSGi integration tests

### DIFF
--- a/integration-tests/osgi/src/testAutoconfigureDeclarativeConfig/java/io/opentelemetry/integrationtest/osgi/AutoconfigureDeclarativeConfigTest.java
+++ b/integration-tests/osgi/src/testAutoconfigureDeclarativeConfig/java/io/opentelemetry/integrationtest/osgi/AutoconfigureDeclarativeConfigTest.java
@@ -75,8 +75,8 @@ public class AutoconfigureDeclarativeConfigTest {
     Path configFile = tempDir.resolve("otel-config.yaml");
     Files.write(configFile, yaml.getBytes(StandardCharsets.UTF_8));
 
-    // System.setProperty is required: addPropertiesSupplier because property suppliers are not
-    // resolved until after otel.config.file check
+    // System.setProperty (not addPropertiesSupplier) is required because property suppliers are
+    // not resolved until after the otel.config.file check.
     System.setProperty("otel.config.file", configFile.toString());
     AutoConfiguredOpenTelemetrySdk autoConfigured;
     try {

--- a/integration-tests/osgi/src/testSdk/java/io/opentelemetry/integrationtest/osgi/OpenTelemetryOsgiTest.java
+++ b/integration-tests/osgi/src/testSdk/java/io/opentelemetry/integrationtest/osgi/OpenTelemetryOsgiTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.test.junit5.context.BundleContextExtension;
 
+/** Verifies the SDK (traces, metrics, logs) and Context API work in OSGi. */
 @ExtendWith(BundleContextExtension.class)
 public class OpenTelemetryOsgiTest {
 


### PR DESCRIPTION
<!-- No issue: internal test docs cleanup, issue not required -->

## Description

- Add a class-level Javadoc to `OpenTelemetryOsgiTest`, matching the five sibling OSGi suite classes that all carry a `/** Verifies ... in OSGi. */` summary. The wording reflects what the class exercises: the SDK (traces, metrics, logs) and the Context API.
- Fix the garbled comment in `AutoconfigureDeclarativeConfigTest`: the code uses `System.setProperty`, not `addPropertiesSupplier`, so the comment now explains that `System.setProperty` is required because property suppliers are not resolved until after the `otel.config.file` check.
- Comment/Javadoc only — no behavior, signature, or public API change.
- Related: module introduced in #8417.

## Testing done

- Docs-only (Javadoc/comment), test-exempt: no test added.
- `./gradlew :integration-tests:osgi:spotlessApply` then `:spotlessCheck` passed; `compileTestSdkJava` and `compileTestAutoconfigureDeclarativeConfigJava` compiled.
- OSGi Felix suites are heavyweight integration tests, not run for a comment/Javadoc-only change.
- Test module: no apidiff; no user-facing change, so no CHANGELOG entry.

