### PR TITLE
Fix stale Javadoc references in api/incubator

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/ConfigProvider.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/ConfigProvider.java
@@ -21,7 +21,7 @@ public interface ConfigProvider {
 
   /**
    * Returns the {@link DeclarativeConfigProperties} corresponding to <a
-   * href="https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/instrumentation.json">instrumentation
+   * href="https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/instrumentation.yaml">instrumentation
    * config</a>, or {@link DeclarativeConfigProperties#empty()} if unavailable.
    *
    * @return the instrumentation {@link DeclarativeConfigProperties}

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtil.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/config/InstrumentationConfigUtil.java
@@ -94,9 +94,8 @@ public class InstrumentationConfigUtil {
 
   /**
    * Walk down the {@code segments} of {@link ConfigProvider#getInstrumentationConfig()} and call
-   * {@code accessor} on the terminal node. Returns null if {@link
-   * ConfigProvider#getInstrumentationConfig()} is null, or if null is encountered walking the
-   * {@code segments}, or if {@code accessor} returns null.
+   * {@code accessor} on the terminal node. Returns null if null is encountered walking the {@code
+   * segments}, or if {@code accessor} returns null.
    *
    * <p>See other methods in {@link InstrumentationConfigUtil} for usage examples.
    */

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/ExtendedContextPropagators.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation/ExtendedContextPropagators.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
  * Utility class to simplify context propagation.
  *
  * <p>The <a
- * href="https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/extended-tracer/README.md">README</a>
+ * href="https://github.com/open-telemetry/opentelemetry-java/tree/main/api/incubator#extended-contextpropagator-apis">README</a>
  * explains the use cases in more detail.
  */
 public final class ExtendedContextPropagators {


### PR DESCRIPTION
Fixes #8614

## Description

Three public Javadoc comments in `:api:incubator` point at things that moved or no longer exist.

- `InstrumentationConfigUtil.getOrNull()`: drop "Returns null if `ConfigProvider#getInstrumentationConfig()` is null" — #7954 (a46b073cc) made that method non-null and deleted the null check, leaving the Javadoc behind. That return path cannot happen; the other two null conditions are real and stay.
- `ConfigProvider.getInstrumentationConfig()`: retarget the schema link from `schema/instrumentation.json` (404) to `schema/instrumentation.yaml` — open-telemetry/opentelemetry-configuration#411 deleted the JSON files and made YAML the source of truth.
- `ExtendedContextPropagators`: retarget the README link from contrib `extended-tracer/README.md` (404) to the `api/incubator` README section that replaced it — open-telemetry/opentelemetry-java-contrib#1129 removed that module after the code moved here.
- Related: #8605, which removed a 404ing link that had no replacement.

## Testing done

- Docs-only, test-exempt: no signature change, so no apidiff entry; no user-facing behavior change, so no CHANGELOG entry.
- `./gradlew :api:incubator:check` — 96 tests passed.
- Verified with `curl`: both old links 404, both new links 200.

