### PR TITLE
Fix profiles data model attribute count parameter name and timestamp doc unit

### DIFF
--- a/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/data/ProfileData.java
+++ b/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/data/ProfileData.java
@@ -39,7 +39,7 @@ public interface ProfileData {
       ValueTypeData periodType,
       long period,
       String profileId,
-      int droppedAttributesCount,
+      int totalAttributeCount,
       String originalPayloadFormat,
       ByteBuffer originalPayload,
       List<Integer> attributeIndices) {
@@ -54,7 +54,7 @@ public interface ProfileData {
         periodType,
         period,
         profileId,
-        droppedAttributesCount,
+        totalAttributeCount,
         originalPayloadFormat,
         originalPayload,
         attributeIndices);

--- a/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/data/SampleData.java
+++ b/sdk/profiles/src/main/java/io/opentelemetry/sdk/profiles/data/SampleData.java
@@ -55,8 +55,8 @@ public interface SampleData {
   List<Long> getValues();
 
   /**
-   * Timestamps associated with Sample represented in ms. These timestamps are expected to fall
-   * within the Profile's time range.
+   * Timestamps associated with Sample represented as nanoseconds past the epoch. These timestamps
+   * are expected to fall within the Profile's time range.
    */
   List<Long> getTimestamps();
 }


### PR DESCRIPTION
<!-- No issue: minor non-behavioral doc/naming correctness, issue not required -->

## Description

- `ProfileData.create(...)`'s 11th parameter is named `droppedAttributesCount`, but the value is exposed via `getTotalAttributeCount()` and `ProfileMarshaler` derives dropped from it (`getTotalAttributeCount() - getAttributeIndices().size()`). It holds the total, not the dropped count, so the name misleads callers. Rename it to `totalAttributeCount`.
- This matches the Span family, where marshalers compute `droppedAttributesCount = getTotalAttributeCount() - getAttributes().size()` (e.g. `SpanMarshaler`, `LogStatelessMarshaler`).
- `SampleData.getTimestamps()` javadoc said "represented in ms", but `SampleMarshaler` serializes to `timestamps_unix_nano` and the timestamps must fall within the profile's nanosecond range (`ProfileData.getTimeNanos()`). Fix the unit to nanoseconds.

## Testing done

- Docs/naming only — no behavior, signature, or wire-output change; test-exempt. Parameter names are not part of the binary signature, so japicmp shows no diff and no `docs/apidiffs` update is needed. Not user-facing, so no CHANGELOG entry.
- `./gradlew :sdk:profiles:check` passed (test + spotlessCheck + ErrorProne/NullAway + jApiCmp).

