### PR TITLE
Fix gradle deprecation warnings

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -79,7 +79,7 @@ tasks {
     options.release.set(11)
   }
 
-  val testJavaVersion: String? by project
+  val testJavaVersion = project.findProperty("testJavaVersion") as String?
   test {
     enabled = testJavaVersion != "8"
     dependsOn(writeArtifactsAndJars)
@@ -89,7 +89,7 @@ tasks {
 
 // https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html
 
-val sourcesPath by configurations.creating {
+val sourcesPath = configurations.create("sourcesPath") {
   isCanBeResolved = true
   isCanBeConsumed = false
   extendsFrom(configurations.implementation.get())
@@ -100,7 +100,7 @@ val sourcesPath by configurations.creating {
   }
 }
 
-val coverageDataPath by configurations.creating {
+val coverageDataPath = configurations.create("coverageDataPath") {
   isCanBeResolved = true
   isCanBeConsumed = false
   extendsFrom(configurations.implementation.get())

--- a/buildSrc/src/main/kotlin/otel.bom-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.bom-conventions.gradle.kts
@@ -17,7 +17,7 @@ rootProject.subprojects.forEach { subproject ->
 }
 val otelBom = extensions.create<OtelBomExtension>("otelBom")
 
-val generateBuildSubstitutions by tasks.registering {
+val generateBuildSubstitutions = tasks.register("generateBuildSubstitutions") {
   group = "publishing"
   description = "Generate a code snippet that can be copy-pasted for use in composite builds."
 }
@@ -38,7 +38,7 @@ afterEvaluate {
     .filter(otelBom.projectFilter.get()::test)
     .filter { it.plugins.hasPlugin("maven-publish") }
 
-  generateBuildSubstitutions {
+  generateBuildSubstitutions.configure {
     val outputFile = File(layout.buildDirectory.asFile.get(), "substitutions.gradle.kts")
     outputs.file(outputFile)
     val substitutionSnippet = bomProjects.joinToString(

--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   errorprone(project(":custom-checks"))
 }
 
-val disableErrorProne = properties["disableErrorProne"]?.toString()?.toBoolean() ?: false
+val disableErrorProne = findProperty("disableErrorProne")?.toString()?.toBoolean() ?: false
 
 tasks {
   withType<JavaCompile>().configureEach {

--- a/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts
@@ -16,7 +16,7 @@ tasks.named("jacocoTestReport") {
 }
 
 configurations {
-  val implementation by getting
+  val implementation = getByName("implementation")
 
   create("transitiveSourceElements") {
     isCanBeResolved = false

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -106,16 +106,16 @@ fun getCurrentClassPath(): List<File> {
 if (!project.hasProperty("otel.release") && !project.name.startsWith("bom")) {
   afterEvaluate {
     tasks {
-      val jApiCmp by registering(JapicmpTask::class) {
+      val jApiCmp = register<JapicmpTask>("jApiCmp") {
         // Depends on jar task for all published modules. See notes below.
         getAllPublishedModules().forEach {
           dependsOn(it.tasks.getByName("jar"))
         }
 
         // the japicmp "new" version is either the user-specified one, or the locally built jar.
-        val apiNewVersion: String? by project
+        val apiNewVersion = project.findProperty("apiNewVersion") as String?
         // the japicmp "old" version is either the user-specified one, or the latest release.
-        val apiBaseVersion: String? by project
+        val apiBaseVersion = project.findProperty("apiBaseVersion") as String?
         val baselineVersion = apiBaseVersion ?: latestReleasedVersion
 
         // Setup new and old classpath, new and old archives.

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -265,12 +265,12 @@ configurations.configureEach {
   }
 }
 
-val dependencyManagement by configurations.creating {
+val dependencyManagement = configurations.create("dependencyManagement") {
   isCanBeConsumed = false
   isCanBeResolved = false
 }
 
-val mockitoAgent by configurations.creating {
+val mockitoAgent = configurations.create("mockitoAgent") {
   extendsFrom(dependencyManagement)
 }
 

--- a/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
@@ -23,32 +23,32 @@ jmh {
   // Could not expand ZIP 'byte-buddy-agent-1.9.7.jar'.
   includeTests.set(false)
   profilers.add("gc")
-  val jmhIncludeSingleClass: String? by project
+  val jmhIncludeSingleClass = project.findProperty("jmhIncludeSingleClass") as String?
   if (jmhIncludeSingleClass != null) {
-    includes.add(jmhIncludeSingleClass as String)
+    includes.add(jmhIncludeSingleClass)
   }
 
-  val jmhFork: String? by project
+  val jmhFork = project.findProperty("jmhFork") as String?
   if (jmhFork != null) {
-    fork.set(jmhFork!!.toInt())
+    fork.set(jmhFork.toInt())
   }
 
-  val jmhIterations: String? by project
+  val jmhIterations = project.findProperty("jmhIterations") as String?
   if (jmhIterations != null) {
-    iterations.set(jmhIterations!!.toInt())
+    iterations.set(jmhIterations.toInt())
   }
 
-  val jmhTime: String? by project
+  val jmhTime = project.findProperty("jmhTime") as String?
   if (jmhTime != null) {
     timeOnIteration.set(jmhTime)
   }
 
-  val jmhWarmupIterations: String? by project
+  val jmhWarmupIterations = project.findProperty("jmhWarmupIterations") as String?
   if (jmhWarmupIterations != null) {
-    warmupIterations.set(jmhWarmupIterations!!.toInt())
+    warmupIterations.set(jmhWarmupIterations.toInt())
   }
 
-  val jmhWarmup: String? by project
+  val jmhWarmup = project.findProperty("jmhWarmup") as String?
   if (jmhWarmup != null) {
     warmup.set(jmhWarmup)
   }

--- a/buildSrc/src/main/kotlin/otel.protobuf-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.protobuf-conventions.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 protobuf {
-  val versions: Map<String, String> by project
+  val versions = project.property("versions") as Map<*, *>
   protoc {
     // The artifact spec for the Protobuf Compiler
     artifact = "com.google.protobuf:protoc:${versions["com.google.protobuf"]}"

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -44,7 +44,7 @@ tasks {
   }
 
   // only test on java 21+
-  val testJavaVersion: String? by project
+  val testJavaVersion = project.findProperty("testJavaVersion") as String?
   if (testJavaVersion != null && Integer.valueOf(testJavaVersion) < 21) {
     test {
       enabled = false

--- a/exporters/common/build.gradle.kts
+++ b/exporters/common/build.gradle.kts
@@ -56,7 +56,7 @@ if (javaVersion >= JavaVersion.VERSION_1_9) {
   }
 }
 
-val versions: Map<String, String> by project
+val versions = project.property("versions") as Map<*, *>
 dependencies {
   api(project(":api:all"))
   compileOnly(project(":sdk-extensions:autoconfigure-spi"))
@@ -87,7 +87,7 @@ dependencies {
   testRuntimeOnly("io.grpc:grpc-netty-shaded")
 }
 
-val testJavaVersion: String? by project
+val testJavaVersion = project.findProperty("testJavaVersion") as String?
 
 testing {
   suites {

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
   jmhRuntimeOnly("io.grpc:grpc-netty")
 }
 
-val testJavaVersion: String? by project
+val testJavaVersion = project.findProperty("testJavaVersion") as String?
 
 testing {
   suites {

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -12,7 +12,7 @@ description = "OpenTelemetry Protocol Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.internal.otlp")
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
-val versions: Map<String, String> by project
+val versions = project.property("versions") as Map<*, *>
 dependencies {
   protoSource("io.opentelemetry.proto:opentelemetry-proto:${versions["io.opentelemetry.proto"]}")
 

--- a/exporters/otlp/profiles/build.gradle.kts
+++ b/exporters/otlp/profiles/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 description = "OpenTelemetry - Profiles Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.profiles")
 
-val versions: Map<String, String> by project
+val versions = project.property("versions") as Map<*, *>
 
 dependencies {
   api(project(":sdk:common"))

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -63,7 +63,7 @@ testing {
 }
 
 sourceSets {
-  val module by creating
+  val module = create("module")
   main {
     output.dir(mapOf("builtBy" to "compileModuleJava"), module.java.destinationDirectory)
   }

--- a/integration-tests/osgi/build.gradle.kts
+++ b/integration-tests/osgi/build.gradle.kts
@@ -194,7 +194,7 @@ fun registerOsgiSuite(
     bndrun = resolveTask.flatMap { it.outputBndrun }
     bundles = files(sourceSet.runtimeClasspath, bundleTask.get().archiveFile)
     if (minJavaVersion != null) {
-      val testJavaVersion: String? by project
+      val testJavaVersion = project.findProperty("testJavaVersion") as String?
       enabled = testJavaVersion == null || testJavaVersion!!.toInt() >= minJavaVersion
     }
     // BND reports success when zero tests ran (e.g. if bundles failed to start). Fail explicitly.

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 tasks {
-  val shadowJar by existing(Jar::class) {
+  val shadowJar = named<Jar>("shadowJar") {
     archiveFileName.set("tracecontext-tests.jar")
 
     manifest {

--- a/javadoc-crawler/build.gradle.kts
+++ b/javadoc-crawler/build.gradle.kts
@@ -15,7 +15,7 @@ otelJava.osgiEnabled.set(false)
 otelJava.minJavaVersionSupported.set(JavaVersion.VERSION_17)
 
 tasks {
-  val crawl by registering(JavaExec::class) {
+  val crawl = register<JavaExec>("crawl") {
     dependsOn(classes)
 
     mainClass.set("io.opentelemetry.javadocs.JavaDocsCrawler")

--- a/sdk-extensions/declarative-config/build.gradle.kts
+++ b/sdk-extensions/declarative-config/build.gradle.kts
@@ -65,7 +65,7 @@ val configurationRef = "refs/tags/v$configurationTag" // Replace with commit SHA
 val configurationRepoZip = "https://github.com/open-telemetry/opentelemetry-configuration/archive/$configurationRef.zip"
 val buildDirectory = layout.buildDirectory.asFile.get()
 
-val downloadConfigurationSchema by tasks.registering(Download::class) {
+val downloadConfigurationSchema = tasks.register<Download>("downloadConfigurationSchema") {
   src(configurationRepoZip)
   // The version is encoded in the filename so that a configurationTag change results in a new
   // path that doesn't yet exist, triggering a fresh download. On subsequent builds with the same
@@ -78,7 +78,7 @@ val downloadConfigurationSchema by tasks.registering(Download::class) {
   overwrite(false)
 }
 
-val unzipConfigurationSchema by tasks.registering(Sync::class) {
+val unzipConfigurationSchema = tasks.register<Sync>("unzipConfigurationSchema") {
   // Sync (not Copy) removes stale files from the destination when the source changes, ensuring
   // files deleted or renamed between schema versions don't linger in the build dir.
   dependsOn(downloadConfigurationSchema)
@@ -140,7 +140,7 @@ jsonSchema2Pojo {
 val generateJsonSchema2Pojo = tasks.getByName("generateJsonSchema2Pojo")
 generateJsonSchema2Pojo.dependsOn(unzipConfigurationSchema)
 
-val syncPojoModelsToSrc by tasks.registering(Copy::class) {
+val syncPojoModelsToSrc = tasks.register<Copy>("syncPojoModelsToSrc") {
   dependsOn(generateJsonSchema2Pojo)
   finalizedBy("spotlessApply")
   val modelDir = File(projectDir, "src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model")
@@ -168,7 +168,7 @@ val syncPojoModelsToSrc by tasks.registering(Copy::class) {
 // autoconfigure and without the risk of divergence from manual syncing.
 val generatedResourceConfigDir =
   layout.buildDirectory.dir("generated/sources/resource-configuration/java/main")
-val copyResourceConfiguration by tasks.registering(Copy::class) {
+val copyResourceConfiguration = tasks.register<Copy>("copyResourceConfiguration") {
   from(
     project(":sdk-extensions:autoconfigure").file(
       "src/main/java/io/opentelemetry/sdk/autoconfigure/EnvironmentResource.java"


### PR DESCRIPTION
Fixes these kind of warnings in the build output:

```
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.bom-conventions.gradle.kts:20:41 'fun RegisteringDomainObjectDelegateProviderWithAction<out TaskContainer, Task>.provideDelegate(receiver: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<TaskProvider<Task>>' is deprecated. Use 'val task = tasks.register(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.bom-conventions.gradle.kts:20:41 'fun <T : Any, C : NamedDomainObjectContainer<T>> C.registering(action: T.() -> Unit): RegisteringDomainObjectDelegateProviderWithAction<out C, T>' is deprecated. Use 'val element = register(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.bom-conventions.gradle.kts:20:41 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts:16:25 'val properties: (Mutable)Map<String, out Any?>' is deprecated. Deprecated in Java.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts:19:25 'fun provideDelegate(thisRef: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<CapturedType(out Configuration)>' is deprecated. Use 'val element = getByName(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts:19:25 'val <T : Any, U : NamedDomainObjectCollection<out T>> U.getting: NamedDomainObjectCollectionDelegateProvider<out T>' is deprecated. Use 'val element = getByName(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jacoco-conventions.gradle.kts:19:25 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts:109:22 'fun <U : Task> RegisteringDomainObjectDelegateProviderWithTypeAndAction<out TaskContainer, U>.provideDelegate(receiver: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<TaskProvider<U>>' is deprecated. Use 'val task = tasks.register<Type>(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts:109:22 'fun <T : Any, C : PolymorphicDomainObjectContainer<T>, U : T> C.registering(type: KClass<U>, action: U.() -> Unit): RegisteringDomainObjectDelegateProviderWithTypeAndAction<out C, U>' is deprecated. Use 'val element = register<Type>(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts:109:22 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts:116:39 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts:118:40 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:268:44 'fun provideDelegate(thisRef: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<Configuration>' is deprecated. Use 'val element = create(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:268:44 'fun <T : Any> NamedDomainObjectContainer<T>.creating(configuration: T.() -> Unit): NamedDomainObjectContainerCreatingDelegateProvider<T>' is deprecated. Use 'val element = create(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:268:44 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:273:36 'fun provideDelegate(thisRef: Any?, property: KProperty<*>): ExistingDomainObjectDelegate<Configuration>' is deprecated. Use 'val element = create(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:273:36 'fun <T : Any> NamedDomainObjectContainer<T>.creating(configuration: T.() -> Unit): NamedDomainObjectContainerCreatingDelegateProvider<T>' is deprecated. Use 'val element = create(name) { }' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts:273:36 'fun <T> ExistingDomainObjectDelegate<out T>.getValue(receiver: Any?, property: KProperty<*>): T' is deprecated. Use the named() API instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:26:41 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:31:27 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:36:33 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:41:27 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:46:39 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts:51:29 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
w: file:///Users/jberg/code/opentelemetry-java-1/buildSrc/src/main/kotlin/otel.protobuf-conventions.gradle.kts:10:40 'fun Project.provideDelegate(any: Any?, property: KProperty<*>): PropertyDelegate' is deprecated. Use 'val property = project.property(name)' or 'val property = project.findProperty(name)' instead. See the Gradle 9.6 upgrading guide.
```