### PR TITLE
Fix copy-paste class javadoc on OTLP AnyValue stateless marshalers

### DIFF
--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/AnyValueStatelessMarshaler.java
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
- * A Marshaler of key value pairs. See {@link AnyValueMarshaler}.
+ * A Marshaler of {@link Value}. See {@link AnyValueMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/ArrayAnyValueStatelessMarshaler.java
@@ -14,7 +14,7 @@ import io.opentelemetry.proto.common.v1.internal.ArrayValue;
 import java.io.IOException;
 import java.util.List;
 
-/** A Marshaler of key value pairs. See {@link ArrayAnyValueMarshaler}. */
+/** A Marshaler of array values. See {@link ArrayAnyValueMarshaler}. */
 final class ArrayAnyValueStatelessMarshaler implements StatelessMarshaler<List<Value<?>>> {
 
   static final ArrayAnyValueStatelessMarshaler INSTANCE = new ArrayAnyValueStatelessMarshaler();

--- a/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
+++ b/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/internal/otlp/KeyValueStatelessMarshaler.java
@@ -13,7 +13,7 @@ import io.opentelemetry.exporter.internal.marshal.StatelessMarshalerUtil;
 import java.io.IOException;
 
 /**
- * A Marshaler of key value pairs. See {@link AnyValueMarshaler}.
+ * A Marshaler of key value pairs. See {@link KeyValueMarshaler}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.


### PR DESCRIPTION
<!-- No issue: docs-only cleanup, issue not required (per #8479 / #8071 docs-typo precedent) -->

## Description

Three stateless marshalers in `io.opentelemetry.exporter.internal.otlp` carry a class javadoc copy-pasted from the KeyValue marshaler, so the description or the sibling `{@link}` no longer matches what the class marshals.

- `AnyValueStatelessMarshaler` marshals a single `Value` (AnyValue), not "key value pairs" — corrected to `A Marshaler of {@link Value}`.
- `ArrayAnyValueStatelessMarshaler` marshals a list of values (`ArrayValue.VALUES`) — corrected to `A Marshaler of array values`.
- `KeyValueStatelessMarshaler`'s description is right, but its `See {@link ...}` pointed at `AnyValueMarshaler`. Every sibling stateless marshaler links to its own non-stateless counterpart (e.g. `AttributeKeyValueStatelessMarshaler` → `KeyValueMarshaler`), so this now links to `KeyValueMarshaler`.

Internal package only: no behavior, wire output, public API, or signature change.

## Testing done

- Docs-only, test-exempt: no test added.
- `./gradlew :exporters:otlp:common:check` passed (spotless, ErrorProne `{@link}` validation, jApiCmp, unit tests).
- No api diff, and no `CHANGELOG.md` entry (not user-facing).

