### PR TITLE
Strengthen graal incubating-not-found test to detect incubator API on classpath

### DIFF
--- a/integration-tests/graal/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingNotFoundApiTests.java
+++ b/integration-tests/graal/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingNotFoundApiTests.java
@@ -7,20 +7,24 @@ package io.opentelemetry.integrationtests.graal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerProvider;
-import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import org.junit.jupiter.api.Test;
 
 class IncubatingNotFoundApiTests {
   @Test
   void incubatingApiIsNotFoundViaReflection() {
-    assertThat(LoggerProvider.noop().get("test")).isInstanceOf(Logger.class);
-    assertThat(TracerProvider.noop().get("test")).isInstanceOf(Tracer.class);
-    assertThat(MeterProvider.noop().get("test").counterBuilder("test"))
-        .isInstanceOf(LongCounterBuilder.class);
+    // The graal module deliberately excludes :api:incubator, so the noop instances must come from
+    // the stable api packages, not io.opentelemetry.api.incubator.*. An isInstanceOf check against
+    // the stable types cannot detect a regression here because the incubator Extended* types
+    // subtype the stable types; assert on the runtime class package instead, since the Extended*
+    // types are not on this module's classpath to reference directly.
+    assertThat(LoggerProvider.noop().get("test").getClass().getName())
+        .doesNotStartWith("io.opentelemetry.api.incubator.");
+    assertThat(TracerProvider.noop().get("test").getClass().getName())
+        .doesNotStartWith("io.opentelemetry.api.incubator.");
+    assertThat(MeterProvider.noop().get("test").counterBuilder("test").getClass().getName())
+        .doesNotStartWith("io.opentelemetry.api.incubator.");
   }
 }


### PR DESCRIPTION
Fixes #8509

## Description

- `incubatingApiIsNotFoundViaReflection()` asserted `isInstanceOf(Logger/Tracer/LongCounterBuilder.class)` on the noop instances. The incubator `Extended*` noops subtype those stable types, so the assertions hold even when an incubator noop is returned — the test never checks what its name claims.
- Assert instead that the noop runtime class is not under `io.opentelemetry.api.incubator.*`, which fails if `:api:incubator` is wrongly added to this module (the regression it guards). A package-name check is used because the module does not depend on `:api:incubator` and cannot reference the `Extended*` types directly.
- Mirrors the sibling `graal-incubating` `IncubatingApiTests.incubatingApiIsLoadedViaReflection()`, which asserts the `Extended*` subtypes are present. The file was added by open-telemetry/opentelemetry-java#6617 as the no-CCE safety net.

## Testing done

- The test has no `@EnabledInNativeImage`, so it runs on the regular JVM `test` task, not native-CI-only.
- `./gradlew :integration-tests:graal:check` — passed (test + spotlessCheck + checkstyle).
- No CHANGELOG/apidiff: test-only change in a non-published module, no behavior or API change.

