### PR TITLE
Output event name in SystemOutLogRecordExporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### SDK
+
+#### Exporters
+
+* Logging: Output event name in `SystemOutLogRecordExporter`
+  ([#8609](https://github.com/open-telemetry/opentelemetry-java/pull/8609))
+
 ## Version 1.64.0 (2026-07-10)
 
 ### API

--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
@@ -65,13 +65,18 @@ public class SystemOutLogRecordExporter implements LogRecordExporter {
   static void formatLog(StringBuilder stringBuilder, LogRecordData log) {
     InstrumentationScopeInfo instrumentationScopeInfo = log.getInstrumentationScopeInfo();
     Value<?> body = log.getBodyValue();
+    String eventName = log.getEventName();
     stringBuilder
         .append(
             ISO_FORMAT.format(
                 Instant.ofEpochMilli(NANOSECONDS.toMillis(log.getTimestampEpochNanos()))
                     .atZone(ZoneOffset.UTC)))
         .append(" ")
-        .append(log.getSeverity())
+        .append(log.getSeverity());
+    if (eventName != null && !eventName.isEmpty()) {
+      stringBuilder.append(" [eventName: ").append(eventName).append("]");
+    }
+    stringBuilder
         .append(" '")
         .append(body == null ? "" : body.asString())
         .append("' : ")

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
@@ -54,6 +54,34 @@ class SystemOutLogRecordExporterTest {
   }
 
   @Test
+  void formatWithEventName() {
+    long timestamp =
+        LocalDateTime.of(1970, Month.AUGUST, 7, 10, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    LogRecordData log =
+        TestLogRecordData.builder()
+            .setResource(Resource.empty())
+            .setInstrumentationScopeInfo(
+                InstrumentationScopeInfo.builder("logTest").setVersion("1.0").build())
+            .setBody("message")
+            .setSeverity(Severity.ERROR3)
+            .setEventName("my.event")
+            .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
+            .setSpanContext(
+                SpanContext.create(
+                    "00000000000000010000000000000002",
+                    "0000000000000003",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()))
+            .build();
+    StringBuilder output = new StringBuilder();
+    SystemOutLogRecordExporter.formatLog(output, log);
+    assertThat(output.toString())
+        .isEqualTo(
+            "1970-08-07T10:00:00Z ERROR3 [eventName: my.event] 'message' : "
+                + "00000000000000010000000000000002 0000000000000003 [scopeInfo: logTest:1.0] {}");
+  }
+
+  @Test
   void shutdown() {
     SystemOutLogRecordExporter exporter = SystemOutLogRecordExporter.create();
     assertThat(exporter.shutdown().isSuccess()).isTrue();


### PR DESCRIPTION
Fixes #8608

## Description

- `SystemOutLogRecordExporter.formatLog()` did not print the log record's event name; it now appends `[eventName: <name>]` after the severity when one is set.
- This aligns the debug exporter with the OTLP log exporters, which already serialize `LogRecord.EVENT_NAME` (`LogStatelessMarshaler`, `LogMarshaler`).
- `LogRecordData.getEventName()` is a stable log data-model field (stabilized in #7277); this exporter was not updated when the field was added.
- Output is unchanged when the event name is null or empty.

## Testing done

- Added `SystemOutLogRecordExporterTest#formatWithEventName` for the event-name-present case; the existing `format` test covers the absent case.
- `./gradlew :exporters:logging:check` — 16 tests passed.
- User-facing output change, so a `## Unreleased` CHANGELOG entry is included. No public API change (`formatLog` is package-private), so no apidiff update.

Related: PR #6591 updated `formatLog`'s body field when the data model changed.

