### PR TITLE
FIx for BSP benchmark aux counters (exportedSpans/droppedSpans) always reporting zero

### DIFF
--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorCpuBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorCpuBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 /*
  * Run this along with a profiler to measure the CPU usage of BatchSpanProcessor's exporter thread.
@@ -47,7 +48,8 @@ public class BatchSpanProcessorCpuBenchmark {
     private long droppedSpans;
 
     @Setup(Level.Iteration)
-    public final void setup() {
+    public final void setup(BenchmarkParams params) {
+      numThreads = params.getThreads();
       metricReader = InMemoryMetricReader.create();
       MeterProvider meterProvider =
           SdkMeterProvider.builder().registerMetricReader(metricReader).build();
@@ -110,7 +112,6 @@ public class BatchSpanProcessorCpuBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_01Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 1;
     doWork(benchmarkState);
   }
 
@@ -123,7 +124,6 @@ public class BatchSpanProcessorCpuBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_02Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 2;
     doWork(benchmarkState);
   }
 
@@ -136,7 +136,6 @@ public class BatchSpanProcessorCpuBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_05Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 5;
     doWork(benchmarkState);
   }
 
@@ -149,7 +148,6 @@ public class BatchSpanProcessorCpuBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_10Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 10;
     doWork(benchmarkState);
   }
 
@@ -162,7 +160,6 @@ public class BatchSpanProcessorCpuBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_20Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 20;
     doWork(benchmarkState);
   }
 }

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -33,13 +33,16 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     private InMemoryMetricReader metricReader;
     private BatchSpanProcessor processor;
     private Tracer tracer;
+    private double dropRatio;
     private long exportedSpans;
     private long droppedSpans;
     private int numThreads;
+    private int numIterations;
 
     @Setup(Level.Iteration)
     public final void setup(BenchmarkParams params) {
       numThreads = params.getThreads();
+      numIterations = params.getMeasurement().getCount();
       metricReader = InMemoryMetricReader.create();
       MeterProvider meterProvider =
           SdkMeterProvider.builder().registerMetricReader(metricReader).build();
@@ -53,6 +56,7 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     public final void recordMetrics() {
       BatchSpanProcessorMetrics metrics =
           new BatchSpanProcessorMetrics(metricReader.collectAllMetrics(), numThreads);
+      dropRatio = metrics.dropRatio(numIterations);
       exportedSpans = metrics.exportedSpans();
       droppedSpans = metrics.droppedSpans();
     }
@@ -71,6 +75,10 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     @TearDown(Level.Iteration)
     public final void recordMetrics(BenchmarkState benchmarkState) {
       this.benchmarkState = benchmarkState;
+    }
+
+    public double dropRatio() {
+      return benchmarkState.dropRatio;
     }
 
     public long exportedSpans() {

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 public class BatchSpanProcessorDroppedSpansBenchmark {
 
@@ -37,7 +38,8 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     private int numThreads;
 
     @Setup(Level.Iteration)
-    public final void setup() {
+    public final void setup(BenchmarkParams params) {
+      numThreads = params.getThreads();
       metricReader = InMemoryMetricReader.create();
       MeterProvider meterProvider =
           SdkMeterProvider.builder().registerMetricReader(metricReader).build();
@@ -89,7 +91,6 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
   @BenchmarkMode(Mode.Throughput)
   public void export(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 5;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorDroppedSpansBenchmark.java
@@ -32,7 +32,6 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     private InMemoryMetricReader metricReader;
     private BatchSpanProcessor processor;
     private Tracer tracer;
-    private double dropRatio;
     private long exportedSpans;
     private long droppedSpans;
     private int numThreads;
@@ -52,7 +51,6 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
     public final void recordMetrics() {
       BatchSpanProcessorMetrics metrics =
           new BatchSpanProcessorMetrics(metricReader.collectAllMetrics(), numThreads);
-      dropRatio = metrics.dropRatio();
       exportedSpans = metrics.exportedSpans();
       droppedSpans = metrics.droppedSpans();
     }
@@ -64,17 +62,13 @@ public class BatchSpanProcessorDroppedSpansBenchmark {
   }
 
   @State(Scope.Thread)
-  @AuxCounters(AuxCounters.Type.OPERATIONS)
+  @AuxCounters(AuxCounters.Type.EVENTS)
   public static class ThreadState {
     BenchmarkState benchmarkState;
 
     @TearDown(Level.Iteration)
     public final void recordMetrics(BenchmarkState benchmarkState) {
       this.benchmarkState = benchmarkState;
-    }
-
-    public double dropRatio() {
-      return benchmarkState.dropRatio;
     }
 
     public long exportedSpans() {

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMetrics.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMetrics.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
 import java.util.OptionalLong;
+import org.openjdk.jmh.annotations.AuxCounters;
 
 public class BatchSpanProcessorMetrics {
   private final Collection<MetricData> allMetrics;
@@ -19,6 +20,28 @@ public class BatchSpanProcessorMetrics {
   public BatchSpanProcessorMetrics(Collection<MetricData> allMetrics, int numThreads) {
     this.allMetrics = allMetrics;
     this.numThreads = numThreads;
+  }
+
+  /**
+   * Returns the share of dropped spans as a value in {@code [0, 1]}.
+   *
+   * <p>Only meaningful for benchmarks whose {@link AuxCounters} use {@link
+   * AuxCounters.Type#EVENTS}: JMH emits a {@code ScalarResult} with {@code AggregationPolicy.SUM},
+   * which sums the aux counters across the {@code numThreads} thread-local {@code @State} instances
+   * and the {@code numIterations} measurement iterations. The raw {@code dropped / (exported +
+   * dropped)} is therefore inflated by {@code numThreads * numIterations}, and both factors are
+   * divided back out here so the value reported by JMH equals the per-iteration drop ratio.
+   *
+   * <p>For {@link AuxCounters.Type#OPERATIONS} JMH emits a {@code ThroughputResult} (rate per unit
+   * time) aggregated as a mean across iterations, so this method does not apply — the drop rate is
+   * read directly from {@link #droppedSpans()} and the ratio, if needed, is computed from the two
+   * rates.
+   */
+  public double dropRatio(int numIterations) {
+    long exported = getMetric(false);
+    long dropped = getMetric(true);
+    long total = exported + dropped;
+    return total == 0 ? 0.0 : (double) dropped / total / numThreads / numIterations;
   }
 
   public long exportedSpans() {

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMetrics.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMetrics.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.trace.export;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -21,15 +21,6 @@ public class BatchSpanProcessorMetrics {
     this.numThreads = numThreads;
   }
 
-  public double dropRatio() {
-    long exported = getMetric(false);
-    long dropped = getMetric(true);
-    long total = exported + dropped;
-    // Due to peculiarities of JMH reporting we have to divide this by the number of the
-    // concurrent threads running the actual benchmark.
-    return total == 0 ? 0 : (double) dropped / total / numThreads;
-  }
-
   public long exportedSpans() {
     return getMetric(false) / numThreads;
   }
@@ -39,14 +30,17 @@ public class BatchSpanProcessorMetrics {
   }
 
   private long getMetric(boolean dropped) {
-    String labelValue = String.valueOf(dropped);
     OptionalLong value =
         allMetrics.stream()
             .filter(metricData -> metricData.getName().equals("processedSpans"))
             .filter(metricData -> !metricData.isEmpty())
             .map(metricData -> metricData.getLongSumData().getPoints())
             .flatMap(Collection::stream)
-            .filter(point -> labelValue.equals(point.getAttributes().get(stringKey("dropped"))))
+            .filter(
+                point -> {
+                  Boolean attrDropped = point.getAttributes().get(booleanKey("dropped"));
+                  return attrDropped != null && attrDropped == dropped;
+                })
             .mapToLong(LongPointData::getValue)
             .findFirst();
     return value.isPresent() ? value.getAsLong() : 0;

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMultiThreadBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMultiThreadBenchmark.java
@@ -38,16 +38,19 @@ public class BatchSpanProcessorMultiThreadBenchmark {
     private BatchSpanProcessor processor;
     private Tracer tracer;
     private int numThreads = 1;
+    private int numIterations = 1;
 
     @Param({"0"})
     private int delayMs;
 
+    private double dropRatio;
     private long exportedSpans;
     private long droppedSpans;
 
     @Setup(Level.Iteration)
     public final void setup(BenchmarkParams params) {
       numThreads = params.getThreads();
+      numIterations = params.getMeasurement().getCount();
       collector = InMemoryMetricReader.create();
       MeterProvider meterProvider =
           SdkMeterProvider.builder().registerMetricReader(collector).build();
@@ -61,6 +64,7 @@ public class BatchSpanProcessorMultiThreadBenchmark {
     public final void recordMetrics() {
       BatchSpanProcessorMetrics metrics =
           new BatchSpanProcessorMetrics(collector.collectAllMetrics(), numThreads);
+      dropRatio = metrics.dropRatio(numIterations);
       exportedSpans = metrics.exportedSpans();
       droppedSpans = metrics.droppedSpans();
       processor.shutdown().join(10, TimeUnit.SECONDS);
@@ -75,6 +79,10 @@ public class BatchSpanProcessorMultiThreadBenchmark {
     @TearDown(Level.Iteration)
     public final void recordMetrics(BenchmarkState benchmarkState) {
       this.benchmarkState = benchmarkState;
+    }
+
+    public double dropRatio() {
+      return benchmarkState.dropRatio;
     }
 
     public long exportedSpans() {

--- a/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMultiThreadBenchmark.java
+++ b/sdk/trace/src/jmh/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorMultiThreadBenchmark.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 @State(Scope.Benchmark)
 public class BatchSpanProcessorMultiThreadBenchmark {
@@ -45,7 +46,8 @@ public class BatchSpanProcessorMultiThreadBenchmark {
     private long droppedSpans;
 
     @Setup(Level.Iteration)
-    public final void setup() {
+    public final void setup(BenchmarkParams params) {
+      numThreads = params.getThreads();
       collector = InMemoryMetricReader.create();
       MeterProvider meterProvider =
           SdkMeterProvider.builder().registerMetricReader(collector).build();
@@ -66,7 +68,7 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   }
 
   @State(Scope.Thread)
-  @AuxCounters(AuxCounters.Type.OPERATIONS)
+  @AuxCounters(AuxCounters.Type.EVENTS)
   public static class ThreadState {
     BenchmarkState benchmarkState;
 
@@ -93,7 +95,6 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_01Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 1;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }
@@ -107,7 +108,6 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_02Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 2;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }
@@ -121,7 +121,6 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_05Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 5;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }
@@ -135,7 +134,6 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_10Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 10;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }
@@ -149,7 +147,6 @@ public class BatchSpanProcessorMultiThreadBenchmark {
   @OutputTimeUnit(TimeUnit.SECONDS)
   public void export_20Thread(
       BenchmarkState benchmarkState, @SuppressWarnings("unused") ThreadState threadState) {
-    benchmarkState.numThreads = 20;
     benchmarkState.processor.onEnd(
         (ReadableSpan) benchmarkState.tracer.spanBuilder("span").startSpan());
   }


### PR DESCRIPTION
## TLDR
Closes issue #8538 (BatchSpanProcessorDroppedSpansBenchmark, BatchSpanProcessorMultiThreadBenchmark, and BatchSpanProcessorCpuBenchmark were reporting exportedSpans and droppedSpans auxiliary counters as 0)

- Fixed an issue where exportedSpans / droppedSpans metrics were always reported as 0
- Switched `AuxCounters.Type` from `OPERATIONS` to `EVENTS` in `DroppedSpansBenchmark` and `MultiThreadBenchmark` to fix misleading throughput-normalized counters and make drop rates and totals directly interpretable.
- Small refactoring of affected benchmark classes (removed duplicated `numThreads` variable)

## BatchSpanProcessorDroppedSpansBenchmark impact

Running `BatchSpanProcessorDroppedSpansBenchmark` on main produces (measured with
`-PjmhIterations=1 -PjmhTime=5`; the benchmark default is 20s):

```
Benchmark                                    Mode   Score
BatchSpanProcessorDroppedSpansBenchmark.export  thrpt  10 054 842 ops/s
  exportedSpans:  ≈ 0 ops/s   ← always zero, bug
  droppedSpans:   ≈ 0 ops/s   ← always zero, bug
  dropRatio:      n/a          ← does not exist on main
```

With the fix applied (measured with `-PjmhIterations=1 -PjmhTime=5`):

```
Benchmark                                    Mode   Score
BatchSpanProcessorDroppedSpansBenchmark.export  thrpt  13 300 880 ops/s
  exportedSpans:  53 300 735   ← total spans exported in iteration (5s)
  droppedSpans:   13 203 785   ← total spans dropped; drop rate ≈ 19.9%
  dropRatio:      0.199        ← per-iteration drop ratio, directly readable
```

`Type.EVENTS` aux counters report the total event count for the measurement iteration,
not a per-second rate.

## BatchSpanProcessorMultiThreadBenchmark impact

`MultiThreadBenchmark` shares the same `BatchSpanProcessorMetrics` helper, so it carried the
same stringKey bug — all counters reported `≈ 0` on main.

Before fix (all thread variants, measured with `-PjmhIterations=1 -PjmhTime=5`):
```
export_01Thread  thrpt:  6 804 256 ops/s  exportedSpans: ≈ 0 ops/s  droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_02Thread  thrpt:  7 096 311 ops/s  exportedSpans: ≈ 0 ops/s  droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_05Thread  thrpt: 10 041 481 ops/s  exportedSpans: ≈ 0 ops/s  droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_10Thread  thrpt:  8 087 320 ops/s  exportedSpans: ≈ 0 ops/s  droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_20Thread  thrpt: 11 468 451 ops/s  exportedSpans: ≈ 0 ops/s  droppedSpans: ≈ 0 ops/s   ← always zero, bug
```

After fix — `Type.EVENTS` + `BenchmarkParams` (measured with `-PjmhIterations=1 -PjmhTime=5`).
With `Type.EVENTS`, aux counters report absolute totals per iteration rather than a per-second
rate, so `dropRatio = droppedSpans / (exportedSpans + droppedSpans)` is directly readable:
```
export_01Thread  thrpt:  7 368 011 ops/s  exportedSpans: 36 276 736 #  droppedSpans:     565 127 #  drop rate:  1.5%
export_02Thread  thrpt:  7 612 288 ops/s  exportedSpans: 37 061 120 #  droppedSpans:   1 001 304 #  drop rate:  2.6%
export_05Thread  thrpt:  9 911 699 ops/s  exportedSpans: 24 016 895 #  droppedSpans:  25 542 165 #  drop rate: 51.5%
export_10Thread  thrpt: 11 255 927 ops/s  exportedSpans: 49 254 910 #  droppedSpans:   7 024 210 #  drop rate: 12.5%
export_20Thread  thrpt: 12 248 437 ops/s  exportedSpans: 15 362 560 #  droppedSpans:  45 891 840 #  drop rate: 74.9%
```

## BatchSpanProcessorCpuBenchmark impact

`CpuBenchmark` keeps `Type.OPERATIONS` — each operation submits exactly one span and
`LockSupport.parkNanos(100_000)` limits throughput to ~10k spans/sec per thread, so per-second
values are readable integers. The stringKey bug caused all counters to report `≈ 0`:

Before fix (all thread variants):
```
export_01Thread  thrpt:   6 360 ops/s  exportedSpans: ≈ 0 ops/s   droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_02Thread  thrpt:  12 738 ops/s  exportedSpans: ≈ 0 ops/s   droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_05Thread  thrpt:  31 964 ops/s  exportedSpans: ≈ 0 ops/s   droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_10Thread  thrpt:  64 101 ops/s  exportedSpans: ≈ 0 ops/s   droppedSpans: ≈ 0 ops/s   ← always zero, bug
export_20Thread  thrpt: 129 603 ops/s  exportedSpans: ≈ 0 ops/s   droppedSpans: ≈ 0 ops/s   ← always zero, bug
```

After fix (`Type.OPERATIONS` in throughput mode reports the counter rate in the same units as
the primary metric — spans/s, not spans/op. Since each operation submits exactly one span,
`exportedSpans ≈ primary_thrpt`, scaling linearly with thread count):
```
export_01Thread  thrpt:   6 367 ops/s  exportedSpans:   6 348 spans/s  droppedSpans: 0
export_02Thread  thrpt:  12 761 ops/s  exportedSpans:  12 698 spans/s  droppedSpans: 0
export_05Thread  thrpt:  31 991 ops/s  exportedSpans:  31 947 spans/s  droppedSpans: 0
export_10Thread  thrpt:  64 178 ops/s  exportedSpans:  64 102 spans/s  droppedSpans: 0
export_20Thread  thrpt: 129 033 ops/s  exportedSpans: 129 022 spans/s  droppedSpans: 0
```

No drops are expected — `CpuBenchmark` measures export throughput at a controlled low rate
(~10k spans/s per thread via `parkNanos`), not queue saturation. `Type.OPERATIONS` is the
natural unit here: the per-second rate is what a CPU profiler run reports.

> Note: these are single-iteration smoke measurements (`-PjmhFork=1 -PjmhWarmupIterations=1
> -PjmhIterations=1 -PjmhTime=5s`), so throughput scores carry more noise than the benchmark's
> default 5×20s configuration.

## Details

- `stringKey("dropped")` → `booleanKey("dropped")` in `BatchSpanProcessorMetrics` — fixes the main issue
- `AuxCounters.Type.OPERATIONS` → `Type.EVENTS` in `BatchSpanProcessorDroppedSpansBenchmark`
  and `BatchSpanProcessorMultiThreadBenchmark` — `Type.OPERATIONS` in throughput mode reports
  `counter / time`, so `exportedSpans` and `droppedSpans` appear in `ops/s`. This makes it impossible to read absolute totals. `Type.EVENTS` reports raw iteration totals, from which `drop ratio = droppedSpans / (exportedSpans + droppedSpans)`.
- `numThreads` derived from `BenchmarkParams.getThreads()` injected into `@Setup(Level.Iteration)`
  in all three benchmarks instead of being hardcoded in each benchmark method body — removes
  the fragile manual coupling between `@Threads(N)` and `numThreads = N` (verified:
  `getThreads()` correctly returns the per-method thread count, not the JMH global default)
