### PR TITLE
Fix PrometheusHttpServerBuilder copy constructor dropping the default handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Exporters
 
+* Prometheus: Fix `PrometheusHttpServer.toBuilder()` dropping the configured default handler
+  ([#8619](https://github.com/open-telemetry/opentelemetry-java/pull/8619))
 * Logging: Output event name in `SystemOutLogRecordExporter`
   ([#8609](https://github.com/open-telemetry/opentelemetry-java/pull/8609))
 

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
@@ -52,6 +52,7 @@ public final class PrometheusHttpServerBuilder {
     this.metricReaderBuilder = new PrometheusMetricReaderBuilder(builder.metricReaderBuilder);
     this.executor = builder.executor;
     this.memoryMode = builder.memoryMode;
+    this.defaultHandler = builder.defaultHandler;
     this.defaultAggregationSelector = builder.defaultAggregationSelector;
     this.authenticator = builder.authenticator;
   }

--- a/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
+++ b/exporters/prometheus/src/test/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerTest.java
@@ -24,6 +24,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.sun.net.httpserver.Authenticator;
 import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpPrincipal;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.common.Attributes;
@@ -755,6 +756,9 @@ class PrometheusHttpServerTest {
         };
     builder.setAuthenticator(authenticator);
 
+    HttpHandler defaultHandler = exchange -> {};
+    builder.setDefaultHandler(defaultHandler);
+
     PrometheusHttpServer httpServer = builder.build();
     PrometheusHttpServerBuilder fromOriginalBuilder = httpServer.toBuilder();
     httpServer.close();
@@ -765,6 +769,7 @@ class PrometheusHttpServerTest {
         .hasFieldOrPropertyWithValue("executor", executor)
         .hasFieldOrPropertyWithValue("prometheusRegistry", prometheusRegistry)
         .hasFieldOrPropertyWithValue("authenticator", authenticator)
+        .hasFieldOrPropertyWithValue("defaultHandler", defaultHandler)
         .extracting("metricReaderBuilder")
         .usingRecursiveComparison()
         .isEqualTo(


### PR DESCRIPTION
Fixes #8618

## Description

- The package-private `PrometheusHttpServerBuilder` copy constructor copied 8 of the builder's 9 fields, omitting `defaultHandler` and silently losing an `HttpHandler` set via `setDefaultHandler()`.
- `build()` stores a defensive copy on the server and `toBuilder()` copies that again, so `toBuilder()` users lose the handler despite the documented "same configuration as this instance" contract. The first `build()` is unaffected — it passes `defaultHandler` from the field directly.
- Added the missing assignment in field-declaration order, matching the adjacent `authenticator` line: an identical `@Nullable`, setter-only field passed to `HTTPServer.builder()`. The field arrived in #6476 without a copy-constructor line; `memoryMode` had the same omission, fixed later in #6799.

## Testing done

- Extended `PrometheusHttpServerTest#toBuilder`: the new assertion fails with `expected: <handler> but was: null` before the fix, passes after.
- `./gradlew :exporters:prometheus:check` — 191 tests plus 1 `testJpms` test pass.
- `CHANGELOG.md` `## Unreleased` entry added. No apidiff: signatures unchanged, alpha module untracked in `docs/apidiffs/`.
- Not run: `*IT` and GraalVM native-image tests (outside `check`).

