### PR TITLE
Include aggregation temporality in LoggingMetricExporter toString

### DIFF
--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java
@@ -107,6 +107,6 @@ public final class LoggingMetricExporter implements MetricExporter {
 
   @Override
   public String toString() {
-    return "LoggingMetricExporter{}";
+    return "LoggingMetricExporter{aggregationTemporality=" + aggregationTemporality + "}";
   }
 }

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/LoggingMetricExporterTest.java
@@ -140,6 +140,9 @@ class LoggingMetricExporterTest {
 
   @Test
   void stringRepresentation() {
-    assertThat(LoggingMetricExporter.create().toString()).isEqualTo("LoggingMetricExporter{}");
+    assertThat(LoggingMetricExporter.create().toString())
+        .isEqualTo("LoggingMetricExporter{aggregationTemporality=CUMULATIVE}");
+    assertThat(LoggingMetricExporter.create(AggregationTemporality.DELTA).toString())
+        .isEqualTo("LoggingMetricExporter{aggregationTemporality=DELTA}");
   }
 }


### PR DESCRIPTION
Fixes #8622

## Description

- `LoggingMetricExporter.toString()` returned the constant `"LoggingMetricExporter{}"`, so `create(DELTA)` and the default `create()` (CUMULATIVE) printed identically, hiding this exporter's only setting.
- This reaches real debug output: `OpenTelemetrySdk.toString()` prints the meter provider, and `PeriodicMetricReader.toString()` appends `"exporter=" + exporter`.
- The other three `MetricExporter` implementations that override `toString()` (`OtlpGrpcMetricExporter`, `OtlpHttpMetricExporter`, `OtlpStdoutMetricExporter`) already print their temporality.
- Plain concatenation rather than `StringJoiner`, since there is a single field — the form used elsewhere for single-field `toString()` (e.g. `SdkMeter`, `SdkObservableInstrument`).
- Precedent: #6402 "Add missing fields to OTLP metric exporters" fixed the same gap for the OTLP metric exporters and left this class out.

```java
return "LoggingMetricExporter{aggregationTemporality=" + aggregationTemporality + "}";
```

## Testing done

- Extended `LoggingMetricExporterTest#stringRepresentation` to assert that `create()` prints `CUMULATIVE` and `create(DELTA)` prints `DELTA`; it fails against the old constant.
- `./gradlew :exporters:logging:check --rerun-tasks` — 15 tests passed.
- No public API change (`toString()` signature unchanged), so no apidiff update.

