### PR TITLE
Skip empty baggage key in OtTracePropagator extract

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java
@@ -146,7 +146,8 @@ public final class OtTracePropagator implements TextMapPropagator {
           break;
         }
         String lowercaseKey = key.toLowerCase(Locale.ROOT);
-        if (!lowercaseKey.startsWith(PREFIX_BAGGAGE_HEADER)) {
+        if (!lowercaseKey.startsWith(PREFIX_BAGGAGE_HEADER)
+            || lowercaseKey.length() == PREFIX_BAGGAGE_HEADER.length()) {
           continue;
         }
         String value = getter.get(carrier, key);

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/OtTracePropagatorTest.java
@@ -391,6 +391,19 @@ class OtTracePropagatorTest {
   }
 
   @Test
+  void extract_Baggage_EmptyKey() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put(OtTracePropagator.TRACE_ID_HEADER, TRACE_ID);
+    carrier.put(OtTracePropagator.SPAN_ID_HEADER, SPAN_ID);
+    carrier.put(OtTracePropagator.SAMPLED_HEADER, Common.TRUE_INT);
+    carrier.put(OtTracePropagator.PREFIX_BAGGAGE_HEADER, "value"); // Not really a valid key.
+
+    Context context = propagator.extract(Context.current(), carrier, getter);
+
+    assertThat(Baggage.fromContext(context)).isEqualTo(Baggage.empty());
+  }
+
+  @Test
   void extract_Baggage_InvalidContext() {
     Map<String, String> carrier = new LinkedHashMap<>();
     carrier.put(OtTracePropagator.TRACE_ID_HEADER, TraceId.getInvalid());


### PR DESCRIPTION
Fixes #8629

## Description

- `OtTracePropagator.extract()` only checked `startsWith(PREFIX_BAGGAGE_HEADER)`, so a header named exactly `ot-baggage-` produced a baggage entry keyed `""`. `inject()` re-emits it, and it consumes one of the 64 baggage entries.
- Skip a header whose length equals the prefix length, matching `JaegerPropagator.getBaggageFromHeader()` and its `extract_baggageOnly_withPrefix_emptyKey` test in the same package.
- An empty key is not a valid baggage key here: `W3CBaggagePropagator.isValidBaggageKey()` rejects it, and the `ImmutableKeyValuePairs` Javadoc makes removing empty keys the caller's responsibility.
- Handling of normal `ot-baggage-<key>` headers, byte accounting, and limits are unchanged.

## Testing done

- Added `OtTracePropagatorTest#extract_Baggage_EmptyKey`, asserting `Baggage.empty()` for a valid span context plus an `ot-baggage-` header.
- Not vacuous: reverting the production change fails it.
- `./gradlew :extensions:trace-propagators:check --rerun-tasks` — 132 tests passed.
- No apidiff (method body only) and no CHANGELOG (only malformed entries stop being extracted).
- `*IT` and GraalVM native-image tests were not run locally.

