### PR TITLE
Assert buildObserver on counter and up-down-counter in shared default meter test

### DIFF
--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
@@ -72,6 +72,15 @@ public abstract class AbstractDefaultMeterTest {
     counter.add(1);
     counter.add(1, Attributes.of(stringKey("thing"), "car"));
     counter.add(1, Attributes.of(stringKey("thing"), "car"), Context.current());
+
+    ObservableLongMeasurement measurement =
+        meter
+            .counterBuilder("size")
+            .setDescription("The size I'm measuring")
+            .setUnit("1")
+            .buildObserver();
+    measurement.record(1);
+    measurement.record(1, Attributes.of(stringKey("thing"), "car"));
   }
 
   @Test
@@ -86,6 +95,16 @@ public abstract class AbstractDefaultMeterTest {
     counter.add(1.2);
     counter.add(2.5, Attributes.of(stringKey("thing"), "car"));
     counter.add(2.5, Attributes.of(stringKey("thing"), "car"), Context.current());
+
+    ObservableDoubleMeasurement measurement =
+        meter
+            .counterBuilder("size")
+            .ofDoubles()
+            .setDescription("The size I'm measuring")
+            .setUnit("1")
+            .buildObserver();
+    measurement.record(1.2);
+    measurement.record(2.5, Attributes.of(stringKey("thing"), "car"));
   }
 
   @Test
@@ -99,6 +118,15 @@ public abstract class AbstractDefaultMeterTest {
     counter.add(-1);
     counter.add(1, Attributes.of(stringKey("thing"), "car"));
     counter.add(1, Attributes.of(stringKey("thing"), "car"), Context.current());
+
+    ObservableLongMeasurement measurement =
+        meter
+            .upDownCounterBuilder("size")
+            .setDescription("The size I'm measuring")
+            .setUnit("1")
+            .buildObserver();
+    measurement.record(-1);
+    measurement.record(1, Attributes.of(stringKey("thing"), "car"));
   }
 
   @Test
@@ -113,6 +141,16 @@ public abstract class AbstractDefaultMeterTest {
     counter.add(-2e4);
     counter.add(1.0e-1, Attributes.of(stringKey("thing"), "car"));
     counter.add(1.0e-1, Attributes.of(stringKey("thing"), "car"), Context.current());
+
+    ObservableDoubleMeasurement measurement =
+        meter
+            .upDownCounterBuilder("size")
+            .ofDoubles()
+            .setDescription("The size I'm measuring")
+            .setUnit("1")
+            .buildObserver();
+    measurement.record(-2e4);
+    measurement.record(1.0e-1, Attributes.of(stringKey("thing"), "car"));
   }
 
   @Test


### PR DESCRIPTION
<!-- No issue: test coverage gap in shared test base; sibling PRs #8483/#8567 merged without an issue -->

## Description

- `AbstractDefaultMeterTest` called `buildObserver()` only on the two gauge builders.
- Six public metric builders declare `buildObserver()`, and both no-op meters (`DefaultMeter`, `ExtendedDefaultMeter`) override all six. The eight counter and up-down-counter overrides (4 builders x 2 impls) were never executed by any test.
- Adds `buildObserver()` with `record(value)` and `record(value, Attributes)` to the four existing counter and up-down-counter tests, in the same shape as the gauge tests.
- No production, signature, or public API change. Same pattern as #8483 and #8567.

## Testing done

- `./gradlew :api:all:test --tests DefaultMeterTest` — 18 passed. `./gradlew :api:incubator:test --tests ExtendedDefaultMeterTest` — 19 passed. `./gradlew :api:testing-internal:check` passed.
- Coverage gap, so tests pass both before and after the change.
- Gap confirmed real: with a temporary `UnsupportedOperationException` in `DefaultMeter`'s long-counter `buildObserver()`, the old test still passed and the new one failed. Probe reverted.
