### PR TITLE
Gate PeriodicMetricReader self-observability by internal telemetry version

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,2 +1,4 @@
 Comparing source compatibility of opentelemetry-sdk-metrics-1.65.0-SNAPSHOT.jar against opentelemetry-sdk-metrics-1.64.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder setInternalTelemetryVersion(io.opentelemetry.sdk.common.InternalTelemetryVersion)

--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ConfigurableMetricReaderProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
@@ -80,8 +81,10 @@ final class MetricExporterConfiguration {
     if (customizedMetricExporter != metricExporter) {
       closeables.add(customizedMetricExporter);
     }
+    InternalTelemetryVersion telemetryVersion = InternalTelemetryConfiguration.getVersion(config);
     MetricReader reader =
         PeriodicMetricReader.builder(customizedMetricExporter)
+            .setInternalTelemetryVersion(telemetryVersion)
             .setInterval(config.getDuration("otel.metric.export.interval", DEFAULT_EXPORT_INTERVAL))
             .build();
     closeables.add(reader);

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactory.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactory.java
@@ -64,6 +64,8 @@ final class MetricReaderFactory
 
       PeriodicMetricReaderBuilder builder = PeriodicMetricReader.builder(metricExporter);
 
+      context.setInternalTelemetry(unused -> {}, builder::setInternalTelemetryVersion);
+
       if (model.getInterval() != null) {
         builder.setInterval(Duration.ofMillis(model.getInterval()));
       }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.export;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.internal.ComponentId;
 import io.opentelemetry.sdk.metrics.Aggregation;
@@ -48,6 +49,7 @@ public final class PeriodicMetricReader implements MetricReader {
   private final ScheduledExecutorService scheduler;
   private final Scheduled scheduled;
   private final Object lock = new Object();
+  private final InternalTelemetryVersion internalTelemetryVersion;
 
   private volatile CollectionRegistration collectionRegistration = CollectionRegistration.noop();
 
@@ -71,12 +73,14 @@ public final class PeriodicMetricReader implements MetricReader {
       MetricExporter exporter,
       long intervalNanos,
       ScheduledExecutorService scheduler,
-      int maxExportBatchSize) {
+      int maxExportBatchSize,
+      InternalTelemetryVersion internalTelemetryVersion) {
     this.exporter = exporter;
     this.intervalNanos = intervalNanos;
     this.scheduler = scheduler;
     this.maxExportBatchSize = maxExportBatchSize;
     this.scheduled = new Scheduled();
+    this.internalTelemetryVersion = internalTelemetryVersion;
   }
 
   @Override
@@ -166,7 +170,9 @@ public final class PeriodicMetricReader implements MetricReader {
    */
   @SuppressWarnings("UnusedMethod")
   private void setMeterProvider(MeterProvider meterProvider) {
-    this.scheduled.setMeterProvider(meterProvider);
+    if (internalTelemetryVersion != InternalTelemetryVersion.LEGACY) {
+      scheduled.setMeterProvider(meterProvider);
+    }
   }
 
   @Override

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -89,11 +89,7 @@ public final class PeriodicMetricReaderBuilder {
         metricExporter, intervalNanos, executor, maxExportBatchSize, internalTelemetryVersion);
   }
 
-  /**
-   * Sets the internal telemetry version used to control self-observability metrics.
-   *
-   * @since 1.65.0
-   */
+  /** Sets the internal telemetry version used to control self-observability metrics. */
   public PeriodicMetricReaderBuilder setInternalTelemetryVersion(InternalTelemetryVersion version) {
     requireNonNull(version, "version");
     this.internalTelemetryVersion = version;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.export;
 import static io.opentelemetry.api.internal.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.internal.DaemonThreadFactory;
 import java.time.Duration;
 import java.util.concurrent.Executors;
@@ -25,6 +26,8 @@ public final class PeriodicMetricReaderBuilder {
   static final long DEFAULT_SCHEDULE_DELAY_MINUTES = 1;
 
   private final MetricExporter metricExporter;
+
+  private InternalTelemetryVersion internalTelemetryVersion = InternalTelemetryVersion.LATEST;
 
   private long intervalNanos = TimeUnit.MINUTES.toNanos(DEFAULT_SCHEDULE_DELAY_MINUTES);
 
@@ -82,6 +85,18 @@ public final class PeriodicMetricReaderBuilder {
       executor =
           Executors.newScheduledThreadPool(1, new DaemonThreadFactory("PeriodicMetricReader"));
     }
-    return new PeriodicMetricReader(metricExporter, intervalNanos, executor, maxExportBatchSize);
+    return new PeriodicMetricReader(
+        metricExporter, intervalNanos, executor, maxExportBatchSize, internalTelemetryVersion);
+  }
+
+  /**
+   * Sets the internal telemetry version used to control self-observability metrics.
+   *
+   * @since 1.65.0
+   */
+  public PeriodicMetricReaderBuilder setInternalTelemetryVersion(InternalTelemetryVersion version) {
+    requireNonNull(version, "version");
+    this.internalTelemetryVersion = version;
+    return this;
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
@@ -107,6 +108,18 @@ class PeriodicMetricReaderTest {
     reader.register(collectionRegistration);
 
     verify(scheduler, times(1)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+  }
+
+  @Test
+  void build_withInternalTelemetryVersion() {
+    WaitingMetricExporter exporter = new WaitingMetricExporter();
+
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(exporter)
+            .setInternalTelemetryVersion(InternalTelemetryVersion.LATEST)
+            .build();
+
+    assertThat(reader).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
## What was changed

- Added support for configuring `PeriodicMetricReader` with an `InternalTelemetryVersion`.
- Updated `MetricExporterConfiguration` to propagate the configured telemetry version when creating `PeriodicMetricReader`.
- Gated metric reader self-observability initialization based on the configured telemetry version.
- Preserved existing SDK behavior by defaulting `PeriodicMetricReaderBuilder` to `InternalTelemetryVersion.LATEST`.

## Why?

`PeriodicMetricReader` always emitted `otel.sdk.metric_reader.collection.duration` whenever a real `MeterProvider` was available, regardless of `OTEL_EXPERIMENTAL_SDK_TELEMETRY_VERSION`.

Tracing and logging already gate SDK self-observability using `InternalTelemetryConfiguration.getVersion(config)`. This change aligns metric reader self-observability with the existing behavior while preserving the default behavior for direct SDK users.

Fixes #8566