### PR TITLE
Fix incorrect article in OtlpJsonLoggingMetricExporter Javadoc

### DIFF
--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -29,7 +29,7 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
   private final OtlpStdoutMetricExporter delegate;
 
   /**
-   * Returns a new {@link OtlpJsonLoggingMetricExporter} with a aggregation temporality of {@link
+   * Returns a new {@link OtlpJsonLoggingMetricExporter} with an aggregation temporality of {@link
    * AggregationTemporality#CUMULATIVE}.
    */
   public static MetricExporter create() {


### PR DESCRIPTION
<!-- No issue: pure typo, no issue -->

## Description

- Fix the indefinite article in the `create()` Javadoc: "with a aggregation temporality" -> "with an aggregation temporality".
- The sibling `create(AggregationTemporality)` Javadoc a few lines below already reads correctly; this aligns the two.

## Testing done

- Javadoc-only typo, test-exempt: no test added.
- `./gradlew :exporters:logging-otlp:check` passed (77 tests).
- No apidiff change and no CHANGELOG entry (not user-facing).

