### PR TITLE
Last value aggregations use volatile instead of atomics

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregator.java
@@ -21,9 +21,6 @@ import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoirFactory;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -93,8 +90,9 @@ public final class DoubleLastValueAggregator implements Aggregator<DoublePointDa
   }
 
   static final class Handle extends AggregatorHandle<DoublePointData> {
-    private final AtomicReference<AtomicLong> current = new AtomicReference<>(null);
-    private final AtomicLong valueBits = new AtomicLong();
+    // AggregatorHandle#valuesRecorded records whether any values have been recorded so this field
+    // never needs to be reset on collect. Stale values are never observed.
+    private volatile double currentValue;
 
     // Only used when memoryMode is REUSABLE_DATA
     @Nullable private final MutableDoublePointData reusablePoint;
@@ -116,9 +114,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoublePointDa
         Attributes attributes,
         List<DoubleExemplarData> exemplars,
         boolean reset) {
-      AtomicLong valueBits =
-          Objects.requireNonNull(reset ? this.current.getAndSet(null) : this.current.get());
-      double value = Double.longBitsToDouble(valueBits.get());
+      double value = this.currentValue;
       if (reusablePoint != null) {
         reusablePoint.set(startEpochNanos, epochNanos, attributes, value, exemplars);
         return reusablePoint;
@@ -130,8 +126,7 @@ public final class DoubleLastValueAggregator implements Aggregator<DoublePointDa
 
     @Override
     protected void doRecordDouble(double value) {
-      valueBits.set(Double.doubleToLongBits(value));
-      current.compareAndSet(null, valueBits);
+      this.currentValue = value;
     }
   }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongLastValueAggregator.java
@@ -21,9 +21,6 @@ import io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarReservoirFactory;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -89,8 +86,9 @@ public final class LongLastValueAggregator implements Aggregator<LongPointData> 
   }
 
   static final class Handle extends AggregatorHandle<LongPointData> {
-    private final AtomicReference<AtomicLong> current = new AtomicReference<>(null);
-    private final AtomicLong value = new AtomicLong();
+    // AggregatorHandle#valuesRecorded records whether any values have been recorded so this field
+    // never needs to be reset on collect. Stale values are never observed.
+    private volatile long currentValue;
 
     // Only used when memoryMode is REUSABLE_DATA
     @Nullable private final MutableLongPointData reusablePoint;
@@ -112,22 +110,19 @@ public final class LongLastValueAggregator implements Aggregator<LongPointData> 
         Attributes attributes,
         List<LongExemplarData> exemplars,
         boolean reset) {
-      AtomicLong value =
-          Objects.requireNonNull(reset ? this.current.getAndSet(null) : this.current.get());
-      long currentValue = value.get();
+      long value = this.currentValue;
       if (reusablePoint != null) {
-        reusablePoint.set(startEpochNanos, epochNanos, attributes, currentValue, exemplars);
+        reusablePoint.set(startEpochNanos, epochNanos, attributes, value, exemplars);
         return reusablePoint;
       } else {
         return ImmutableLongPointData.create(
-            startEpochNanos, epochNanos, attributes, currentValue, exemplars);
+            startEpochNanos, epochNanos, attributes, value, exemplars);
       }
     }
 
     @Override
     protected void doRecordLong(long value) {
-      this.value.set(value);
-      this.current.compareAndSet(null, this.value);
+      this.currentValue = value;
     }
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleLastValueAggregatorTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.sdk.metrics.internal.aggregator;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -274,14 +273,5 @@ class DoubleLastValueAggregatorTest {
         handle.aggregateThenMaybeReset(0, 10, Attributes.empty(), /* reset= */ true);
 
     assertThat(pointData).isSameAs(pointDataWithReset);
-  }
-
-  @Test
-  void testNullPointerExceptionWhenUnset() {
-    init(MemoryMode.REUSABLE_DATA);
-    AggregatorHandle<DoublePointData> handle = aggregator.createHandle(0);
-    assertThatThrownBy(
-            () -> handle.aggregateThenMaybeReset(0, 10, Attributes.empty(), /* reset= */ true))
-        .isInstanceOf(NullPointerException.class);
   }
 }


### PR DESCRIPTION
Huge win in last value aggregation performance by ussing a volatile instead of atomics. The realization is that atomics aren't required because the tracking of whether values are recorded is done in the parent `AggregatorHandle`, meaning the actual aggregator itself is never collected if there are no values. Thus it doesn't need to reset to an "unset" state.

Hopefully this also reduces the variance of gauge performance cases, which have been unreliable. 

| Benchmark | Threads | Temporality | Cardinality | Instrument | Baseline (ops/s) | After (ops/s) | Δ ops/s | Δ % |
| :--- | ---: | :--- | ---: | :--- | ---: | ---: | ---: | ---: |
| threads1 | 1 | CUMULATIVE | 1 | COUNTER_SUM | 158,568,637 | 157,302,401 | -1,266,235 | -0.8% |
| threads1 | 1 | CUMULATIVE | 1 | GAUGE_LAST_VALUE | 84,391,938 | 177,561,358 | +93,169,419 | **+110.4%** |
| threads1 | 1 | CUMULATIVE | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 42,063,874 | 39,226,998 | -2,836,876 | -6.7% |
| threads1 | 1 | CUMULATIVE | 1 | HISTOGRAM_EXPLICIT | 96,618,066 | 97,039,201 | +421,135 | +0.4% |
| threads1 | 1 | CUMULATIVE | 1 | UP_DOWN_COUNTER_SUM | 155,066,532 | 155,220,291 | +153,759 | +0.1% |
| threads1 | 1 | CUMULATIVE | 128 | COUNTER_SUM | 113,296,533 | 112,512,651 | -783,882 | -0.7% |
| threads1 | 1 | CUMULATIVE | 128 | GAUGE_LAST_VALUE | 133,640,492 | 143,589,227 | +9,948,735 | +7.4% |
| threads1 | 1 | CUMULATIVE | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 42,456,092 | 41,839,011 | -617,081 | -1.5% |
| threads1 | 1 | CUMULATIVE | 128 | HISTOGRAM_EXPLICIT | 68,795,746 | 68,355,287 | -440,459 | -0.6% |
| threads1 | 1 | CUMULATIVE | 128 | UP_DOWN_COUNTER_SUM | 110,120,331 | 109,630,704 | -489,627 | -0.4% |
| threads1 | 1 | DELTA | 1 | COUNTER_SUM | 116,642,454 | 115,575,628 | -1,066,826 | -0.9% |
| threads1 | 1 | DELTA | 1 | GAUGE_LAST_VALUE | 41,310,133 | 124,167,205 | +82,857,072 | **+200.6%** |
| threads1 | 1 | DELTA | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 42,801,022 | 41,251,394 | -1,549,628 | -3.6% |
| threads1 | 1 | DELTA | 1 | HISTOGRAM_EXPLICIT | 58,788,702 | 61,217,877 | +2,429,175 | +4.1% |
| threads1 | 1 | DELTA | 1 | UP_DOWN_COUNTER_SUM | 113,438,421 | 112,345,626 | -1,092,794 | -1.0% |
| threads1 | 1 | DELTA | 128 | COUNTER_SUM | 90,648,633 | 89,443,733 | -1,204,900 | -1.3% |
| threads1 | 1 | DELTA | 128 | GAUGE_LAST_VALUE | 30,048,822 | 104,916,888 | +74,868,066 | **+249.2%** |
| threads1 | 1 | DELTA | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 40,351,625 | 40,868,681 | +517,056 | +1.3% |
| threads1 | 1 | DELTA | 128 | HISTOGRAM_EXPLICIT | 68,966,473 | 69,167,930 | +201,457 | +0.3% |
| threads1 | 1 | DELTA | 128 | UP_DOWN_COUNTER_SUM | 96,706,975 | 93,188,151 | -3,518,824 | -3.6% |
| threads4 | 4 | CUMULATIVE | 1 | COUNTER_SUM | 71,299,570 | 72,529,285 | +1,229,715 | +1.7% |
| threads4 | 4 | CUMULATIVE | 1 | GAUGE_LAST_VALUE | 31,089,443 | 66,748,976 | +35,659,533 | **+114.7%** |
| threads4 | 4 | CUMULATIVE | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 18,315,218 | 16,773,898 | -1,541,319 | -8.4% |
| threads4 | 4 | CUMULATIVE | 1 | HISTOGRAM_EXPLICIT | 17,130,737 | 20,587,648 | +3,456,911 | +20.2% |
| threads4 | 4 | CUMULATIVE | 1 | UP_DOWN_COUNTER_SUM | 67,441,580 | 70,858,140 | +3,416,560 | +5.1% |
| threads4 | 4 | CUMULATIVE | 128 | COUNTER_SUM | 101,917,926 | 106,807,936 | +4,890,011 | +4.8% |
| threads4 | 4 | CUMULATIVE | 128 | GAUGE_LAST_VALUE | 99,772,907 | 151,544,793 | +51,771,886 | **+51.9%** |
| threads4 | 4 | CUMULATIVE | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 69,414,310 | 69,808,432 | +394,122 | +0.6% |
| threads4 | 4 | CUMULATIVE | 128 | HISTOGRAM_EXPLICIT | 71,859,876 | 73,052,921 | +1,193,044 | +1.7% |
| threads4 | 4 | CUMULATIVE | 128 | UP_DOWN_COUNTER_SUM | 102,675,867 | 102,818,613 | +142,746 | +0.1% |
| threads4 | 4 | DELTA | 1 | COUNTER_SUM | 17,860,366 | 17,215,213 | -645,154 | -3.6% |
| threads4 | 4 | DELTA | 1 | GAUGE_LAST_VALUE | 18,414,726 | 18,575,692 | +160,967 | +0.9% |
| threads4 | 4 | DELTA | 1 | HISTOGRAM_BASE2_EXPONENTIAL | 10,272,237 | 10,723,117 | +450,879 | +4.4% |
| threads4 | 4 | DELTA | 1 | HISTOGRAM_EXPLICIT | 12,299,067 | 12,034,402 | -264,665 | -2.2% |
| threads4 | 4 | DELTA | 1 | UP_DOWN_COUNTER_SUM | 17,354,541 | 18,025,717 | +671,175 | +3.9% |
| threads4 | 4 | DELTA | 128 | COUNTER_SUM | 70,640,757 | 69,943,441 | -697,316 | -1.0% |
| threads4 | 4 | DELTA | 128 | GAUGE_LAST_VALUE | 52,635,745 | 82,263,039 | +29,627,294 | **+56.3%** |
| threads4 | 4 | DELTA | 128 | HISTOGRAM_BASE2_EXPONENTIAL | 52,465,326 | 53,754,789 | +1,289,463 | +2.5% |
| threads4 | 4 | DELTA | 128 | HISTOGRAM_EXPLICIT | 53,967,236 | 54,678,786 | +711,551 | +1.3% |
| threads4 | 4 | DELTA | 128 | UP_DOWN_COUNTER_SUM | 68,654,779 | 68,744,860 | +90,081 | +0.1% |