### PR TITLE
Fix Javadoc errors in JFR profiles shim

### DIFF
--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExecutionSampleEventConverter.java
@@ -16,9 +16,9 @@ import java.util.concurrent.TimeUnit;
 import jdk.jfr.consumer.RecordedEvent;
 
 /**
- * Converter for batching a steam of recorded jfr.ExecutionSample events into a format suitable for
+ * Converter for batching a stream of recorded jfr.ExecutionSample events into a format suitable for
  * consumption in a ProfileData i.e. for OTLP export. Similar converters, or a more generalized
- * converter, are need for each JFR event type.
+ * converter, are needed for each JFR event type.
  */
 public class JfrExecutionSampleEventConverter {
 

--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrLocationDataCompositor.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrLocationDataCompositor.java
@@ -32,7 +32,7 @@ public class JfrLocationDataCompositor {
    * Returns a new JFR Compositor, using the offered Dictionary for storage.
    *
    * @param profilesDictionaryCompositor the underlying dictionary state store.
-   * @return a new ProfilesDictionaryCompositor.
+   * @return a new JfrLocationDataCompositor.
    */
   public static JfrLocationDataCompositor create(
       ProfilesDictionaryCompositor profilesDictionaryCompositor) {


### PR DESCRIPTION
<!-- No issue: minor Javadoc fix, issue not required -->

## Description

- Fix the `@return` tag on `JfrLocationDataCompositor.create(...)`, which said `ProfilesDictionaryCompositor` but the method returns `JfrLocationDataCompositor`.
- Fix two typos in the `JfrExecutionSampleEventConverter` class Javadoc: "steam" -> "stream", "are need" -> "are needed".
- Javadoc-only; no behavior, signature, or public API change.
- Open PR #8349 also edits these files but not these Javadoc lines, so there is no collision; happy to fold into #8349 if a maintainer prefers.

## Testing done

- Docs-only, test-exempt; `./gradlew :opentelemetry-jfr-profiles-shim:check` passed (compile, spotlessCheck, ErrorProne/NullAway).
- Module is unpublished, so no japicmp/apidiff and no CHANGELOG entry.
