### PR TITLE
Remove link to 404ing curio-server-framework

### DIFF
--- a/docs/sdk-configuration-design.md
+++ b/docs/sdk-configuration-design.md
@@ -594,8 +594,7 @@ presence of the wrapper and invoke it automatically.
 
 ### Spring Sleuth
 
-Spring Sleuth (or any similar observability-aware server framework such as
-[curio-server-framework](https://github.com/curioswitch/curiostack/blob/master/common/server/framework/src/main/java/org/curioswitch/common/server/framework/monitoring/MonitoringModule.java)
+Spring Sleuth (or any similar observability-aware server framework
 or internal frameworks developed by devops teams at companies) is also a mechanism for automatically
 configuring the SDK. In general, we would expect Sleuth users to not be using the java agent.
 


### PR DESCRIPTION
Resolves #8601.

The entire https://github.com/curioswitch/curiostack repo has either been deleted or been made private.