### PR TITLE
Fix TraceStateBuilder.remove corrupting the builder when the same key is removed twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### API
+
+* Fix `TraceStateBuilder.remove` corrupting the builder when the same key is removed twice
+  ([#8613](https://github.com/open-telemetry/opentelemetry-java/pull/8613))
+
 ### SDK
 
 #### Exporters

--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
@@ -92,8 +92,10 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
     }
     for (int i = 0; i < reversedEntries.size(); i += 2) {
       if (reversedEntries.get(i).equals(key)) {
-        reversedEntries.set(i + 1, null);
-        numEntries--;
+        if (reversedEntries.get(i + 1) != null) {
+          reversedEntries.set(i + 1, null);
+          numEntries--;
+        }
         return this;
       }
     }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -17,8 +17,10 @@ import org.junit.jupiter.api.Test;
 class TraceStateTest {
   private static final String FIRST_KEY = "key_1";
   private static final String SECOND_KEY = "key_2";
+  private static final String THIRD_KEY = "key_3";
   private static final String FIRST_VALUE = "value.1";
   private static final String SECOND_VALUE = "value.2";
+  private static final String THIRD_VALUE = "value.3";
 
   private final TraceState firstTraceState =
       TraceState.builder().put(FIRST_KEY, FIRST_VALUE).build();
@@ -301,6 +303,32 @@ class TraceStateTest {
   void removeNotPresent() {
     assertThat(multiValueTraceState.toBuilder().remove("unknown").build())
         .isEqualTo(multiValueTraceState);
+  }
+
+  @Test
+  void removeTwice() {
+    assertThat(firstTraceState.toBuilder().remove(FIRST_KEY).remove(FIRST_KEY).build())
+        .isEqualTo(TraceState.getDefault());
+  }
+
+  @Test
+  void removeTwice_KeepsRemainingEntry() {
+    assertThat(multiValueTraceState.toBuilder().remove(FIRST_KEY).remove(FIRST_KEY).build().asMap())
+        .containsExactly(entry(SECOND_KEY, SECOND_VALUE));
+  }
+
+  @Test
+  void removeTwice_KeepsRemainingEntries() {
+    assertThat(
+            TraceState.builder()
+                .put(FIRST_KEY, FIRST_VALUE)
+                .put(SECOND_KEY, SECOND_VALUE)
+                .put(THIRD_KEY, THIRD_VALUE)
+                .remove(FIRST_KEY)
+                .remove(FIRST_KEY)
+                .build()
+                .asMap())
+        .containsExactly(entry(THIRD_KEY, THIRD_VALUE), entry(SECOND_KEY, SECOND_VALUE));
   }
 
   @Test


### PR DESCRIPTION
Fixes #8612

## Description

- `ArrayBasedTraceStateBuilder.remove()` decremented `numEntries` without checking whether the value was already `null`, so removing a key twice drove the counter below the real count.
- `build()` trusts `numEntries` in three places, so the drift leaks a `{a=null}` entry, silently drops live entries, or throws `ArrayIndexOutOfBoundsException`.
- Mirrors the sibling `put()` (same class, line 74-78), which already does this check; first removal is unchanged.
- No in-repo caller, but `TraceStateBuilder` is stable public API for external instrumentation and vendor propagators. The silent data loss contradicts the no-op contract of the `remove(String)` Javadoc ("if it is present") and of `removeNotPresent()`, and is reachable via `reuseBuilder()`.
- Same defect shape as #8499 (`PooledHashMap` dropping live entries).

## Testing done

- Added `TraceStateTest#removeTwice`, `#removeTwice_KeepsRemainingEntry`, `#removeTwice_KeepsRemainingEntries` for one, two, and three entries. All three fail without the fix; 41 pass with it.
- `./gradlew :api:all:check` — passed, 504 tests.
- No signature change (package-private class): apidiff unchanged.
- `CHANGELOG.md` `## Unreleased` → `### API` entry added.

