### PR TITLE
Fix typos in sdk-common Javadoc

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/InternalTelemetryVersion.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/InternalTelemetryVersion.java
@@ -12,7 +12,7 @@ package io.opentelemetry.sdk.common;
  */
 public enum InternalTelemetryVersion {
   /**
-   * Record self-monitoring metrics defined in the SDK prior the standardization in semantic
+   * Record self-monitoring metrics defined in the SDK prior to the standardization in semantic
    * conventions.
    */
   LEGACY,

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AndroidFriendlyRandomHolder.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AndroidFriendlyRandomHolder.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 
 /**
  * {@link RandomSupplier} instance that doesn't use {@link java.util.concurrent.ThreadLocalRandom},
- * which is broken on most versions of Android (it uses the same seed everytime it starts up).
+ * which is broken on most versions of Android (it uses the same seed every time it starts up).
  */
 enum AndroidFriendlyRandomHolder implements Supplier<Random> {
   INSTANCE;

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/DefaultExceptionAttributeResolver.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/DefaultExceptionAttributeResolver.java
@@ -17,7 +17,7 @@ import java.io.StringWriter;
  * guarantees are made.
  *
  * @see ExceptionAttributeResolver#getDefault()
- * @see ExceptionAttributeResolver#getDefault(boolean) ()
+ * @see ExceptionAttributeResolver#getDefault(boolean)
  */
 final class DefaultExceptionAttributeResolver implements ExceptionAttributeResolver {
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/RandomSupplier.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/RandomSupplier.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 /**
- * Provides random number generater constructor utilities.
+ * Provides random number generator constructor utilities.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/resources/Resource.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * {@link Resource} represents a resource, which capture identifying information about the entities
+ * {@link Resource} represents a resource, which captures identifying information about the entities
  * for which signals (stats or traces) are reported.
  */
 @Immutable


### PR DESCRIPTION
<!-- No issue: trivial Javadoc typo fix, issue not required -->

## Description

- Fix five Javadoc typos in the `sdk-common` module; text-only, no behavior or signature change.
- `InternalTelemetryVersion`: "prior the standardization" -> "prior to the standardization".
- `Resource`: "which capture identifying information" -> "which captures" (singular subject).
- `RandomSupplier`: "random number generater" -> "generator".
- `DefaultExceptionAttributeResolver`: drop stray `()` after the `@see ...getDefault(boolean)` reference.
- `AndroidFriendlyRandomHolder`: "everytime" -> "every time".

## Testing done

- Docs-only, test-exempt: no test added; `./gradlew :sdk:common:check` passed (compile, spotless, ErrorProne/NullAway, jApiCmp).
- No signature change, so jApiCmp produced no apidiff; not user-facing, so no CHANGELOG entry.

