### PR TITLE
Update japicmp baseline docs to match pinned apidiffBaselineVersion

### DIFF
--- a/docs/knowledge/api-design.md
+++ b/docs/knowledge/api-design.md
@@ -86,8 +86,9 @@ Rules:
 ## japicmp
 
 `otel.japicmp-conventions` runs the `jApiCmp` task as part of `check` for every published module.
-It compares the locally-built jar against the latest release to detect breaking changes, and writes
-a human-readable diff to `docs/apidiffs/current_vs_latest/<artifact>.txt`.
+It compares the locally-built jar against the release pinned by `apidiffBaselineVersion` in
+`version.gradle.kts` to detect breaking changes, and writes a human-readable diff to
+`docs/apidiffs/current_vs_latest/<artifact>.txt`.
 
 - Breaking changes in stable modules fail the build.
 - AutoValue classes are exempt from the abstract-method-added check — the generated implementation

--- a/docs/knowledge/gradle-conventions.md
+++ b/docs/knowledge/gradle-conventions.md
@@ -23,7 +23,7 @@ Every module applies a base set of convention plugins from `buildSrc/src/main/ko
 | `otel.publish-conventions` | Maven publishing, POM generation | Published (non-internal) modules |
 | `otel.animalsniffer-conventions` | Android API level compatibility checking | Modules targeting Android |
 | `otel.jmh-conventions` | JMH benchmark support | Modules with benchmarks |
-| `otel.japicmp-conventions` | API diff generation against latest release | Published modules (applied by `otel.publish-conventions`) |
+| `otel.japicmp-conventions` | API diff generation against the pinned `apidiffBaselineVersion` release | Published modules (applied by `otel.publish-conventions`) |
 | `otel.protobuf-conventions` | Protobuf code generation | Protobuf modules only |
 
 A typical published module:


### PR DESCRIPTION
No issue: docs incomplete-fix follow-up to #8591, PR-only (precedent: #8491)

## Description

- #8591 pinned the japicmp baseline to `apidiffBaselineVersion` in `version.gradle.kts` and removed the `latest.release` lookup, but `api-design.md` and `gradle-conventions.md` still describe the old dynamic behavior.
- #8591 updated `build.md`, which delegates with "See api-design.md#japicmp for details" — the accurate doc points readers at a stale one.
- Both docs now name the pinned `apidiffBaselineVersion` release, mirroring `build.md`.
- Left alone on purpose: the `docs/apidiffs/current_vs_latest/` directory name and the `latest` path literal in `otel.japicmp-conventions.gradle.kts` name the output path, not the comparison baseline; #8591 kept them in `build.md` too.

## Testing done

- Docs-only: no behavior, signature, or public API change, so no tests, no Gradle run, and no apidiff or CHANGELOG entry.
- Verified against `otel.japicmp-conventions.gradle.kts` lines 20/108 (`baselineVersion = apiBaseVersion ?: apidiffBaselineVersion`) and `version.gradle.kts` line 2 (`= "1.64.0"`).
- Grepped `docs/knowledge/`, `buildSrc/`, `.github/`, `version.gradle.kts` for the old wording — nothing stale remains.
