### PR TITLE
Remove duplicate getStringList resolver in DeclarativeConfigPropertyUtil

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigPropertyUtil.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigPropertyUtil.java
@@ -31,7 +31,6 @@ final class DeclarativeConfigPropertyUtil {
               DeclarativeConfigPropertyUtil::getBooleanList,
               DeclarativeConfigPropertyUtil::getLongList,
               DeclarativeConfigPropertyUtil::getDoubleList,
-              DeclarativeConfigPropertyUtil::getStringList,
               DeclarativeConfigPropertyUtil::getStructuredList,
               DeclarativeConfigPropertyUtil::getStructured);
 


### PR DESCRIPTION
Fixes #8569

## Description

- `valueResolvers` in `DeclarativeConfigPropertyUtil` referenced `getStringList` twice.
- `resolveValue` returns the first non-null resolver result, so the second `getStringList` entry was unreachable dead code with no behavior effect.
- Removing it leaves the list matching the ten resolver methods one-to-one (`getString`/`Boolean`/`Long`/`Double`, the four `*List` variants, `getStructuredList`, `getStructured`).

## Testing done

- Internal package-private util in the `opentelemetry-api-incubator` (-alpha) module; unreachable dead code removed, so no observable behavior change and no new test. Existing `:api:incubator` tests guard against regression.
- `./gradlew :api:incubator:check` passed.
- No public API change, so no `docs/apidiffs` update; no user-facing change, so no CHANGELOG entry.

