### PR TITLE
Enforce last-value-wins semantics in AttributesMap without performance regression

### DIFF
--- a/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
+++ b/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
@@ -52,6 +52,9 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Thread)
 public class AttributesMapBenchmark {
 
+  // Default SpanLimits attribute count limit.
+  private static final int CAPACITY = 128;
+
   @Param({"4", "16", "20", "32", "128"})
   int numAttributes;
 
@@ -72,7 +75,7 @@ public class AttributesMapBenchmark {
       boolKeys.add(booleanKey("key" + i));
       values.add("value" + i);
     }
-    filledMap = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    filledMap = AttributesMap.create(CAPACITY, Integer.MAX_VALUE);
     for (int i = 0; i < numAttributes; i++) {
       filledMap.put(stringKeys.get(i), values.get(i));
     }
@@ -81,7 +84,7 @@ public class AttributesMapBenchmark {
   /** Each key name is unique — the common production case. */
   @Benchmark
   public AttributesMap uniqueKeys() {
-    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    AttributesMap map = AttributesMap.create(CAPACITY, Integer.MAX_VALUE);
     for (int i = 0; i < numAttributes; i++) {
       map.put(stringKeys.get(i), values.get(i));
     }
@@ -127,7 +130,7 @@ public class AttributesMapBenchmark {
    */
   @Benchmark
   public void putThenForEach(Blackhole bh) {
-    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    AttributesMap map = AttributesMap.create(CAPACITY, Integer.MAX_VALUE);
     for (int i = 0; i < numAttributes; i++) {
       map.put(stringKeys.get(i), values.get(i));
     }

--- a/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
+++ b/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
@@ -52,7 +52,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Thread)
 public class AttributesMapBenchmark {
 
-  @Param({"4", "16", "128"})
+  @Param({"4", "16", "20", "32", "128"})
   int numAttributes;
 
   private List<AttributeKey<String>> stringKeys;

--- a/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
+++ b/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.common.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmark for {@link AttributesMap}. Covers writes ({@code put}) and reads ({@code get},
+ * {@code forEach}), parametrized by number of attributes.
+ *
+ * <p>Write scenarios:
+ *
+ * <ul>
+ *   <li>{@code uniqueKeys} — normal case: each key name is distinct
+ *   <li>{@code sameKeySameType} — repeated put with the same AttributeKey (pure overwrite)
+ *   <li>{@code sameKeyDifferentType} — regression benchmark: same string name cycling through four
+ *       types (pre-fix: produces N entries; post-fix: produces 1 entry)
+ *   <li>{@code mixedUniqueAndOverwrite} — primary realistic case: unique keys followed by
+ *       same-name overwrites with a different type, exactly {@code numAttributes} puts total
+ * </ul>
+ *
+ * <p>Read scenarios (run on a pre-filled map of {@code numAttributes} unique string entries):
+ *
+ * <ul>
+ *   <li>{@code getHit} — lookup with the exact stored key type (hit)
+ *   <li>{@code getTypeMiss} — lookup with a different type for the same key name (miss by type;
+ *       behaviour changes after the fix: post-fix only one entry exists per name)
+ *   <li>{@code forEachAll} — full iteration over all entries
+ * </ul>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class AttributesMapBenchmark {
+
+  @Param({"4", "16", "128"})
+  int numAttributes;
+
+  private List<AttributeKey<String>> stringKeys;
+  private List<AttributeKey<Boolean>> boolKeys;
+  private List<AttributeKey<Long>> longKeys;
+  private List<AttributeKey<Double>> doubleKeys;
+  private List<String> values;
+
+  // Pre-filled map used by read benchmarks — populated once in @Setup.
+  private AttributesMap filledMap;
+
+  @Setup
+  public void setup() {
+    stringKeys = new ArrayList<>(numAttributes);
+    boolKeys = new ArrayList<>(numAttributes);
+    longKeys = new ArrayList<>(numAttributes);
+    doubleKeys = new ArrayList<>(numAttributes);
+    values = new ArrayList<>(numAttributes);
+    for (int i = 0; i < numAttributes; i++) {
+      stringKeys.add(stringKey("key" + i));
+      boolKeys.add(booleanKey("key" + i));
+      longKeys.add(longKey("key" + i));
+      doubleKeys.add(doubleKey("key" + i));
+      values.add("value" + i);
+    }
+    filledMap = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    for (int i = 0; i < numAttributes; i++) {
+      filledMap.put(stringKeys.get(i), values.get(i));
+    }
+  }
+
+  /** Each key name is unique — the common production case. */
+  @Benchmark
+  public AttributesMap uniqueKeys() {
+    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    for (int i = 0; i < numAttributes; i++) {
+      map.put(stringKeys.get(i), values.get(i));
+    }
+    return map;
+  }
+
+  /** Same AttributeKey reused — standard same-type overwrite path. Capacity=1 since only one
+   * entry ever occupies the map. */
+  @Benchmark
+  public AttributesMap sameKeySameType() {
+    AttributesMap map = AttributesMap.create(1, Integer.MAX_VALUE);
+    AttributeKey<String> key = stringKeys.get(0);
+    for (int i = 0; i < numAttributes; i++) {
+      map.put(key, values.get(i));
+    }
+    return map;
+  }
+
+  /**
+   * Same string key name, cycling through string → boolean → long → double → string → ...
+   *
+   * <p>Regression benchmark: pre-fix produces up to 4 entries (one per type); post-fix produces 1
+   * entry (last-value-wins). Capacity=4 matches the number of distinct types in the cycle.
+   */
+  @Benchmark
+  public AttributesMap sameKeyDifferentType() {
+    AttributesMap map = AttributesMap.create(4, Integer.MAX_VALUE);
+    for (int i = 0; i < numAttributes; i++) {
+      switch (i % 4) {
+        case 0:
+          map.put(stringKeys.get(0), values.get(0));
+          break;
+        case 1:
+          map.put(boolKeys.get(0), true);
+          break;
+        case 2:
+          map.put(longKeys.get(0), 42L);
+          break;
+        default:
+          map.put(doubleKeys.get(0), 3.14);
+          break;
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Realistic mixed case: first {@code numAttributes/2} puts insert unique string keys, the
+   * remaining puts overwrite those same keys with boolean values (different type). Always performs
+   * exactly {@code numAttributes} put operations total.
+   */
+  @Benchmark
+  public AttributesMap mixedUniqueAndOverwrite() {
+    int first = numAttributes / 2;
+    int second = numAttributes - first;
+    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    for (int i = 0; i < first; i++) {
+      map.put(stringKeys.get(i), values.get(i));
+    }
+    for (int i = 0; i < second; i++) {
+      map.put(boolKeys.get(i), i % 2 == 0);
+    }
+    return map;
+  }
+
+  // ---- Read benchmarks (operate on pre-filled map) ----
+
+  /**
+   * Lookup with the exact stored key type — always a hit. Measures the cost of a successful
+   * {@code get()} for each entry in the map.
+   */
+  @Benchmark
+  public void getHit(Blackhole bh) {
+    for (int i = 0; i < numAttributes; i++) {
+      bh.consume(filledMap.get(stringKeys.get(i)));
+    }
+  }
+
+  /**
+   * Lookup with a different type for the same key name — always a type-miss (returns null).
+   *
+   * <p>Pre-fix: map contains N string entries; boolean keys simply miss the HashMap. Post-fix: map
+   * contains N string entries; boolean key finds the entry but type check returns null. Isolates
+   * the type-check overhead introduced by the fix.
+   */
+  @Benchmark
+  public void getTypeMiss(Blackhole bh) {
+    for (int i = 0; i < numAttributes; i++) {
+      bh.consume(filledMap.get(boolKeys.get(i)));
+    }
+  }
+
+  /** Full iteration over all entries via {@code forEach}. */
+  @Benchmark
+  public void forEachAll(Blackhole bh) {
+    filledMap.forEach((k, v) -> bh.consume(v));
+  }
+}

--- a/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
+++ b/sdk/common/src/jmh/java/io/opentelemetry/sdk/common/internal/AttributesMapBenchmark.java
@@ -6,15 +6,12 @@
 package io.opentelemetry.sdk.common.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
-import static io.opentelemetry.api.common.AttributeKey.doubleKey;
-import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -26,28 +23,24 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Microbenchmark for {@link AttributesMap}. Covers writes ({@code put}) and reads ({@code get},
- * {@code forEach}), parametrized by number of attributes.
+ * Microbenchmark for {@link AttributesMap}. Parametrized by number of attributes.
  *
  * <p>Write scenarios:
  *
  * <ul>
- *   <li>{@code uniqueKeys} — normal case: each key name is distinct
- *   <li>{@code sameKeySameType} — repeated put with the same AttributeKey (pure overwrite)
- *   <li>{@code sameKeyDifferentType} — regression benchmark: same string name cycling through four
- *       types (pre-fix: produces N entries; post-fix: produces 1 entry)
- *   <li>{@code mixedUniqueAndOverwrite} — primary realistic case: unique keys followed by
- *       same-name overwrites with a different type, exactly {@code numAttributes} puts total
+ *   <li>{@code uniqueKeys} — normal production case: each key name is distinct
+ *   <li>{@code putThenForEach} — combined write + export cycle: N unique puts followed by one
+ *       {@code forEach}, modeling the dominant span lifecycle
  * </ul>
  *
  * <p>Read scenarios (run on a pre-filled map of {@code numAttributes} unique string entries):
  *
  * <ul>
  *   <li>{@code getHit} — lookup with the exact stored key type (hit)
- *   <li>{@code getTypeMiss} — lookup with a different type for the same key name (miss by type;
- *       behaviour changes after the fix: post-fix only one entry exists per name)
+ *   <li>{@code getTypeMiss} — lookup with a different type for the same key name (type miss)
  *   <li>{@code forEachAll} — full iteration over all entries
  * </ul>
  */
@@ -64,8 +57,6 @@ public class AttributesMapBenchmark {
 
   private List<AttributeKey<String>> stringKeys;
   private List<AttributeKey<Boolean>> boolKeys;
-  private List<AttributeKey<Long>> longKeys;
-  private List<AttributeKey<Double>> doubleKeys;
   private List<String> values;
 
   // Pre-filled map used by read benchmarks — populated once in @Setup.
@@ -75,14 +66,10 @@ public class AttributesMapBenchmark {
   public void setup() {
     stringKeys = new ArrayList<>(numAttributes);
     boolKeys = new ArrayList<>(numAttributes);
-    longKeys = new ArrayList<>(numAttributes);
-    doubleKeys = new ArrayList<>(numAttributes);
     values = new ArrayList<>(numAttributes);
     for (int i = 0; i < numAttributes; i++) {
       stringKeys.add(stringKey("key" + i));
       boolKeys.add(booleanKey("key" + i));
-      longKeys.add(longKey("key" + i));
-      doubleKeys.add(doubleKey("key" + i));
       values.add("value" + i);
     }
     filledMap = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
@@ -101,70 +88,11 @@ public class AttributesMapBenchmark {
     return map;
   }
 
-  /** Same AttributeKey reused — standard same-type overwrite path. Capacity=1 since only one
-   * entry ever occupies the map. */
-  @Benchmark
-  public AttributesMap sameKeySameType() {
-    AttributesMap map = AttributesMap.create(1, Integer.MAX_VALUE);
-    AttributeKey<String> key = stringKeys.get(0);
-    for (int i = 0; i < numAttributes; i++) {
-      map.put(key, values.get(i));
-    }
-    return map;
-  }
-
-  /**
-   * Same string key name, cycling through string → boolean → long → double → string → ...
-   *
-   * <p>Regression benchmark: pre-fix produces up to 4 entries (one per type); post-fix produces 1
-   * entry (last-value-wins). Capacity=4 matches the number of distinct types in the cycle.
-   */
-  @Benchmark
-  public AttributesMap sameKeyDifferentType() {
-    AttributesMap map = AttributesMap.create(4, Integer.MAX_VALUE);
-    for (int i = 0; i < numAttributes; i++) {
-      switch (i % 4) {
-        case 0:
-          map.put(stringKeys.get(0), values.get(0));
-          break;
-        case 1:
-          map.put(boolKeys.get(0), true);
-          break;
-        case 2:
-          map.put(longKeys.get(0), 42L);
-          break;
-        default:
-          map.put(doubleKeys.get(0), 3.14);
-          break;
-      }
-    }
-    return map;
-  }
-
-  /**
-   * Realistic mixed case: first {@code numAttributes/2} puts insert unique string keys, the
-   * remaining puts overwrite those same keys with boolean values (different type). Always performs
-   * exactly {@code numAttributes} put operations total.
-   */
-  @Benchmark
-  public AttributesMap mixedUniqueAndOverwrite() {
-    int first = numAttributes / 2;
-    int second = numAttributes - first;
-    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
-    for (int i = 0; i < first; i++) {
-      map.put(stringKeys.get(i), values.get(i));
-    }
-    for (int i = 0; i < second; i++) {
-      map.put(boolKeys.get(i), i % 2 == 0);
-    }
-    return map;
-  }
-
   // ---- Read benchmarks (operate on pre-filled map) ----
 
   /**
-   * Lookup with the exact stored key type — always a hit. Measures the cost of a successful
-   * {@code get()} for each entry in the map.
+   * Lookup with the exact stored key type — always a hit. Measures the cost of a successful {@code
+   * get()} for each entry in the map.
    */
   @Benchmark
   public void getHit(Blackhole bh) {
@@ -174,11 +102,10 @@ public class AttributesMapBenchmark {
   }
 
   /**
-   * Lookup with a different type for the same key name — always a type-miss (returns null).
+   * Lookup with a different type for the same key name — always returns null.
    *
-   * <p>Pre-fix: map contains N string entries; boolean keys simply miss the HashMap. Post-fix: map
-   * contains N string entries; boolean key finds the entry but type check returns null. Isolates
-   * the type-check overhead introduced by the fix.
+   * <p>The map holds N string-typed entries; boolean keys for the same names locate each entry by
+   * name but fail the type check. Isolates the cost of a name-hit / type-miss lookup.
    */
   @Benchmark
   public void getTypeMiss(Blackhole bh) {
@@ -191,5 +118,19 @@ public class AttributesMapBenchmark {
   @Benchmark
   public void forEachAll(Blackhole bh) {
     filledMap.forEach((k, v) -> bh.consume(v));
+  }
+
+  /**
+   * Combined write + read cycle: fill a fresh map with N unique string keys, then iterate all
+   * entries once. Models the dominant production path: N puts during span building, followed by one
+   * forEach at export time.
+   */
+  @Benchmark
+  public void putThenForEach(Blackhole bh) {
+    AttributesMap map = AttributesMap.create(numAttributes, Integer.MAX_VALUE);
+    for (int i = 0; i < numAttributes; i++) {
+      map.put(stringKeys.get(i), values.get(i));
+    }
+    map.forEach((k, v) -> bh.consume(v));
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -8,9 +8,9 @@ package io.opentelemetry.sdk.common.internal;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
@@ -19,35 +19,50 @@ import javax.annotation.Nullable;
  * A map with a fixed capacity that drops attributes when the map gets full, and which truncates
  * string and array string attribute values to the {@link #lengthLimit}.
  *
- * <p>Keyed internally by raw string attribute name, so that attributes with the same name but
- * different types are treated as the same key (last-value-wins), consistent with the OpenTelemetry
- * specification.
+ * <p>Keyed internally by attribute name, so that attributes with the same name but different types
+ * are treated as the same key (last-value-wins), consistent with the OpenTelemetry specification.
+ *
+ * <p>Backed by parallel arrays and an open-addressing {@code int[]} hash table (linear probing,
+ * load factor ≤ 0.5). Avoids per-entry object allocation; {@code forEach} is a tight sequential
+ * array loop with no pointer chasing.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
 public final class AttributesMap implements Attributes {
 
+  /**
+   * Sentinel value meaning "slot is empty" in the hash table. Using 0 lets {@code new int[n]} (JVM
+   * zero-initialization) serve as the initial fill, eliminating explicit {@code Arrays.fill} calls.
+   * Occupied slots store {@code entryIndex + 1} so that index 0 is distinguishable from EMPTY.
+   */
+  private static final int EMPTY = 0;
+
   private final long capacity;
   private final int lengthLimit;
   private int totalAddedValues = 0;
+  private int size = 0;
 
-  private final LinkedHashMap<String, AttributeEntry> data;
+  /**
+   * Open-addressing hash table: {@code hashTable[slot]} = index into entry arrays, or {@link
+   * #EMPTY}. Length is always a power of 2 and ≥ 2× the entry array length (load factor ≤ 0.5).
+   */
+  private int[] hashTable;
 
-  private static final class AttributeEntry {
-    AttributeKey<?> key;
-    Object value;
+  /** Parallel entry arrays. Index {@code i} holds the i-th inserted entry. */
+  private String[] entryNames;
 
-    AttributeEntry(AttributeKey<?> key, Object value) {
-      this.key = key;
-      this.value = value;
-    }
-  }
+  private AttributeKey<?>[] entryKeys;
+  private Object[] entryValues;
 
   private AttributesMap(long capacity, int lengthLimit) {
     this.capacity = capacity;
     this.lengthLimit = lengthLimit;
-    this.data = new LinkedHashMap<>();
+    int init = (int) Math.min(capacity, 16L);
+    entryNames = new String[init];
+    entryKeys = new AttributeKey<?>[init];
+    entryValues = new Object[init];
+    hashTable = new int[tableSizeFor(init)]; // JVM zero-init == EMPTY
   }
 
   /**
@@ -74,18 +89,28 @@ public final class AttributesMap implements Attributes {
     }
     totalAddedValues++;
     String name = key.getKey();
-    AttributeEntry entry = data.get(name);
-    if (entry == null && data.size() >= capacity) {
+    int slot = findSlot(name);
+    int stored = hashTable[slot]; // EMPTY or 1-based index
+    if (stored == EMPTY) {
+      if (size >= capacity) {
+        return null;
+      }
+      Object limited = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
+      if (size == entryNames.length) {
+        grow();
+        slot = findSlot(name); // hashTable was rebuilt by grow()
+      }
+      entryNames[size] = name;
+      entryKeys[size] = key;
+      entryValues[size] = limited;
+      hashTable[slot] = size + 1; // 1-based
+      size++;
       return null;
     }
-    Object limited = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
-    if (entry == null) {
-      data.put(name, new AttributeEntry(key, limited));
-      return null;
-    }
-    Object old = entry.value;
-    entry.key = key;
-    entry.value = limited;
+    int idx = stored - 1;
+    Object old = entryValues[idx];
+    entryKeys[idx] = key;
+    entryValues[idx] = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
     return old;
   }
 
@@ -103,27 +128,33 @@ public final class AttributesMap implements Attributes {
   @Override
   @Nullable
   public <T> T get(AttributeKey<T> key) {
-    AttributeEntry entry = data.get(key.getKey());
-    if (entry == null || !entry.key.getType().equals(key.getType())) {
+    int stored = hashTable[findSlot(key.getKey())];
+    if (stored == EMPTY) {
       return null;
     }
-    return (T) entry.value;
+    int idx = stored - 1;
+    if (!entryKeys[idx].getType().equals(key.getType())) {
+      return null;
+    }
+    return (T) entryValues[idx];
   }
 
   @Override
   public int size() {
-    return data.size();
+    return size;
   }
 
   @Override
   public boolean isEmpty() {
-    return data.isEmpty();
+    return size == 0;
   }
 
   @Override
   public Map<AttributeKey<?>, Object> asMap() {
-    Map<AttributeKey<?>, Object> snapshot = new HashMap<>(data.size());
-    data.values().forEach(e -> snapshot.put(e.key, e.value));
+    Map<AttributeKey<?>, Object> snapshot = new HashMap<>(size);
+    for (int i = 0; i < size; i++) {
+      snapshot.put(entryKeys[i], entryValues[i]);
+    }
     return Collections.unmodifiableMap(snapshot);
   }
 
@@ -134,7 +165,9 @@ public final class AttributesMap implements Attributes {
 
   @Override
   public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> action) {
-    data.forEach((name, entry) -> action.accept(entry.key, entry.value));
+    for (int i = 0; i < size; i++) {
+      action.accept(entryKeys[i], entryValues[i]);
+    }
   }
 
   @Override
@@ -168,5 +201,48 @@ public final class AttributesMap implements Attributes {
   /** Create an immutable copy of the attributes in this map. */
   public Attributes immutableCopy() {
     return Attributes.builder().putAll(this).build();
+  }
+
+  /**
+   * Returns the hash table slot that either contains the entry for {@code name} or is the first
+   * empty slot available for insertion. Single shared probe loop used by {@code put}, {@code get},
+   * and {@code grow}. Slots store {@code entryIndex + 1}; 0 ({@link #EMPTY}) means unoccupied.
+   */
+  private int findSlot(String name) {
+    int mask = hashTable.length - 1;
+    int slot = name.hashCode() & mask;
+    int stored;
+    while ((stored = hashTable[slot]) != EMPTY && !entryNames[stored - 1].equals(name)) {
+      slot = (slot + 1) & mask;
+    }
+    return slot;
+  }
+
+  private void grow() {
+    long maxLen = Math.min(capacity, (long) Integer.MAX_VALUE - 8);
+    int newLen = (int) Math.min((long) entryNames.length * 2, maxLen);
+    entryNames = Arrays.copyOf(entryNames, newLen);
+    entryKeys = Arrays.copyOf(entryKeys, newLen);
+    entryValues = Arrays.copyOf(entryValues, newLen);
+    hashTable = new int[tableSizeFor(newLen)]; // JVM zero-init == EMPTY
+    for (int i = 0; i < size; i++) {
+      int slot = findSlot(entryNames[i]);
+      hashTable[slot] = i + 1; // 1-based
+    }
+  }
+
+  /**
+   * Returns the smallest power of 2 that is ≥ 2n, guaranteeing load factor ≤ 0.5. Using {@code
+   * (2n-1)} instead of {@code 2n} prevents doubling the result when {@code n} is itself a power of
+   * 2.
+   */
+  private static int tableSizeFor(int n) {
+    if (n <= 2) {
+      return 4;
+    }
+    if (n >= (1 << 29)) {
+      return 1 << 30;
+    }
+    return Integer.highestOneBit(2 * n - 1) << 1;
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -38,7 +38,7 @@ public final class AttributesMap implements Attributes {
    */
   private static final int EMPTY = 0;
 
-  private final long capacity;
+  private final int capacity;
   private final int lengthLimit;
   private int totalAddedValues = 0;
   private int size = 0;
@@ -49,6 +49,9 @@ public final class AttributesMap implements Attributes {
    */
   private int[] hashTable;
 
+  /** Cached {@code hashTable.length - 1}; kept in sync with {@link #hashTable}. */
+  private int mask;
+
   /** Parallel entry arrays. Index {@code i} holds the i-th inserted entry. */
   private String[] entryNames;
 
@@ -56,13 +59,14 @@ public final class AttributesMap implements Attributes {
   private Object[] entryValues;
 
   private AttributesMap(long capacity, int lengthLimit) {
-    this.capacity = capacity;
+    this.capacity = (int) Math.min(capacity, Integer.MAX_VALUE);
     this.lengthLimit = lengthLimit;
     int init = (int) Math.min(capacity, 16L);
     entryNames = new String[init];
     entryKeys = new AttributeKey<?>[init];
     entryValues = new Object[init];
     hashTable = new int[tableSizeFor(init)]; // JVM zero-init == EMPTY
+    mask = hashTable.length - 1;
   }
 
   /**
@@ -209,7 +213,6 @@ public final class AttributesMap implements Attributes {
    * and {@code grow}. Slots store {@code entryIndex + 1}; 0 ({@link #EMPTY}) means unoccupied.
    */
   private int findSlot(String name) {
-    int mask = hashTable.length - 1;
     int slot = name.hashCode() & mask;
     int stored;
     while ((stored = hashTable[slot]) != EMPTY && !entryNames[stored - 1].equals(name)) {
@@ -225,6 +228,7 @@ public final class AttributesMap implements Attributes {
     entryKeys = Arrays.copyOf(entryKeys, newLen);
     entryValues = Arrays.copyOf(entryValues, newLen);
     hashTable = new int[tableSizeFor(newLen)]; // JVM zero-init == EMPTY
+    mask = hashTable.length - 1;
     for (int i = 0; i < size; i++) {
       int slot = findSlot(entryNames[i]);
       hashTable[slot] = i + 1; // 1-based

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
@@ -18,28 +19,35 @@ import javax.annotation.Nullable;
  * A map with a fixed capacity that drops attributes when the map gets full, and which truncates
  * string and array string attribute values to the {@link #lengthLimit}.
  *
- * <p>WARNING: In order to reduce memory allocation, this class extends {@link HashMap} when it
- * would be more appropriate to delegate. The problem with extending is that we don't enforce that
- * all {@link HashMap} methods for reading / writing data conform to the configured attribute
- * limits. Therefore, it's easy to accidentally call something like {@link Map#putAll(Map)} and
- * bypass the restrictions (see <a
- * href="https://github.com/open-telemetry/opentelemetry-java/issues/7135">#7135</a>). Callers MUST
- * take care to only call methods from {@link AttributesMap}, and not {@link HashMap}.
+ * <p>Keyed internally by raw string attribute name, so that attributes with the same name but
+ * different types are treated as the same key (last-value-wins), consistent with the OpenTelemetry
+ * specification.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class AttributesMap extends HashMap<AttributeKey<?>, Object> implements Attributes {
-
-  private static final long serialVersionUID = -5072696312123632376L;
+public final class AttributesMap implements Attributes {
 
   private final long capacity;
   private final int lengthLimit;
   private int totalAddedValues = 0;
 
+  private final LinkedHashMap<String, AttributeEntry> data;
+
+  private static final class AttributeEntry {
+    AttributeKey<?> key;
+    Object value;
+
+    AttributeEntry(AttributeKey<?> key, Object value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+
   private AttributesMap(long capacity, int lengthLimit) {
     this.capacity = capacity;
     this.lengthLimit = lengthLimit;
+    this.data = new LinkedHashMap<>();
   }
 
   /**
@@ -55,18 +63,30 @@ public final class AttributesMap extends HashMap<AttributeKey<?>, Object> implem
   /**
    * Add the attribute key value pair, applying capacity and length limits. Callers MUST ensure the
    * {@code value} type matches the type required by {@code key}.
+   *
+   * <p>If an attribute with the same string key name already exists (regardless of type), it is
+   * overwritten — last-value-wins, consistent with the OTel spec.
    */
-  @Override
   @Nullable
   public Object put(AttributeKey<?> key, @Nullable Object value) {
     if (value == null) {
       return null;
     }
     totalAddedValues++;
-    if (size() >= capacity && !containsKey(key)) {
+    String name = key.getKey();
+    AttributeEntry entry = data.get(name);
+    if (entry == null && data.size() >= capacity) {
       return null;
     }
-    return super.put(key, AttributeUtil.applyAttributeLengthLimit(value, lengthLimit));
+    Object limited = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
+    if (entry == null) {
+      data.put(name, new AttributeEntry(key, limited));
+      return null;
+    }
+    Object old = entry.value;
+    entry.key = key;
+    entry.value = limited;
+    return old;
   }
 
   /** Generic overload of {@link #put(AttributeKey, Object)}. */
@@ -83,17 +103,28 @@ public final class AttributesMap extends HashMap<AttributeKey<?>, Object> implem
   @Override
   @Nullable
   public <T> T get(AttributeKey<T> key) {
-    return (T) super.get(key);
+    AttributeEntry entry = data.get(key.getKey());
+    if (entry == null || !entry.key.getType().equals(key.getType())) {
+      return null;
+    }
+    return (T) entry.value;
+  }
+
+  @Override
+  public int size() {
+    return data.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return data.isEmpty();
   }
 
   @Override
   public Map<AttributeKey<?>, Object> asMap() {
-    // Because Attributes is marked Immutable, IDEs may recognize this as redundant usage. However,
-    // this class is private and is actually mutable, so we need to wrap with unmodifiableMap
-    // anyways. We implement the immutable Attributes for this class to support the
-    // Attributes.builder().putAll usage - it is tricky but an implementation detail of this private
-    // class.
-    return Collections.unmodifiableMap(this);
+    Map<AttributeKey<?>, Object> snapshot = new HashMap<>(data.size());
+    data.values().forEach(e -> snapshot.put(e.key, e.value));
+    return Collections.unmodifiableMap(snapshot);
   }
 
   @Override
@@ -103,17 +134,30 @@ public final class AttributesMap extends HashMap<AttributeKey<?>, Object> implem
 
   @Override
   public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> action) {
-    // https://github.com/open-telemetry/opentelemetry-java/issues/4161
-    // Help out android desugaring by having an explicit call to HashMap.forEach, when forEach is
-    // just called through Attributes.forEach desugaring is unable to correctly handle it.
-    super.forEach(action);
+    data.forEach((name, entry) -> action.accept(entry.key, entry.value));
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Attributes)) {
+      return false;
+    }
+    return asMap().equals(((Attributes) o).asMap());
+  }
+
+  @Override
+  public int hashCode() {
+    return asMap().hashCode();
   }
 
   @Override
   public String toString() {
     return "AttributesMap{"
         + "data="
-        + super.toString()
+        + asMap()
         + ", capacity="
         + capacity
         + ", totalAddedValues="

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -240,9 +240,6 @@ public final class AttributesMap implements Attributes {
     if (n <= 2) {
       return 4;
     }
-    if (n >= (1 << 29)) {
-      return 1 << 30;
-    }
     return Integer.highestOneBit(2 * n - 1) << 1;
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -26,15 +27,25 @@ import javax.annotation.Nullable;
  * load factor ≤ 0.5). Avoids per-entry object allocation; {@code forEach} is a tight sequential
  * array loop with no pointer chasing.
  *
+ * <p><b>Not thread-safe.</b> Callers sharing an instance across threads must externally
+ * synchronize. Concurrent mutation is undefined behavior and may throw {@link
+ * ArrayIndexOutOfBoundsException} as readers observe the parallel arrays and hash table in
+ * inconsistent states. {@link #forEach}'s {@link ConcurrentModificationException} on structural
+ * modification is a same-thread misuse detector, not a synchronization primitive.
+ *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
 public final class AttributesMap implements Attributes {
 
   /**
-   * Sentinel value meaning "slot is empty" in the hash table. Using 0 lets {@code new int[n]} (JVM
-   * zero-initialization) serve as the initial fill, eliminating explicit {@code Arrays.fill} calls.
-   * Occupied slots store {@code entryIndex + 1} so that index 0 is distinguishable from EMPTY.
+   * Sentinel meaning "slot is empty" in the hash table. This is a value stored in {@code
+   * hashTable[slot]}, not a slot address; a name whose {@link String#hashCode()} is 0 simply hashes
+   * to slot 0 like any other slot address, and occupancy is decided by comparing the stored value.
+   *
+   * <p>Using 0 lets {@code new int[n]} (JVM zero-initialization) serve as the initial fill,
+   * eliminating explicit {@code Arrays.fill} calls. Occupied slots store {@code entryIndex + 1} so
+   * that entry index 0 is distinguishable from EMPTY.
    */
   private static final int EMPTY = 0;
 
@@ -52,11 +63,29 @@ public final class AttributesMap implements Attributes {
   /** Cached {@code hashTable.length - 1}; kept in sync with {@link #hashTable}. */
   private int mask;
 
-  /** Parallel entry arrays. Index {@code i} holds the i-th inserted entry. */
+  /**
+   * Parallel entry arrays. For entry {@code i} (in insertion order):
+   *
+   * <ul>
+   *   <li>{@link #entryNames}{@code [i]} is the attribute name (cached from {@code
+   *       entryKeys[i].getKey()} to avoid an extra dereference on every probe step).
+   *   <li>{@link #entryKeys}{@code [i]} is the last-put {@link AttributeKey} for that name,
+   *       preserving the caller's type at query time via {@link #get}.
+   *   <li>{@link #entryValues}{@code [i]} is the last-put value, post-length-limit application.
+   * </ul>
+   *
+   * <p>All three are reallocated together in {@link #grow}; entry positions never change.
+   */
   private String[] entryNames;
 
   private AttributeKey<?>[] entryKeys;
   private Object[] entryValues;
+
+  /**
+   * Incremented on every mutation that changes observable state (insert or overwrite). Snapshotted
+   * by {@link #forEach} to detect same-thread structural modification during iteration.
+   */
+  private int modCount = 0;
 
   private AttributesMap(long capacity, int lengthLimit) {
     this.capacity = (int) Math.min(capacity, Integer.MAX_VALUE);
@@ -94,25 +123,29 @@ public final class AttributesMap implements Attributes {
     totalAddedValues++;
     String name = key.getKey();
     int slot = findSlot(name);
-    int stored = hashTable[slot]; // EMPTY or 1-based index
+    int stored = hashTable[slot];
+    int idx;
+    Object old;
     if (stored == EMPTY) {
       if (size >= capacity) {
+        // Drop new entry per spec. totalAddedValues++ above captures the drop for
+        // getTotalAddedValues() / downstream drop-count metrics.
         return null;
       }
-      Object limited = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
       if (size == entryNames.length) {
         grow();
-        slot = findSlot(name); // hashTable was rebuilt by grow()
+        slot = findSlot(name); // grow() rebuilt hashTable
       }
-      entryNames[size] = name;
-      entryKeys[size] = key;
-      entryValues[size] = limited;
-      hashTable[slot] = size + 1; // 1-based
+      idx = size;
+      entryNames[idx] = name;
+      hashTable[slot] = idx + 1;
       size++;
-      return null;
+      old = null;
+    } else {
+      idx = stored - 1;
+      old = entryValues[idx];
     }
-    int idx = stored - 1;
-    Object old = entryValues[idx];
+    modCount++;
     entryKeys[idx] = key;
     entryValues[idx] = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
     return old;
@@ -169,8 +202,12 @@ public final class AttributesMap implements Attributes {
 
   @Override
   public void forEach(BiConsumer<? super AttributeKey<?>, ? super Object> action) {
+    int expectedModCount = modCount;
     for (int i = 0; i < size; i++) {
       action.accept(entryKeys[i], entryValues[i]);
+    }
+    if (modCount != expectedModCount) {
+      throw new ConcurrentModificationException();
     }
   }
 
@@ -213,6 +250,8 @@ public final class AttributesMap implements Attributes {
    * and {@code grow}. Slots store {@code entryIndex + 1}; 0 ({@link #EMPTY}) means unoccupied.
    */
   private int findSlot(String name) {
+    // Linear probe: stop on empty slot (name absent; insertion point) or matching-name slot (name
+    // found). `& mask` wraps at the end of the table.
     int slot = name.hashCode() & mask;
     int stored;
     while ((stored = hashTable[slot]) != EMPTY && !entryNames[stored - 1].equals(name)) {
@@ -229,9 +268,10 @@ public final class AttributesMap implements Attributes {
     entryValues = Arrays.copyOf(entryValues, newLen);
     hashTable = new int[tableSizeFor(newLen)]; // JVM zero-init == EMPTY
     mask = hashTable.length - 1;
+    // Rehash: entry positions in the arrays don't change, but their slot addresses do (new mask).
     for (int i = 0; i < size; i++) {
       int slot = findSlot(entryNames[i]);
-      hashTable[slot] = i + 1; // 1-based
+      hashTable[slot] = i + 1;
     }
   }
 

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -124,14 +124,15 @@ public final class AttributesMap implements Attributes {
     String name = key.getKey();
     int slot = findSlot(name);
     int stored = hashTable[slot];
+    if (stored == EMPTY && size >= capacity) {
+      // Drop new entry per spec. totalAddedValues++ above captures the drop for
+      // getTotalAddedValues() / downstream drop-count metrics.
+      return null;
+    }
+    Object limitedValue = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
     int idx;
     Object old;
     if (stored == EMPTY) {
-      if (size >= capacity) {
-        // Drop new entry per spec. totalAddedValues++ above captures the drop for
-        // getTotalAddedValues() / downstream drop-count metrics.
-        return null;
-      }
       if (size == entryNames.length) {
         grow();
         slot = findSlot(name); // grow() rebuilt hashTable
@@ -147,7 +148,7 @@ public final class AttributesMap implements Attributes {
     }
     modCount++;
     entryKeys[idx] = key;
-    entryValues[idx] = AttributeUtil.applyAttributeLengthLimit(value, lengthLimit);
+    entryValues[idx] = limitedValue;
     return old;
   }
 
@@ -216,10 +217,10 @@ public final class AttributesMap implements Attributes {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Attributes)) {
+    if (!(o instanceof AttributesMap)) {
       return false;
     }
-    return asMap().equals(((Attributes) o).asMap());
+    return asMap().equals(((AttributesMap) o).asMap());
   }
 
   @Override

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -11,22 +11,43 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.opentelemetry.api.common.Attributes;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class AttributesMapTest {
 
-  @Test
-  void asMap() {
-    AttributesMap attributesMap = AttributesMap.create(2, Integer.MAX_VALUE);
-    attributesMap.put(longKey("one"), 1L);
-    attributesMap.put(longKey("two"), 2L);
+  // ---- put ----
 
-    assertThat(attributesMap.asMap())
-        .containsOnly(entry(longKey("one"), 1L), entry(longKey("two"), 2L));
+  @Test
+  void put_returnsNullForNewEntry() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+
+    assertThat(map.put(stringKey("k"), "v")).isNull();
   }
 
   @Test
-  void putSameKeyDifferentType_lastWins() {
+  void put_returnsOldValueOnOverwrite() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("k"), "first");
+
+    assertThat(map.put(stringKey("k"), "second")).isEqualTo("first");
+    assertThat(map.get(stringKey("k"))).isEqualTo("second");
+  }
+
+  @Test
+  void put_ignoresNullValue() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("k"), null);
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.getTotalAddedValues()).isEqualTo(0);
+  }
+
+  @Test
+  void putSameKeyDifferentType_lastValueWins() {
     AttributesMap map = AttributesMap.create(128, Integer.MAX_VALUE);
     map.put(stringKey("k"), "hello");
     map.put(booleanKey("k"), false);
@@ -49,7 +70,7 @@ class AttributesMapTest {
   }
 
   @Test
-  void putSameKeyDifferentType_getByOldTypeMissAfterOverwrite() {
+  void putSameKeyDifferentType_previousTypeGetReturnsNull() {
     AttributesMap map = AttributesMap.create(128, Integer.MAX_VALUE);
     map.put(stringKey("k"), "hello");
     map.put(booleanKey("k"), true);
@@ -58,4 +79,101 @@ class AttributesMapTest {
     assertThat(map.get(booleanKey("k"))).isEqualTo(true);
   }
 
+  // ---- get ----
+
+  @Test
+  void get_returnsNullForAbsentKey() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+
+    assertThat(map.get(stringKey("absent"))).isNull();
+  }
+
+  // ---- capacity ----
+
+  @Test
+  void capacity_dropsEntriesBeyondLimit() {
+    AttributesMap map = AttributesMap.create(2, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+    map.put(stringKey("b"), "v2");
+    map.put(stringKey("c"), "v3"); // dropped — capacity reached
+
+    assertThat(map.size()).isEqualTo(2);
+    assertThat(map.getTotalAddedValues()).isEqualTo(3);
+    assertThat(map.get(stringKey("c"))).isNull();
+  }
+
+  @Test
+  void capacity_zeroDropsAllEntries() {
+    AttributesMap map = AttributesMap.create(0, Integer.MAX_VALUE);
+    map.put(stringKey("k"), "v");
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
+
+  // ---- grow ----
+
+  @Test
+  void grow_preservesAllEntriesWhenSizeExceedsInitialArrayLength() {
+    // init = min(capacity, 16) = 16; grow() is triggered when the 17th entry is inserted
+    int n = 20;
+    AttributesMap map = AttributesMap.create(n, Integer.MAX_VALUE);
+    for (int i = 0; i < n; i++) {
+      map.put(stringKey("key" + i), "val" + i);
+    }
+
+    assertThat(map.size()).isEqualTo(n);
+    for (int i = 0; i < n; i++) {
+      assertThat(map.get(stringKey("key" + i))).isEqualTo("val" + i);
+    }
+  }
+
+  // ---- lengthLimit ----
+
+  @Test
+  void lengthLimit_truncatesStringValues() {
+    AttributesMap map = AttributesMap.create(10, 3);
+    map.put(stringKey("k"), "hello");
+
+    assertThat(map.get(stringKey("k"))).isEqualTo("hel");
+  }
+
+  // ---- forEach ----
+
+  @Test
+  void forEach_iteratesInInsertionOrder() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("first"), "v1");
+    map.put(stringKey("second"), "v2");
+    map.put(stringKey("third"), "v3");
+
+    List<String> keys = new ArrayList<>();
+    map.forEach((k, v) -> keys.add(k.getKey()));
+
+    assertThat(keys).containsExactly("first", "second", "third");
+  }
+
+  // ---- views ----
+
+  @Test
+  void asMap() {
+    AttributesMap attributesMap = AttributesMap.create(2, Integer.MAX_VALUE);
+    attributesMap.put(longKey("one"), 1L);
+    attributesMap.put(longKey("two"), 2L);
+
+    assertThat(attributesMap.asMap())
+        .containsOnly(entry(longKey("one"), 1L), entry(longKey("two"), 2L));
+  }
+
+  @Test
+  void immutableCopy_containsAllEntries() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+    map.put(longKey("b"), 42L);
+
+    Attributes copy = map.immutableCopy();
+
+    assertThat(copy.get(stringKey("a"))).isEqualTo("v1");
+    assertThat(copy.get(longKey("b"))).isEqualTo(42L);
+  }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import com.google.common.testing.EqualsTester;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.List;
@@ -175,5 +176,20 @@ class AttributesMapTest {
 
     assertThat(copy.get(stringKey("a"))).isEqualTo("v1");
     assertThat(copy.get(longKey("b"))).isEqualTo(42L);
+  }
+
+  @Test
+  void equals_andHashCode() {
+    AttributesMap withK_v1a = AttributesMap.create(10, Integer.MAX_VALUE);
+    withK_v1a.put(stringKey("k"), "v1");
+    AttributesMap withK_v1b = AttributesMap.create(10, Integer.MAX_VALUE);
+    withK_v1b.put(stringKey("k"), "v1");
+    AttributesMap withK_v2 = AttributesMap.create(10, Integer.MAX_VALUE);
+    withK_v2.put(stringKey("k"), "v2");
+
+    new EqualsTester()
+        .addEqualityGroup(withK_v1a, withK_v1b)
+        .addEqualityGroup(withK_v2)
+        .testEquals();
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.sdk.common.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -22,4 +24,38 @@ class AttributesMapTest {
     assertThat(attributesMap.asMap())
         .containsOnly(entry(longKey("one"), 1L), entry(longKey("two"), 2L));
   }
+
+  @Test
+  void putSameKeyDifferentType_lastWins() {
+    AttributesMap map = AttributesMap.create(128, Integer.MAX_VALUE);
+    map.put(stringKey("k"), "hello");
+    map.put(booleanKey("k"), false);
+
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(booleanKey("k"))).isEqualTo(false);
+    assertThat(map.get(stringKey("k"))).isNull();
+  }
+
+  @Test
+  void putSameKeyDifferentType_doesNotConsumeExtraCapacity() {
+    AttributesMap map = AttributesMap.create(2, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+    map.put(booleanKey("a"), false); // overwrite — must not consume a new capacity slot
+    map.put(longKey("b"), 42L);
+
+    assertThat(map.size()).isEqualTo(2);
+    assertThat(map.get(booleanKey("a"))).isEqualTo(false);
+    assertThat(map.get(longKey("b"))).isEqualTo(42L);
+  }
+
+  @Test
+  void putSameKeyDifferentType_getByOldTypeMissAfterOverwrite() {
+    AttributesMap map = AttributesMap.create(128, Integer.MAX_VALUE);
+    map.put(stringKey("k"), "hello");
+    map.put(booleanKey("k"), true);
+
+    assertThat(map.get(stringKey("k"))).isNull();
+    assertThat(map.get(booleanKey("k"))).isEqualTo(true);
+  }
+
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -180,16 +180,13 @@ class AttributesMapTest {
 
   @Test
   void equals_andHashCode() {
-    AttributesMap withK_v1a = AttributesMap.create(10, Integer.MAX_VALUE);
-    withK_v1a.put(stringKey("k"), "v1");
-    AttributesMap withK_v1b = AttributesMap.create(10, Integer.MAX_VALUE);
-    withK_v1b.put(stringKey("k"), "v1");
-    AttributesMap withK_v2 = AttributesMap.create(10, Integer.MAX_VALUE);
-    withK_v2.put(stringKey("k"), "v2");
+    AttributesMap mapV1a = AttributesMap.create(10, Integer.MAX_VALUE);
+    mapV1a.put(stringKey("k"), "v1");
+    AttributesMap mapV1b = AttributesMap.create(10, Integer.MAX_VALUE);
+    mapV1b.put(stringKey("k"), "v1");
+    AttributesMap mapV2 = AttributesMap.create(10, Integer.MAX_VALUE);
+    mapV2.put(stringKey("k"), "v2");
 
-    new EqualsTester()
-        .addEqualityGroup(withK_v1a, withK_v1b)
-        .addEqualityGroup(withK_v2)
-        .testEquals();
+    new EqualsTester().addEqualityGroup(mapV1a, mapV1b).addEqualityGroup(mapV2).testEquals();
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.common.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.entry;
 import com.google.common.testing.EqualsTester;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -144,6 +146,30 @@ class AttributesMapTest {
     map.put(stringKey("k"), "hello");
 
     assertThat(map.get(stringKey("k"))).isEqualTo("hel");
+  }
+
+  @Test
+  void lengthLimit_failureDoesNotInsertPartialEntry() {
+    AttributesMap map = AttributesMap.create(10, 3);
+
+    assertThatThrownBy(() -> map.put(stringArrayKey("k"), throwingList()))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.asMap()).isEmpty();
+  }
+
+  @Test
+  void lengthLimit_failureDoesNotPartiallyOverwriteEntry() {
+    AttributesMap map = AttributesMap.create(10, 3);
+    map.put(stringKey("k"), "old");
+
+    assertThatThrownBy(() -> map.put(stringArrayKey("k"), throwingList()))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(stringKey("k"))).isEqualTo("old");
+    assertThat(map.get(stringArrayKey("k"))).isNull();
   }
 
   // ---- forEach ----
@@ -316,5 +342,29 @@ class AttributesMapTest {
     mapV2.put(stringKey("k"), "v2");
 
     new EqualsTester().addEqualityGroup(mapV1a, mapV1b).addEqualityGroup(mapV2).testEquals();
+  }
+
+  @Test
+  void equals_isSymmetricWithOtherAttributesImplementations() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("k"), "v");
+    Attributes attributes = Attributes.of(stringKey("k"), "v");
+
+    assertThat(map).isNotEqualTo(attributes);
+    assertThat(attributes).isNotEqualTo(map);
+  }
+
+  private static List<String> throwingList() {
+    return new AbstractList<String>() {
+      @Override
+      public String get(int index) {
+        throw new IllegalStateException("test");
+      }
+
+      @Override
+      public int size() {
+        return 1;
+      }
+    };
   }
 }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/internal/AttributesMapTest.java
@@ -9,12 +9,19 @@ import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.testing.EqualsTester;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 class AttributesMapTest {
@@ -176,6 +183,127 @@ class AttributesMapTest {
 
     assertThat(copy.get(stringKey("a"))).isEqualTo("v1");
     assertThat(copy.get(longKey("b"))).isEqualTo(42L);
+  }
+
+  // ---- hash collisions ----
+
+  @Test
+  void hashCollision_bothEntriesStoredAndRetrievable() {
+    // "Aa".hashCode() == "BB".hashCode() == 2112: collide in any table size.
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("Aa"), "v-Aa");
+    map.put(stringKey("BB"), "v-BB");
+
+    assertThat(map.size()).isEqualTo(2);
+    assertThat(map.get(stringKey("Aa"))).isEqualTo("v-Aa");
+    assertThat(map.get(stringKey("BB"))).isEqualTo("v-BB");
+  }
+
+  @Test
+  void findSlot_wrapsAroundEndOfTable() {
+    // capacity=4 => mask=7. "o" (111) and "w" (119) both hash to slot 7; the second wraps to 0.
+    AttributesMap map = AttributesMap.create(4, Integer.MAX_VALUE);
+    map.put(stringKey("o"), "v-o");
+    map.put(stringKey("w"), "v-w");
+
+    assertThat(map.size()).isEqualTo(2);
+    assertThat(map.get(stringKey("o"))).isEqualTo("v-o");
+    assertThat(map.get(stringKey("w"))).isEqualTo("v-w");
+  }
+
+  @Test
+  void grow_preservesEntriesIncludingPreExistingCollision() {
+    // capacity=20 => init=16 => grow triggers on 17th insert. "Aa"/"BB" collide at slot 0 both
+    // before and after grow (2112 & 31 == 2112 & 63 == 0), so rehash must preserve the probe path.
+    AttributesMap map = AttributesMap.create(20, Integer.MAX_VALUE);
+    map.put(stringKey("Aa"), "v-Aa");
+    map.put(stringKey("BB"), "v-BB");
+    for (int i = 0; i < 18; i++) {
+      map.put(stringKey("k" + i), "v" + i);
+    }
+
+    assertThat(map.size()).isEqualTo(20);
+    assertThat(map.get(stringKey("Aa"))).isEqualTo("v-Aa");
+    assertThat(map.get(stringKey("BB"))).isEqualTo("v-BB");
+    for (int i = 0; i < 18; i++) {
+      assertThat(map.get(stringKey("k" + i))).isEqualTo("v" + i);
+    }
+  }
+
+  // ---- concurrent modification detection ----
+
+  @Test
+  void forEach_throwsCmeOnConcurrentModification() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+    map.put(stringKey("b"), "v2");
+
+    assertThatThrownBy(() -> map.forEach((k, v) -> map.put(stringKey("c"), "v3")))
+        .isInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void forEach_overwriteDuringIterationThrowsCme() {
+    // Overwrite (no size change) still bumps modCount.
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+
+    assertThatThrownBy(() -> map.forEach((k, v) -> map.put(stringKey("a"), "v2")))
+        .isInstanceOf(ConcurrentModificationException.class);
+  }
+
+  @Test
+  void forEach_noModification_doesNotThrow() {
+    AttributesMap map = AttributesMap.create(10, Integer.MAX_VALUE);
+    map.put(stringKey("a"), "v1");
+    map.put(stringKey("b"), "v2");
+
+    map.forEach((k, v) -> {});
+  }
+
+  // ---- fuzz ----
+
+  @Test
+  void fuzz_matchesReferenceHashMap() {
+    // Random puts vs reference HashMap. Exercises grow, overwrites, and type-varying puts to
+    // the same name. Fixed seed for reproducibility.
+    long seed = 0xC0FFEEL;
+    Random r = new Random(seed);
+    int capacity = 1000;
+    int ops = 5000;
+    int namePoolSize = 200; // ~25 overwrites per name on average
+
+    AttributesMap map = AttributesMap.create(capacity, Integer.MAX_VALUE);
+    Map<String, Map.Entry<AttributeKey<?>, Object>> reference = new HashMap<>();
+
+    for (int i = 0; i < ops; i++) {
+      String name = "key" + r.nextInt(namePoolSize);
+      AttributeKey<?> key;
+      Object value;
+      switch (r.nextInt(3)) {
+        case 0:
+          key = stringKey(name);
+          value = "s" + i;
+          break;
+        case 1:
+          key = longKey(name);
+          value = (long) i;
+          break;
+        default:
+          key = booleanKey(name);
+          value = (i & 1) == 0;
+          break;
+      }
+      map.put(key, value);
+      reference.put(name, new AbstractMap.SimpleImmutableEntry<>(key, value));
+    }
+
+    assertThat(map.size()).isEqualTo(reference.size());
+    for (Map.Entry<String, Map.Entry<AttributeKey<?>, Object>> refEntry : reference.entrySet()) {
+      AttributeKey<?> expectedKey = refEntry.getValue().getKey();
+      Object expectedValue = refEntry.getValue().getValue();
+      assertThat(map.get(expectedKey)).as("key=%s", expectedKey).isEqualTo(expectedValue);
+    }
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkSpanBuilderTest.java
@@ -1172,4 +1172,25 @@ class SdkSpanBuilderTest {
             })
         .doesNotThrowAnyException();
   }
+
+  @Test
+  void setAttribute_sameKeyDifferentType_lastValueWins() {
+    // Regression test for https://github.com/open-telemetry/opentelemetry-java/issues/7897
+    // Setting the same string key with different types must overwrite, not accumulate.
+    SdkSpan span =
+        (SdkSpan)
+            sdkTracer
+                .spanBuilder("test")
+                .setAttribute("key", "string_value")
+                .setAttribute("key", false)
+                .startSpan();
+    try {
+      Attributes attributes = span.toSpanData().getAttributes();
+      assertThat(attributes.size()).isEqualTo(1);
+      assertThat(attributes.get(booleanKey("key"))).isEqualTo(false);
+      assertThat(attributes.get(stringKey("key"))).isNull();
+    } finally {
+      span.end();
+    }
+  }
 }


### PR DESCRIPTION
Fixes the Issue #7897

TLDR; Current AttributesMap does not fully comply with that part of spec:
> “Setting an attribute with the same key as an existing attribute SHOULD overwrite the existing attribute’s value.”
https://opentelemetry.io/docs/specs/otel/trace/api/#set-attributes

## Problem

`AttributesMap` extended `HashMap<AttributeKey<?>, Object>`, using `AttributeKey` as the map
key. Because `AttributeKey.equals()` includes the attribute type, two attributes with the same
name but different types (e.g. `stringKey("http.method")` and `longKey("http.method")`) were
stored as separate entries. 
This violated the OpenTelemetry specification, which requires that
attribute name alone determines identity — last write wins regardless of type.

## Solution

### Correctness fix

Replace the `HashMap<AttributeKey<?>, Object>` backing store with a string-keyed map so that
`put("http.method", String)` followed by `put("http.method", Long)` results in exactly one entry
(the Long value), consuming only one capacity slot.

The first implementations were based on HashMap/LinkedHashMap (2nd performed better once forEach was included in the benchmarks), but they introduced another issue — the fixed `AttributesMap` performed ~40-80% **worse** than baseline.

### putThenForEach — LinkedHashMap fix vs baseline

| n | baseline | LHM fix | LHM vs baseline |
|---|----------|---------|-----------------|
| 4 | 39.3 ± 1.9 | 50.1 ± 0.3 | **+27%** |
| 16 | 156.0 ± 2.4 | 222.8 ± 9.0 | **+43%** |
| 20 | 179.7 ± 3.9 | 261.7 ± 7.2 | **+46%** |
| 32 | 346.4 ± 20.8 | 462.6 ± 4.7 | **+34%** |
| 128 | 1465.5 ± 83.6 | 2085.2 ± 106.3 | **+42%** |


Therefore, I started looking for a better solution that would preserve the required last-value-wins semantics without introducing a performance regression.

LinkedHashMap implementation can be observed in the previous commit — https://github.com/EvgeniiR/opentelemetry-java/blob/d7df58af76e693aa1fe897d2757e2bdb50ab9798/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java

Final solution is described below.

### Performance optimization

Instead of `LinkedHashMap<String, AttributeEntry>`, use parallel arrays with an open-addressing
`int[]` hash table (linear probing, load factor ≤ 0.5):

```
int[]           hashTable   — slot → entryIndex+1 (0 = empty, JVM zero-init)
String[]        entryNames  — for hash lookup
AttributeKey[]  entryKeys   — for get() type check and forEach()
Object[]        entryValues — attribute values
```

`forEach` becomes a tight sequential array loop with no pointer chasing, directly benefiting the export.

## Benchmark results (avgt ns/op, lower is better)

### putThenForEach — N unique puts + 1 forEach (dominant production path)

| n | baseline | PA | PA vs base |
|---|----------|----|------------|
| 4 | 39.3 ± 1.9 | 39.9 ± 0.6 | +2% |
| 16 | 156.0 ± 2.4 | **135.6 ± 7.7** | **−13%** |
| 20 | 179.7 ± 3.9 | 241.3 ± 11.0 | **+34%** |
| 32 | 346.4 ± 20.8 | 346.4 ± 14.4 | 0% |
| 128 | 1465.5 ± 83.6 | 2047.5 ± 52.3 | **+40%** |

The small-span case is effectively unchanged, and 16 attributes improve. The 20- and
128-attribute cases regress: the parallel-array implementation starts with arrays
for 16 entries and grows through 32 and 64 before reaching 128.

### AttributesMapBenchmark — putThenForEach memory allocation (gc.alloc.rate.norm, B/op, lower is better)

| n | baseline | PA | delta |
|---|----------|----|-------|
| 4 | 272 | 384 | **+41%** |
| 16 | 800 | 384 | **−52%** |
| 20 | 928 | 1136 | **+22%** |
| 32 | 1584 | 1136 | **−28%** |
| 128 | 6224 | 5104 | **−18%** |

A smaller initial array would improve `n=4` case, but would move the
resize cost to spans with 16–20 attributes.