### PR TITLE
Fix getMangedChannel typo in ExtendedGrpcSenderConfig

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/ExtendedGrpcSenderConfig.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/grpc/ExtendedGrpcSenderConfig.java
@@ -17,5 +17,5 @@ import javax.annotation.Nullable;
 public interface ExtendedGrpcSenderConfig extends GrpcSenderConfig {
 
   @Nullable
-  Object getMangedChannel();
+  Object getManagedChannel();
 }

--- a/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
+++ b/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
@@ -30,7 +30,7 @@ public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
     ExtendedGrpcSenderConfig extendedSenderConfig = (ExtendedGrpcSenderConfig) grpcSenderConfig;
 
     boolean shutdownChannel = false;
-    Object configManagedChannel = extendedSenderConfig.getMangedChannel();
+    Object configManagedChannel = extendedSenderConfig.getManagedChannel();
     ManagedChannel managedChannel;
     if (configManagedChannel != null) {
       if (!(configManagedChannel instanceof ManagedChannel)) {


### PR DESCRIPTION
<!-- No issue: trivial internal typo fix, issue not required -->

## Description

- Rename the misspelled getter `getMangedChannel()` to `getManagedChannel()` on `ExtendedGrpcSenderConfig`, and update its sole caller `UpstreamGrpcSenderProvider`. The typo was introduced in #7782.
- The interface is internal (`exporter.internal.grpc`), so this is not a public API change: no apidiff (japicmp excludes internal packages), no CHANGELOG.
- The two AutoValue impls (`ImmutableGrpcSenderConfig` in `exporters:otlp:all` and `sdk-extensions:jaeger-remote-sampler`) call the generated constructor positionally, so AutoValue regenerates the property under the corrected name with no source edit.

## Testing done

- Trivial typo on an internal identifier; behavior unchanged, no test added.
- `./gradlew :exporters:common:check :exporters:sender:grpc-managed-channel:check` — passed.
- `./gradlew :exporters:otlp:all:compileJava :sdk-extensions:jaeger-remote-sampler:compileJava` — passed; both AutoValue impls compile against the renamed method.

