### PR TITLE
Only set valuesRecorded if its false

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/AggregatorHandle.java
@@ -107,7 +107,9 @@ public abstract class AggregatorHandle<T extends PointData> {
     throwUnsupportedIfNull(this.longReservoirFactory, UNSUPPORTED_LONG_MESSAGE)
         .offerLongMeasurement(value, attributes, context);
     doRecordLong(value);
-    valuesRecorded = true;
+    if (!valuesRecorded) {
+      valuesRecorded = true;
+    }
   }
 
   /**
@@ -122,7 +124,9 @@ public abstract class AggregatorHandle<T extends PointData> {
     throwUnsupportedIfNull(this.doubleReservoirFactory, UNSUPPORTED_DOUBLE_MESSAGE)
         .offerDoubleMeasurement(value, attributes, context);
     doRecordDouble(value);
-    valuesRecorded = true;
+    if (!valuesRecorded) {
+      valuesRecorded = true;
+    }
   }
 
   /**


### PR DESCRIPTION
Reading a volatile is cheap. Writing it under contention, even when the value doesn't change, is expensive. 

This simple change to read before write yields huge perf improvement for contended cases:

| Benchmark | Threads | Temporality | Cardinality | Instrument | Baseline (ops/s) | After (ops/s) | Δ ops/s | Δ % |
| :--- | ---: | :--- | ---: | :--- | ---: | ---: | ---: | ---: |
| threads1 | 1 | CUMULATIVE | 1 | COUNTER_SUM | 158,568,637 | 157,745,534 | -823,103 | -0.5% |
| threads1 | 1 | CUMULATIVE | 1 | GAUGE_LAST_VALUE | 84,391,938 | 65,769,849 | -18,622,089 | -22.1% |
| threads1 | 1 | CUMULATIVE | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 42,063,874 | 37,577,277 | -4,486,597 | -10.7% |
| threads1 | 1 | CUMULATIVE | 1 | HISTOGRAM_EXPLICIT | 96,618,066 | 92,650,458 | -3,967,609 | -4.1% |
| threads1 | 1 | CUMULATIVE | 1 | UP_DOWN_COUNTER_SUM | 155,066,532 | 161,825,761 | +6,759,229 | +4.4% |
| threads1 | 1 | CUMULATIVE | 128 | COUNTER_SUM | 113,296,533 | 115,410,215 | +2,113,682 | +1.9% |
| threads1 | 1 | CUMULATIVE | 128 | GAUGE_LAST_VALUE | 133,640,492 | 112,619,646 | -21,020,846 | -15.7% |
| threads1 | 1 | CUMULATIVE | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 42,456,092 | 42,146,264 | -309,828 | -0.7% |
| threads1 | 1 | CUMULATIVE | 128 | HISTOGRAM_EXPLICIT | 68,795,746 | 74,813,002 | +6,017,255 | +8.7% |
| threads1 | 1 | CUMULATIVE | 128 | UP_DOWN_COUNTER_SUM | 110,120,331 | 97,792,286 | -12,328,045 | -11.2% |
| threads1 | 1 | DELTA | 1 | COUNTER_SUM | 116,642,454 | 90,174,325 | -26,468,129 | -22.7% |
| threads1 | 1 | DELTA | 1 | GAUGE_LAST_VALUE | 41,310,133 | 38,184,273 | -3,125,860 | -7.6% |
| threads1 | 1 | DELTA | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 42,801,022 | 39,383,490 | -3,417,532 | -8.0% |
| threads1 | 1 | DELTA | 1 | HISTOGRAM_EXPLICIT | 58,788,702 | 61,343,010 | +2,554,308 | +4.3% |
| threads1 | 1 | DELTA | 1 | UP_DOWN_COUNTER_SUM | 113,438,421 | 84,526,251 | -28,912,169 | -25.5% |
| threads1 | 1 | DELTA | 128 | COUNTER_SUM | 90,648,633 | 90,330,455 | -318,178 | -0.4% |
| threads1 | 1 | DELTA | 128 | GAUGE_LAST_VALUE | 30,048,822 | 30,424,414 | +375,592 | +1.2% |
| threads1 | 1 | DELTA | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 40,351,625 | 40,730,215 | +378,590 | +0.9% |
| threads1 | 1 | DELTA | 128 | HISTOGRAM_EXPLICIT | 68,966,473 | 68,001,089 | -965,384 | -1.4% |
| threads1 | 1 | DELTA | 128 | UP_DOWN_COUNTER_SUM | 96,706,975 | 94,746,379 | -1,960,596 | -2.0% |
| threads4 | 4 | CUMULATIVE | 1 | COUNTER_SUM | 71,299,570 | 533,356,066 | +462,056,496 | **+648.0%** |
| threads4 | 4 | CUMULATIVE | 1 | GAUGE_LAST_VALUE | 31,089,443 | 43,956,894 | +12,867,451 | +41.4% |
| threads4 | 4 | CUMULATIVE | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 18,315,218 | 18,228,940 | -86,278 | -0.5% |
| threads4 | 4 | CUMULATIVE | 1 | HISTOGRAM_EXPLICIT | 17,130,737 | 22,713,877 | +5,583,140 | +32.6% |
| threads4 | 4 | CUMULATIVE | 1 | UP_DOWN_COUNTER_SUM | 67,441,580 | 538,397,008 | +470,955,428 | **+698.3%** |
| threads4 | 4 | CUMULATIVE | 128 | COUNTER_SUM | 101,917,926 | 213,724,611 | +111,806,685 | **+109.7%** |
| threads4 | 4 | CUMULATIVE | 128 | GAUGE_LAST_VALUE | 99,772,907 | 176,344,073 | +76,571,166 | **+76.7%** |
| threads4 | 4 | CUMULATIVE | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 69,414,310 | 76,851,238 | +7,436,928 | +10.7% |
| threads4 | 4 | CUMULATIVE | 128 | HISTOGRAM_EXPLICIT | 71,859,876 | 82,288,364 | +10,428,488 | +14.5% |
| threads4 | 4 | CUMULATIVE | 128 | UP_DOWN_COUNTER_SUM | 102,675,867 | 165,755,957 | +63,080,090 | **+61.4%** |
| threads4 | 4 | DELTA | 1 | COUNTER_SUM | 17,860,366 | 38,440,179 | +20,579,813 | **+115.2%** |
| threads4 | 4 | DELTA | 1 | GAUGE_LAST_VALUE | 18,414,726 | 15,757,082 | -2,657,643 | -14.4% |
| threads4 | 4 | DELTA | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 10,272,237 | 13,658,068 | +3,385,831 | +33.0% |
| threads4 | 4 | DELTA | 1 | HISTOGRAM_EXPLICIT | 12,299,067 | 13,142,512 | +843,446 | +6.9% |
| threads4 | 4 | DELTA | 1 | UP_DOWN_COUNTER_SUM | 17,354,541 | 33,054,925 | +15,700,383 | **+90.5%** |
| threads4 | 4 | DELTA | 128 | COUNTER_SUM | 70,640,757 | 92,842,661 | +22,201,904 | +31.4% |
| threads4 | 4 | DELTA | 128 | GAUGE_LAST_VALUE | 52,635,745 | 54,919,519 | +2,283,774 | +4.3% |
| threads4 | 4 | DELTA | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 52,465,326 | 57,485,882 | +5,020,556 | +9.6% |
| threads4 | 4 | DELTA | 128 | HISTOGRAM_EXPLICIT | 53,967,236 | 58,726,086 | +4,758,850 | +8.8% |
| threads4 | 4 | DELTA | 128 | UP_DOWN_COUNTER_SUM | 68,654,779 | 88,332,691 | +19,677,912 | +28.7% |

It provides even bigger wins for #8527 contended test cases. I.e. 