### PR TITLE
Fix OpenTelemetrySdkBuilderUtil.setConfigProvider Javadoc copy-paste

### DIFF
--- a/sdk/all/src/main/java/io/opentelemetry/sdk/internal/OpenTelemetrySdkBuilderUtil.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/internal/OpenTelemetrySdkBuilderUtil.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.internal;
 
 import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -22,7 +21,7 @@ public final class OpenTelemetrySdkBuilderUtil {
 
   private OpenTelemetrySdkBuilderUtil() {}
 
-  /** Reflectively set the {@link ScopeConfigurator} to the {@link SdkTracerProvider}. */
+  /** Reflectively set the {@link SdkConfigProvider} on the {@link OpenTelemetrySdkBuilder}. */
   public static OpenTelemetrySdkBuilder setConfigProvider(
       OpenTelemetrySdkBuilder builder, SdkConfigProvider configProvider) {
     try {


### PR DESCRIPTION
<!-- No issue: internal-package Javadoc fix, issue not required -->

## Description

- `OpenTelemetrySdkBuilderUtil.setConfigProvider` carried a copy-pasted Javadoc reading "Reflectively set the `{@link ScopeConfigurator}` to the `{@link SdkTracerProvider}`", but the method sets a `SdkConfigProvider` on the `OpenTelemetrySdkBuilder`.
- `ScopeConfigurator` was never imported here, so the `{@link}` was a dead reference, and the `SdkTracerProvider` import existed only to resolve that broken link.
- Corrected the Javadoc to reference `SdkConfigProvider` and `OpenTelemetrySdkBuilder` (both already imported) and removed the now-unused `SdkTracerProvider` import.
- The sibling `Sdk{Tracer,Meter,Logger}ProviderUtil` classes carry the same sentence correctly because they import and operate on `ScopeConfigurator`; this `internal` util just inherited the wording.

## Testing done

- Docs-only (internal package), test-exempt: no test added; behavior, signature, and public API are unchanged.
- `./gradlew :sdk:all:check` passed (jApiCmp, checkstyle, ErrorProne/NullAway, tests).
- Internal package (japicmp untracked) → no `docs/apidiffs` update; not user-facing → no `CHANGELOG.md` entry.

