### PR TITLE
Fix Tracer manual context propagation Javadoc example

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/Tracer.java
@@ -45,7 +45,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *     openTelemetry.getTracer("instrumentation-library-name", "1.0.0");
  *   void doWork(Span parent) {
  *     Span childSpan = tracer.spanBuilder("MyChildSpan")
- *         setParent(parent).startSpan();
+ *         .setParent(Context.current().with(parent))
+ *         .startSpan();
  *     childSpan.addEvent("Starting the work.");
  *     try {
  *       doSomeWork(childSpan); // Manually propagate the new span down the stack.


### PR DESCRIPTION
Fixes #8568

## Description

- The "manual context propagation" example in the `Tracer` Javadoc does not compile when copied.
- Adds the missing `.` so the builder chains: `spanBuilder("MyChildSpan").setParent(...).startSpan()`.
- Wraps `Span parent` in `Context.current().with(parent)`, since `SpanBuilder.setParent` accepts a `Context`, not a `Span`.
- Matches the sibling `SpanBuilder` Javadoc, which already uses this idiom.

## Testing done

- Docs-only Javadoc fix, test-exempt: no test added.
- `./gradlew :api:all:check` passed (compile, spotless, jApiCmp) with JDK 21.
- No public API change (jApiCmp: no apidiff); no CHANGELOG (no user-facing change).

