### PR TITLE
Add BatchSpanProcessor.create(SpanExporter) to match SimpleSpanProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### SDK
+
+#### Traces
+
+* Add `BatchSpanProcessor.create(SpanExporter)` convenience factory to mirror
+  `SimpleSpanProcessor.create(SpanExporter)`
+  ([#8561](https://github.com/open-telemetry/opentelemetry-java/issues/8561))
+
 ## Version 1.63.0 (2026-06-05)
 
 ### API

--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of opentelemetry-sdk-trace-1.64.0-SNAPSHOT.jar against opentelemetry-sdk-trace-1.63.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.trace.export.BatchSpanProcessor  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.sdk.trace.export.BatchSpanProcessor create(io.opentelemetry.sdk.trace.export.SpanExporter)

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.sdk.trace.export;
 
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -53,6 +55,24 @@ public final class BatchSpanProcessor implements SpanProcessor {
   private final boolean exportUnsampledSpans;
   private final Worker worker;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+
+  /**
+   * Returns a new {@link BatchSpanProcessor} with default configuration which batches spans
+   * exported by the SDK then pushes them to the {@code spanExporter}.
+   *
+   * <p>This is a convenience method equivalent to {@code
+   * BatchSpanProcessor.builder(spanExporter).build()}. Use {@link #builder(SpanExporter)} if you
+   * need to customize the configuration.
+   *
+   * @param spanExporter the {@link SpanExporter} to which the Spans are pushed.
+   * @return a new {@link BatchSpanProcessor}.
+   * @throws NullPointerException if the {@code spanExporter} is {@code null}.
+   * @since 1.64.0
+   */
+  public static BatchSpanProcessor create(SpanExporter spanExporter) {
+    requireNonNull(spanExporter, "spanExporter");
+    return builder(spanExporter).build();
+  }
 
   /**
    * Returns a new Builder for {@link BatchSpanProcessor}.

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -105,6 +105,21 @@ class BatchSpanProcessorTest {
   }
 
   @Test
+  void createDefaults() {
+    BatchSpanProcessor processor =
+        BatchSpanProcessor.create(new WaitingSpanExporter(0, CompletableResultCode.ofSuccess()));
+    assertThat(processor).isNotNull();
+    processor.shutdown().join(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void createNull() {
+    assertThatThrownBy(() -> BatchSpanProcessor.create(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("spanExporter");
+  }
+
+  @Test
   void builderInvalidConfig() {
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
## What

Adds a `BatchSpanProcessor.create(SpanExporter)` convenience factory returning a default-configured processor (equivalent to `builder(exporter).build()`), mirroring the existing `SimpleSpanProcessor.create(SpanExporter)`.

## Why

`SimpleSpanProcessor` exposes both `create(SpanExporter)` and `builder(SpanExporter)`, but `BatchSpanProcessor` only exposed `builder(SpanExporter)`. Since `SimpleSpanProcessor.create(exporter)` compiles, it's natural to assume `BatchSpanProcessor.create(exporter)` does too — but it fails with `cannot find symbol: method create(SpanExporter)`. This is purely additive and backward-compatible; the builder stays for configuration.

Fixes #8561

## Details

- New `create(SpanExporter)` static factory with `@since 1.64.0` Javadoc.
- Null-check on the exporter, mirroring `SimpleSpanProcessor`.
- Tests: `createDefaults()` and `createNull()`.
- CHANGELOG entry and regenerated `docs/apidiffs/current_vs_latest/opentelemetry-sdk-trace.txt`.