### PR TITLE
Avoid unsafe string encoder on Android

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoderHolder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoderHolder.java
@@ -39,6 +39,12 @@ public final class StringEncoderHolder {
    */
   @Nullable
   public static StringEncoder createUnsafeEncoder() {
+    // Android exposes sun.misc.Unsafe, but String does not have the OpenJDK internal fields used by
+    // UnsafeStringEncoder. ART logs an error when these missing fields are queried, even though the
+    // exception is caught.
+    if ("Dalvik".equals(System.getProperty("java.vm.name"))) {
+      return null;
+    }
     return UnsafeStringEncoder.createIfAvailable();
   }
 

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/StringEncoderTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/marshal/StringEncoderTest.java
@@ -13,6 +13,7 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 class StringEncoderTest {
 
@@ -55,6 +56,12 @@ class StringEncoderTest {
   @DisabledOnJre(JRE.JAVA_8)
   void testUtf8SizeLatin1_VarHandle() {
     testUtf8SizeLatin1(varHandleStringEncoder);
+  }
+
+  @Test
+  @SetSystemProperty(key = "java.vm.name", value = "Dalvik")
+  void unsafeStringEncoderNotAvailableOnAndroid() {
+    assertThat(StringEncoderHolder.createUnsafeEncoder()).isNull();
   }
 
   @SuppressWarnings("AvoidEscapedUnicodeCharacters")


### PR DESCRIPTION
Avoid probing OpenJDK-specific String fields when selecting the unsafe string encoder on Android. Android exposes sun.misc.Unsafe, but querying its different String internals causes ART to emit an error before OpenTelemetry can fall back to the standard encoder.

Fixes #8636.