### PR TITLE
Remove duplicate declarative config resolver

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigPropertyUtil.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/DeclarativeConfigPropertyUtil.java
@@ -31,7 +31,6 @@ final class DeclarativeConfigPropertyUtil {
               DeclarativeConfigPropertyUtil::getBooleanList,
               DeclarativeConfigPropertyUtil::getLongList,
               DeclarativeConfigPropertyUtil::getDoubleList,
-              DeclarativeConfigPropertyUtil::getStringList,
               DeclarativeConfigPropertyUtil::getStructuredList,
               DeclarativeConfigPropertyUtil::getStructured);
 


### PR DESCRIPTION
## Changes

Removes the duplicate `DeclarativeConfigPropertyUtil::getStringList` entry from the declarative config value resolver list.

## Rationale

The duplicate resolver is unreachable because `resolveValue` returns the first non-null value. The resolver list now maps one-to-one to the supported scalar, scalar-list, structured-list, and structured value resolvers.

Closes #8569.

## Verification

```
./gradlew :api:incubator:compileJava :api:incubator:spotlessJavaCheck :api:incubator:checkstyleMain :api:incubator:test
```

AI assistance was used to draft and validate this change.
