### PR TITLE
Align env carrier docs with latest spec

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetter.java
@@ -38,8 +38,8 @@ import javax.annotation.Nullable;
  *   <li>Prepends an underscore if the result would otherwise start with an ASCII digit
  * </ul>
  *
- * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing
- * is the responsibility of the propagator, not this carrier.
+ * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing is
+ * the responsibility of the propagator, not this carrier.
  *
  * <p>If the underlying carrier performs case-insensitive lookup, as Windows environment variable
  * lookup does, reading a normalized key may resolve an entry whose stored name differs only by

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetter.java
@@ -16,11 +16,11 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
- * A {@link TextMapGetter} that extracts context from a map carrier, intended for use with
- * environment variables in child processes.
+ * A {@link TextMapGetter} that extracts context from a map carrier containing environment
+ * variables.
  *
- * <p>This is useful when a child process needs to extract propagated context from its environment.
- * For example:
+ * <p>This is useful when a child process extracts propagated context from environment variables
+ * that an application placed in the child process environment. For example:
  *
  * <pre>{@code
  * Map<String, String> env = System.getenv();
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  *     .extract(Context.current(), env, EnvironmentGetter.getInstance());
  * }</pre>
  *
- * <p>This getter automatically sanitizes keys to match environment variable naming conventions:
+ * <p>This getter automatically normalizes keys as environment variable names:
  *
  * <ul>
  *   <li>Replaces an empty key with a single underscore ({@code _})
@@ -38,10 +38,12 @@ import javax.annotation.Nullable;
  *   <li>Prepends an underscore if the result would otherwise start with an ASCII digit
  * </ul>
  *
- * <p>Values are validated to contain only characters valid in HTTP header fields per <a
- * href="https://datatracker.ietf.org/doc/html/rfc9110#section-5.5">RFC 9110</a> (visible ASCII
- * characters, space, and horizontal tab). Values containing invalid characters are treated as
- * absent and {@code null} is returned.
+ * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing
+ * is the responsibility of the propagator, not this carrier.
+ *
+ * <p>If the underlying carrier performs case-insensitive lookup, as Windows environment variable
+ * lookup does, reading a normalized key may resolve an entry whose stored name differs only by
+ * case.
  *
  * @see <a href=
  *     "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md#format-restrictions">Environment
@@ -66,7 +68,7 @@ public final class EnvironmentGetter implements TextMapGetter<Map<String, String
       LOGGER.log(
           Level.WARNING,
           "keys() called on EnvironmentGetter. "
-              + "This may produce unexpected results with propagators which depend on case sensitivity or special characters in keys.",
+              + "This getter returns only normalized environment variable names, which may produce unexpected results with propagators that depend on original key casing or special characters.",
           new Throwable());
     }
     if (carrier == null) {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetter.java
@@ -33,8 +33,8 @@ import javax.annotation.Nullable;
  *   <li>If the result would start with a digit, an underscore is prepended
  * </ul>
  *
- * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing
- * is the responsibility of the propagator, not this carrier.
+ * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing is
+ * the responsibility of the propagator, not this carrier.
  *
  * <p><strong>Size limitations:</strong> Environment variable sizes are platform-dependent (e.g.,
  * Windows limits name=value pairs to 32,767 characters). Callers are responsible for being aware of

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetter.java
@@ -11,9 +11,9 @@ import javax.annotation.Nullable;
 
 /**
  * A {@link TextMapSetter} that injects context into a map carrier, intended for use with
- * environment variables when spawning child processes.
+ * environment variables when applications spawn child processes.
  *
- * <p>This is useful when an application needs to propagate context to sub-processes via their
+ * <p>This is useful when an application needs to propagate context to a child process via its
  * environment. For example, when using {@link ProcessBuilder}:
  *
  * <pre>{@code
@@ -23,8 +23,7 @@ import javax.annotation.Nullable;
  * processBuilder.environment().putAll(env);
  * }</pre>
  *
- * <p>This setter automatically sanitizes keys to be compatible with environment variable naming
- * conventions:
+ * <p>This setter automatically normalizes keys as environment variable names:
  *
  * <ul>
  *   <li>An empty key is replaced with a single underscore ({@code _})
@@ -34,10 +33,8 @@ import javax.annotation.Nullable;
  *   <li>If the result would start with a digit, an underscore is prepended
  * </ul>
  *
- * <p>Values are validated to contain only characters valid in HTTP header fields per <a
- * href="https://datatracker.ietf.org/doc/html/rfc9110#section-5.5">RFC 9110</a> (visible ASCII
- * characters, space, and horizontal tab). Values containing invalid characters are silently
- * skipped.
+ * <p>Values are treated as opaque strings. Any propagation-format-specific validation or parsing
+ * is the responsibility of the propagator, not this carrier.
  *
  * <p><strong>Size limitations:</strong> Environment variable sizes are platform-dependent (e.g.,
  * Windows limits name=value pairs to 32,767 characters). Callers are responsible for being aware of
@@ -68,9 +65,10 @@ public final class EnvironmentSetter implements TextMapSetter<Map<String, String
   }
 
   /**
-   * Determine if a key is a valid normalized environment variable name. Returns {@code true} if
-   * {@code key} is non-empty, contains only uppercase ASCII letters, digits, and underscores, and
-   * does not start with a digit.
+   * Returns {@code true} if {@code key} is already a normalized environment variable name.
+   *
+   * <p>A normalized name is non-empty, contains only uppercase ASCII letters, digits, and
+   * underscores, and does not start with a digit.
    */
   static boolean isNormalizedKey(String key) {
     if (key.isEmpty()) {
@@ -90,7 +88,7 @@ public final class EnvironmentSetter implements TextMapSetter<Map<String, String
   }
 
   /**
-   * Normalizes a key to be a valid environment variable name.
+   * Normalizes a key as an environment variable name.
    *
    * <ul>
    *   <li>An empty key is replaced with a single underscore ({@code _})

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetterTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/propagation/EnvironmentGetterTest.java
@@ -49,7 +49,7 @@ class EnvironmentGetterTest {
     assertThat(EnvironmentGetter.getInstance().get(carrier, "otel.trace.id")).isEqualTo("val1");
     assertThat(EnvironmentGetter.getInstance().get(carrier, "otel-baggage-key")).isEqualTo("val2");
     assertThat(EnvironmentGetter.getInstance().get(carrier, "")).isEqualTo("val3");
-    // Carrier entries with unnormalized keys are not enumerated.
+    // Carrier entries with unnormalized names are not consulted by get().
     assertThat(EnvironmentGetter.getInstance().get(carrier, "otel-unreachable-key")).isNull();
   }
 
@@ -78,7 +78,7 @@ class EnvironmentGetterTest {
     assertThat(EnvironmentGetter.getInstance().keys(null)).isEmpty();
 
     assertThat(logCapturer.size()).isEqualTo(1);
-    logCapturer.assertContains("keys() called on EnvironmentGetter");
+    logCapturer.assertContains("returns only normalized environment variable names");
   }
 
   @Test
@@ -90,6 +90,7 @@ class EnvironmentGetterTest {
     carrier.put("KEY4", "value\u0000with\u0001control");
     carrier.put("KEY5", "value\nwith\nnewlines");
     carrier.put("KEY6", "value\u0080non-ascii");
+    carrier.put("KEY7", "");
 
     assertThat(EnvironmentGetter.getInstance().get(carrier, "key1")).isEqualTo("simple-value");
     assertThat(EnvironmentGetter.getInstance().get(carrier, "key2")).isEqualTo("value with spaces");
@@ -100,6 +101,7 @@ class EnvironmentGetterTest {
         .isEqualTo("value\nwith\nnewlines");
     assertThat(EnvironmentGetter.getInstance().get(carrier, "key6"))
         .isEqualTo("value\u0080non-ascii");
+    assertThat(EnvironmentGetter.getInstance().get(carrier, "key7")).isEmpty();
   }
 
   @Test

--- a/api/incubator/src/test/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetterTest.java
+++ b/api/incubator/src/test/java/io/opentelemetry/api/incubator/propagation/EnvironmentSetterTest.java
@@ -30,7 +30,7 @@ class EnvironmentSetterTest {
   }
 
   @Test
-  void set_sanitization() {
+  void set_normalization() {
     Map<String, String> carrier = new HashMap<>();
     EnvironmentSetter.getInstance().set(carrier, "otel.trace.id", "val1");
     EnvironmentSetter.getInstance().set(carrier, "otel-baggage-key", "val2");
@@ -59,6 +59,7 @@ class EnvironmentSetterTest {
     EnvironmentSetter.getInstance().set(carrier, "key4", "value\u0000with\u0001control");
     EnvironmentSetter.getInstance().set(carrier, "key5", "value\nwith\nnewlines");
     EnvironmentSetter.getInstance().set(carrier, "key6", "value\u0080non-ascii");
+    EnvironmentSetter.getInstance().set(carrier, "key7", "");
 
     assertThat(carrier).containsEntry("KEY1", "simple-value");
     assertThat(carrier).containsEntry("KEY2", "value with spaces");
@@ -66,6 +67,7 @@ class EnvironmentSetterTest {
     assertThat(carrier).containsEntry("KEY4", "value\u0000with\u0001control");
     assertThat(carrier).containsEntry("KEY5", "value\nwith\nnewlines");
     assertThat(carrier).containsEntry("KEY6", "value\u0080non-ascii");
+    assertThat(carrier).containsEntry("KEY7", "");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Align the incubator environment variable carrier docs and tests with the latest spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md.

The underlying normalization behavior is unchanged. This change removes stale documentation that claimed RFC 9110 value validation, clarifies that carrier values are treated as opaque strings, and documents the case-insensitive lookup note for platforms such as Windows.

## Changes

- Update `EnvironmentGetter` and `EnvironmentSetter` Javadocs to use the latest env-carrier terminology around key normalization.
- Remove stale value-validation language and clarify that propagators, not the carrier, are responsible for format-specific parsing and validation.
- Tighten the `EnvironmentGetter.keys()` warning so it explicitly describes normalized-name enumeration.
- Rename and update tests to reflect normalization terminology.
- Add empty-string value coverage while preserving opaque value pass-through assertions.