### PR TITLE
Standardize JdkHttpSender shutdown to await executor termination

### DIFF
--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -414,9 +414,46 @@ public final class JdkHttpSender implements HttpSender {
 
   @Override
   public CompletableResultCode shutdown() {
-    if (managedExecutor) {
-      executorService.shutdown();
+    if (!managedExecutor) {
+      return closeClient();
     }
+
+    // Use shutdownNow() to interrupt in-flight requests, including retry backoff sleeps
+    executorService.shutdownNow();
+
+    // Wait for threads to terminate in a background thread. Closing the client also blocks until
+    // in-flight requests complete, so it must not run on the caller's thread either.
+    CompletableResultCode result = new CompletableResultCode();
+    Thread terminationThread =
+        new Thread(
+            () -> {
+              try {
+                // Wait up to 5 seconds for threads to terminate
+                // Even if timeout occurs, we proceed since these are daemon threads
+                boolean terminated = executorService.awaitTermination(5, TimeUnit.SECONDS);
+                if (!terminated) {
+                  logger.log(
+                      Level.WARNING,
+                      "Executor did not terminate within 5 seconds, proceeding with shutdown since threads are daemon threads.");
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                CompletableResultCode closeResult = closeClient();
+                if (closeResult.isSuccess()) {
+                  result.succeed();
+                } else {
+                  result.failExceptionally(closeResult.getFailureThrowable());
+                }
+              }
+            },
+            "jdkhttp-shutdown");
+    terminationThread.setDaemon(true);
+    terminationThread.start();
+    return result;
+  }
+
+  private CompletableResultCode closeClient() {
     if (AutoCloseable.class.isInstance(client)) {
       try {
         AutoCloseable.class.cast(client).close();

--- a/exporters/sender/jdk/src/test/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderTest.java
+++ b/exporters/sender/jdk/src/test/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderTest.java
@@ -34,6 +34,8 @@ import java.net.http.HttpHeaders;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -106,6 +108,43 @@ class JdkHttpSenderTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.getFailureThrowable()).isInstanceOf(RuntimeException.class);
     assertThat(result.getFailureThrowable().getMessage()).isEqualTo("testShutdownException");
+  }
+
+  @Test
+  void shutdown_managedExecutor_awaitsTermination() {
+    CompletableResultCode result = sender.shutdown();
+    result.join(10, TimeUnit.SECONDS);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(sender)
+        .extracting("executorService", as(InstanceOfAssertFactories.type(ExecutorService.class)))
+        .satisfies(executor -> assertThat(executor.isTerminated()).isTrue());
+  }
+
+  @Test
+  void shutdown_nonManagedExecutor_doesNotShutDownExecutor() {
+    ExecutorService customExecutor = Executors.newSingleThreadExecutor();
+    try {
+      JdkHttpSender testSender =
+          new JdkHttpSender(
+              mockHttpClient,
+              URI.create("http://localhost"),
+              "text/plain",
+              null,
+              Duration.ofSeconds(10),
+              Collections::emptyMap,
+              null,
+              customExecutor,
+              Long.MAX_VALUE);
+
+      CompletableResultCode result = testSender.shutdown();
+
+      assertThat(result.isDone()).isTrue();
+      assertThat(result.isSuccess()).isTrue();
+      assertThat(customExecutor.isShutdown()).isFalse();
+    } finally {
+      customExecutor.shutdownNow();
+    }
   }
 
   @Test


### PR DESCRIPTION
Related to #8280 — continues #8495

## Description

- `shutdown()` used graceful `executorService.shutdown()`, which does not interrupt workers sleeping in the retry backoff, and never awaited termination — the result code completed while export threads were still running.
- It also called `HttpClient.close()`, which blocks until all operations complete, on the caller's thread.
- Now calls `shutdownNow()`, awaits termination (5s, warning on timeout), and closes the client on a daemon thread before completing the result.
- This mirrors the sibling `HttpSender` implementations `OkHttpGrpcSender` (the reference named in the issue) and `OkHttpHttpSender`. OkHttp's `cancelAll()` / `evictAll()` have no `java.net.http` equivalent; `shutdownNow()` plus `close()` cover that role.
- Close failures still propagate through the result code; unmanaged executors still return immediately.

## Testing done

- Added `JdkHttpSenderTest#shutdown_managedExecutor_awaitsTermination` (executor terminated once the result succeeds) and `#shutdown_nonManagedExecutor_doesNotShutDownExecutor` (completes immediately, injected executor left running).
- Existing `testShutdown` / `testShutdownException` cover close-exception propagation on the new async path.
- `./gradlew :exporters:sender:jdk:check` — 13 tests passed.
- No apidiff or `CHANGELOG.md` entry: the japicmp-excluded `internal` package only.

