### PR TITLE
Configurable benchmark path

### DIFF
--- a/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
@@ -63,14 +63,6 @@ jmh {
   }
 }
 
-// Copy JSON results to a shared directory for later comparison:
-//   -PjmhResultsDir=scratch/benchmarks        target directory
-//   -PjmhLabel=baseline                       filename stem (default: sanitized project path, e.g. sdk-all)
-//
-// Example:
-//   ./gradlew :sdk:all:jmh -PjmhIncludeSingleClass=SpanRecordBenchmark \
-//       -PjmhResultsDir=scratch/benchmarks -PjmhLabel=baseline
-// produces: scratch/benchmarks/baseline.json
 val jmhResultsDir = project.findProperty("jmhResultsDir") as String?
 if (jmhResultsDir != null) {
   val jmhLabel = (project.findProperty("jmhLabel") as String?)

--- a/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.jmh-conventions.gradle.kts
@@ -63,6 +63,31 @@ jmh {
   }
 }
 
+// Copy JSON results to a shared directory for later comparison:
+//   -PjmhResultsDir=scratch/benchmarks        target directory
+//   -PjmhLabel=baseline                       filename stem (default: sanitized project path, e.g. sdk-all)
+//
+// Example:
+//   ./gradlew :sdk:all:jmh -PjmhIncludeSingleClass=SpanRecordBenchmark \
+//       -PjmhResultsDir=scratch/benchmarks -PjmhLabel=baseline
+// produces: scratch/benchmarks/baseline.json
+val jmhResultsDir = project.findProperty("jmhResultsDir") as String?
+if (jmhResultsDir != null) {
+  val jmhLabel = (project.findProperty("jmhLabel") as String?)
+    ?: project.path.trimStart(':').replace(':', '-').ifEmpty { project.name }
+
+  val jmhCopyResults = tasks.register<Copy>("jmhCopyResults") {
+    description = "Copies JMH JSON results to jmhResultsDir for cross-run comparison."
+    from(layout.buildDirectory.file("results/jmh/results.json"))
+    into(rootProject.file(jmhResultsDir))
+    rename { "${jmhLabel}.json" }
+  }
+
+  tasks.named("jmh") {
+    finalizedBy(jmhCopyResults)
+  }
+}
+
 jmhReport {
   val buildDirectory = layout.buildDirectory.asFile.get()
   jmhResultPath = file("$buildDirectory/results/jmh/results.json").absolutePath

--- a/docs/knowledge/other-tasks.md
+++ b/docs/knowledge/other-tasks.md
@@ -23,6 +23,8 @@ The following JMH parameters can be configured via `-P` flags:
 | `-PjmhTime=<duration>` | Time per measurement iteration | `-PjmhTime=2s` |
 | `-PjmhWarmupIterations=<n>` | Warmup iterations | `-PjmhWarmupIterations=3` |
 | `-PjmhWarmup=<duration>` | Time per warmup iteration | `-PjmhWarmup=1s` |
+| `-PjmhResultsDir=<path>` | Copy JSON results to this directory after the run | `-PjmhResultsDir=scratch/benchmarks` |
+| `-PjmhLabel=<stem>` | Filename stem for the copied JSON; only used when `jmhResultsDir` is set (default: sanitized project path, e.g. `sdk-all`) | `-PjmhLabel=baseline` |
 
 ## Composite builds
 


### PR DESCRIPTION
I frequently have to run before / after benchmarks, then compare the results. I have a local comparison script which takes two JSON jmh output files (before and after) and spits out a formatted markdown table summarizing the diff of each case. Its inconvenient to make a copy of the JSON jmh output each time. I'd rather just configure the tooling to put the output where I want it.

Add new jmh options:

- -PjmhResultsDir: directory to put the JSON jmh output
- -PjmhLabel: filename for the JSON jmh output