### PR TITLE
Fix stale parameter name in JcTools.drain Javadoc

### DIFF
--- a/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
+++ b/sdk/trace-shaded-deps/src/main/java/io/opentelemetry/sdk/trace/internal/JcTools.java
@@ -37,7 +37,7 @@ public final class JcTools {
    * Remove up to <i>limit</i> elements from the {@link Queue} and hand to consume.
    *
    * @throws IllegalArgumentException consumer is {@code null}
-   * @throws IllegalArgumentException if maxExportBatchSize is negative
+   * @throws IllegalArgumentException if limit is negative
    */
   @SuppressWarnings("unchecked")
   public static <T> int drain(Queue<T> queue, int limit, Consumer<T> consumer) {


### PR DESCRIPTION
<!-- No issue: trivial internal Javadoc fix, issue not required (mirrors #8479). -->

## Description

- `JcTools.drain(Queue, int, Consumer)` documents `@throws IllegalArgumentException if maxExportBatchSize is negative`, but no `maxExportBatchSize` parameter exists; the argument is `limit`.
- The name is a leftover from the private `drainNonJcQueue(..., int maxExportBatchSize, ...)` helper removed in #7691. The thrown behavior is unchanged: the delegate `MessagePassingQueue.drain(Consumer, int)` throws `IllegalArgumentException` for a negative limit.
- Javadoc-only change in the internal, non-published `:sdk:trace-shaded-deps` module; no signature, behavior, or public API change.

## Testing done

- Docs-only, test-exempt: no test added; `./gradlew :sdk:trace-shaded-deps:check` passed.

