### PR TITLE
Delete copilot token

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -13,7 +13,6 @@ Deployment branches: `main`, `release/*`
 
 Secrets:
 
-- `COPILOT_GITHUB_TOKEN` - owned by [@jack-berg](https://github.com/jack-berg)
 - `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
 - `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
 - `SONATYPE_GUIDE_PAT` - owned by [@jack-berg](https://github.com/jack-berg)


### PR DESCRIPTION
Now that we use the shared workflow, we no longer need a repo level copilot token for the PR dashboard 