### PR TITLE
Reduce LongSumAggregator.doRecordLong visibility to protected

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java
@@ -130,7 +130,7 @@ public final class LongSumAggregator
     }
 
     @Override
-    public void doRecordLong(long value) {
+    protected void doRecordLong(long value) {
       current.add(value);
     }
   }


### PR DESCRIPTION
Fixes #8506

## Description

- Narrow `LongSumAggregator.Handle.doRecordLong(long)` from `public` to `protected`.
- The base hook `AggregatorHandle.doRecordLong(long)` is `protected`, and all sibling overrides in the `internal.aggregator` package are `protected` (DoubleSum, DoubleLastValue, LongLastValue, DoubleExplicitBucketHistogram, DoubleBase2ExponentialHistogram, DropAggregator). `LongSumAggregator` was the lone `public` outlier.
- The single-arg `doRecordLong(value)` is only called by `AggregatorHandle.recordLong` in the same class; no external caller relies on `public`.
- Completes the visibility cleanup from #3557, which missed this method.
- `internal.aggregator` is an internal package, so this is not a public API change: no apidiff diff, no CHANGELOG entry.

## Testing done

- Visibility-only, no behavior change, test-exempt; no new test added.
- `./gradlew :sdk:metrics:check` — 694 tests passed (jApiCmp clean, no apidiff change).
