### PR TITLE
Log the exception when a gRPC response frame is invalid

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -188,7 +188,7 @@ public final class OkHttpGrpcSender implements GrpcSender {
         compressed = body.source().readByte() != 0;
         body.source().skip(4); // message length — we bound reads by EOF instead
       } catch (IOException e) {
-        logger.log(Level.FINE, "Invalid gRPC response frame");
+        logger.log(Level.FINE, "Invalid gRPC response frame", e);
         onResponse.accept(
             ImmutableGrpcResponse.create(grpcStatus(response), grpcMessage(response), new byte[0]));
         return;


### PR DESCRIPTION
Fixes #8625

## Description

- `OkHttpGrpcSender.handleResponse()` caught the `IOException` from reading the 5-byte gRPC frame header but logged only a message, dropping the cause. The two sibling `catch` blocks in the same method already pass it (`"Failed to read response body", e` and `"Failed to decompress response body", e`).
- Diagnostics-only, no behavior change: the branch, the returned response, and the log message string are unchanged — the log record just gains its `thrown` field.
- A gRPC error response with `grpc-status` in the headers and an empty body reaches this branch via `EOFException`.
- Introduced by #8224 (b665652bb), which added this branch and the compliant sibling in the same commit.

## Testing done

- No test added: nothing observable changes, and no existing test asserts this log record.
- `./gradlew :exporters:sender:okhttp:check` — 42 tests passed.
- No apidiff or CHANGELOG entry: `io.opentelemetry.exporter.sender.okhttp.internal` is internal and the change is not user-facing.
