### PR TITLE
Use NumberFormatException in baggage decoder

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/BaggageCodec.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/BaggageCodec.java
@@ -84,8 +84,14 @@ class BaggageCodec {
   private static int digit16(byte b) {
     int i = Character.digit((char) b, RADIX);
     if (i == -1) {
-      throw new IllegalArgumentException( // FIXME
-          "Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+      throw new NumberFormatException(
+          "Invalid URL encoding: not a valid digit (radix "
+              + RADIX
+              + "): byte="
+              + b
+              + ", char='"
+              + (char) (b & 0xff)
+              + "'");
     }
     return i;
   }

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/BaggageCodecTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/BaggageCodecTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.api.baggage.propagation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -37,5 +38,13 @@ class BaggageCodecTest {
   void shouldIgnoreIfMalformedData() {
     assertThat(BaggageCodec.decode("%", StandardCharsets.UTF_8)).isEqualTo("");
     assertThat(BaggageCodec.decode("%1", StandardCharsets.UTF_8)).isEqualTo("");
+  }
+
+  @Test
+  void shouldThrowNumberFormatExceptionForInvalidHexDigit() {
+    assertThatThrownBy(() -> BaggageCodec.decode("%G0", StandardCharsets.UTF_8))
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessageContaining("byte=71")
+        .hasMessageContaining("char='G'");
   }
 }


### PR DESCRIPTION
## Summary
- replace the invalid hex-digit exception in `BaggageCodec.digit16(byte)` with `NumberFormatException`
- include byte and character details in the error message
- add a focused regression test for invalid hex input

Fixes #8556

## Testing
- `./gradlew :api:all:test --tests "*BaggageCodecTest" --tests "*W3CBaggagePropagatorTest"`
- `./gradlew :api:all:spotlessCheck`