### PR TITLE
Fix target_info metric name in PrometheusHttpServerBuilder javadoc

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
@@ -96,7 +96,7 @@ public final class PrometheusHttpServerBuilder {
     return this;
   }
 
-  /** Set if the {@code otel_target_info} metric is generated. Default is {@code true}. */
+  /** Set if the {@code target_info} metric is generated. Default is {@code true}. */
   public PrometheusHttpServerBuilder setTargetInfoMetricEnabled(boolean targetInfoMetricEnabled) {
     metricReaderBuilder.setTargetInfoMetricEnabled(targetInfoMetricEnabled);
     return this;


### PR DESCRIPTION
No issue: trivial javadoc typo, submitting directly.

## Description

- `PrometheusHttpServerBuilder.setTargetInfoMetricEnabled` documents the metric as `otel_target_info`, but the exported name is `target_info`.
- `Otel2PrometheusConverter.makeTargetInfo()` hardcodes `MetricMetadata.builder().name("target")`, which the Prometheus client exposes as `target_info`; no code path adds an `otel_` prefix.
- `PrometheusMetricReaderBuilder.setTargetInfoMetricEnabled`, which this method delegates to, already documents it as `target_info`.
- The name matches the [Prometheus compatibility spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md), which defines `target_info`.
- Introduced in #7934, which added this method.

## Testing done

- Docs-only, test-exempt: no test added — existing tests already assert `target_info` output.
- `./gradlew :exporters:prometheus:check` — 202 tests + 1 testJpms test passed.
- No apidiff or CHANGELOG entry: `exporters/prometheus` is alpha (not tracked by japicmp) and nothing user-facing changes.

