### PR TITLE
Fix StringEncoder javadoc implementation priority order

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoder.java
@@ -18,8 +18,11 @@ import javax.annotation.Nullable;
  * this priority order:
  *
  * <ul>
- *   <li>{@code VarHandleStringEncoder} - High-performance Java 9+ implementation using VarHandle
- *   <li>{@code UnsafeStringEncoder} - High-performance Java 8+ implementation using sun.misc.Unsafe
+ *   <li>{@code UnsafeStringEncoder} - High-performance Java 8+ implementation using
+ *       sun.misc.Unsafe. Only attempted when the Java version is detected to be below 23, to avoid
+ *       the JEP 498 deprecation warning.
+ *   <li>{@code VarHandleStringEncoder} - High-performance Java 9+ implementation using VarHandle.
+ *       Requires {@code --add-opens=java.base/java.lang=ALL-UNNAMED}.
  *   <li>{@code FallbackStringEncoder} - Implementation using standard Java operations
  * </ul>
  *


### PR DESCRIPTION
Fixes #8620

## Description

- The `StringEncoder` javadoc listed `VarHandleStringEncoder` before `UnsafeStringEncoder`, but `StringEncoderHolder.createInstance()` tries Unsafe first — its inline comment says "so try it first" because Unsafe is faster.
- Reordered the list to match the code, and noted that Unsafe is only attempted when the Java version is detected to be below 23, which is what `proactivelyAvoidUnsafe()` does to avoid the JEP 498 deprecation warning.
- Also noted that VarHandle requires `--add-opens=java.base/java.lang=ALL-UNNAMED`, per the existing comment in `StringEncoderHolder`.
- Both files came from #7701, so the javadoc was inaccurate from the start.

## Testing done

- Docs-only, test-exempt: javadoc only, no behavior, signature, or public API change.
- `./gradlew :exporters:common:check` passed — 66 tests (57 `test`, 8 `testSenderProvider`, 1 `testWithoutUnsafe`), 0 failures.
- No apidiff update: every class in this module is under `io.opentelemetry.exporter.internal.*`, which japicmp excludes.
- No `CHANGELOG.md` entry: not user-facing.

