### PR TITLE
Draft: Add TLS protocol configuration for OTLP HTTP exporters

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/logs/OtlpHttpLogRecordExporterBuilder.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -271,6 +272,22 @@ public final class OtlpHttpLogRecordExporterBuilder {
   public OtlpHttpLogRecordExporterBuilder setExecutorService(ExecutorService executorService) {
     requireNonNull(executorService, "executorService");
     delegate.setExecutorService(executorService);
+    return this;
+  }
+
+  /**
+   * Sets the TLS protocol versions enabled for HTTPS connections. If unset, sender defaults are
+   * used.
+   *
+   * <p>Protocol names use the JSSE convention, for example {@code TLSv1.2} and {@code TLSv1.3}. The
+   * JVM security policy may prevent use of configured protocols.
+   *
+   * @param enabledProtocols the non-empty list of TLS protocol versions to enable
+   * @return this builder
+   */
+  public OtlpHttpLogRecordExporterBuilder setEnabledProtocols(List<String> enabledProtocols) {
+    requireNonNull(enabledProtocols, "enabledProtocols");
+    delegate.setEnabledProtocols(enabledProtocols);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -330,6 +331,22 @@ public final class OtlpHttpMetricExporterBuilder {
   public OtlpHttpMetricExporterBuilder setExecutorService(ExecutorService executorService) {
     requireNonNull(executorService, "executorService");
     delegate.setExecutorService(executorService);
+    return this;
+  }
+
+  /**
+   * Sets the TLS protocol versions enabled for HTTPS connections. If unset, sender defaults are
+   * used.
+   *
+   * <p>Protocol names use the JSSE convention, for example {@code TLSv1.2} and {@code TLSv1.3}. The
+   * JVM security policy may prevent use of configured protocols.
+   *
+   * @param enabledProtocols the non-empty list of TLS protocol versions to enable
+   * @return this builder
+   */
+  public OtlpHttpMetricExporterBuilder setEnabledProtocols(List<String> enabledProtocols) {
+    requireNonNull(enabledProtocols, "enabledProtocols");
+    delegate.setEnabledProtocols(enabledProtocols);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.common.internal.StandardComponentId;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -272,6 +273,22 @@ public final class OtlpHttpSpanExporterBuilder {
   public OtlpHttpSpanExporterBuilder setExecutorService(ExecutorService executorService) {
     requireNonNull(executorService, "executorService");
     delegate.setExecutorService(executorService);
+    return this;
+  }
+
+  /**
+   * Sets the TLS protocol versions enabled for HTTPS connections. If unset, sender defaults are
+   * used.
+   *
+   * <p>Protocol names use the JSSE convention, for example {@code TLSv1.2} and {@code TLSv1.3}. The
+   * JVM security policy may prevent use of configured protocols.
+   *
+   * @param enabledProtocols the non-empty list of TLS protocol versions to enable
+   * @return this builder
+   */
+  public OtlpHttpSpanExporterBuilder setEnabledProtocols(List<String> enabledProtocols) {
+    requireNonNull(enabledProtocols, "enabledProtocols");
+    delegate.setEnabledProtocols(enabledProtocols);
     return this;
   }
 

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporterBuilder.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporterBuilder.java
@@ -69,6 +69,7 @@ public final class HttpExporterBuilder {
   private ComponentLoader componentLoader =
       ComponentLoader.forClassLoader(HttpExporterBuilder.class.getClassLoader());
   @Nullable private ExecutorService executorService;
+  @Nullable private List<String> enabledProtocols;
 
   public HttpExporterBuilder(
       StandardComponentId.ExporterType exporterType, String defaultEndpoint) {
@@ -167,6 +168,14 @@ public final class HttpExporterBuilder {
     return this;
   }
 
+  public HttpExporterBuilder setEnabledProtocols(List<String> enabledProtocols) {
+    if (enabledProtocols.isEmpty()) {
+      throw new IllegalArgumentException("enabledProtocols must not be empty");
+    }
+    this.enabledProtocols = Collections.unmodifiableList(new ArrayList<>(enabledProtocols));
+    return this;
+  }
+
   public HttpExporterBuilder exportAsJson() {
     this.exportAsJson = true;
     exporterType = mapToJsonTypeIfPossible(exporterType);
@@ -204,6 +213,7 @@ public final class HttpExporterBuilder {
     copy.internalTelemetryVersion = internalTelemetryVersion;
     copy.proxyOptions = proxyOptions;
     copy.componentLoader = componentLoader;
+    copy.enabledProtocols = enabledProtocols;
     return copy;
   }
 
@@ -245,6 +255,7 @@ public final class HttpExporterBuilder {
                 isPlainHttp ? null : tlsConfigHelper.getSslContext(),
                 isPlainHttp ? null : tlsConfigHelper.getTrustManager(),
                 executorService,
+                enabledProtocols,
                 // 4mb to align with spec guidance - even though we don't do anything with the
                 // response today, we will so better to have future-looking memory profile
                 4 * 1024L * 1024L));

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/ImmutableHttpSenderConfig.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/ImmutableHttpSenderConfig.java
@@ -23,6 +23,10 @@ import javax.net.ssl.X509TrustManager;
 @AutoValue
 abstract class ImmutableHttpSenderConfig implements HttpSenderConfig {
 
+  @Override
+  @Nullable
+  public abstract List<String> getEnabledProtocols();
+
   @SuppressWarnings("TooManyParameters")
   static HttpSenderConfig create(
       URI endpoint,
@@ -36,6 +40,7 @@ abstract class ImmutableHttpSenderConfig implements HttpSenderConfig {
       @Nullable SSLContext sslContext,
       @Nullable X509TrustManager trustManager,
       @Nullable ExecutorService executorService,
+      @Nullable List<String> enabledProtocols,
       long maxResponseBodySize) {
     return new AutoValue_ImmutableHttpSenderConfig(
         endpoint,
@@ -49,6 +54,7 @@ abstract class ImmutableHttpSenderConfig implements HttpSenderConfig {
         sslContext,
         trustManager,
         executorService,
+        enabledProtocols,
         maxResponseBodySize);
   }
 

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSender.java
@@ -45,6 +45,7 @@ import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 
 /**
  * {@link HttpSender} which is backed by JDK {@link HttpClient}.
@@ -118,9 +119,10 @@ public final class JdkHttpSender implements HttpSender {
       @Nullable ProxyOptions proxyOptions,
       @Nullable SSLContext sslContext,
       @Nullable ExecutorService executorService,
+      @Nullable List<String> enabledProtocols,
       long maxResponseBodySize) {
     this(
-        configureClient(sslContext, connectTimeout, proxyOptions),
+        configureClient(sslContext, connectTimeout, proxyOptions, enabledProtocols),
         endpoint,
         contentType,
         compressor,
@@ -144,13 +146,19 @@ public final class JdkHttpSender implements HttpSender {
   private static HttpClient configureClient(
       @Nullable SSLContext sslContext,
       Duration connectTimeout,
-      @Nullable ProxyOptions proxyOptions) {
+      @Nullable ProxyOptions proxyOptions,
+      @Nullable List<String> enabledProtocols) {
     HttpClient.Builder builder = HttpClient.newBuilder().connectTimeout(connectTimeout);
     if (sslContext != null) {
       builder.sslContext(sslContext);
     }
     if (proxyOptions != null) {
       builder.proxy(proxyOptions.getProxySelector());
+    }
+    if (enabledProtocols != null) {
+      SSLParameters sslParameters = new SSLParameters();
+      sslParameters.setProtocols(enabledProtocols.toArray(new String[0]));
+      builder.sslParameters(sslParameters);
     }
     return builder.build();
   }

--- a/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderProvider.java
+++ b/exporters/sender/jdk/src/main/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderProvider.java
@@ -30,6 +30,7 @@ public final class JdkHttpSenderProvider implements HttpSenderProvider {
         httpSenderConfig.getProxyOptions(),
         httpSenderConfig.getSslContext(),
         httpSenderConfig.getExecutorService(),
+        httpSenderConfig.getEnabledProtocols(),
         httpSenderConfig.getMaxResponseBodySize());
   }
 }

--- a/exporters/sender/jdk/src/test/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderTest.java
+++ b/exporters/sender/jdk/src/test/java/io/opentelemetry/exporter/sender/jdk/internal/JdkHttpSenderTest.java
@@ -191,6 +191,7 @@ class JdkHttpSenderTest {
             null,
             null,
             null,
+            null,
             Long.MAX_VALUE);
 
     try {
@@ -219,6 +220,7 @@ class JdkHttpSenderTest {
             Duration.ofNanos(1),
             Duration.ofSeconds(10),
             Collections::emptyMap,
+            null,
             null,
             null,
             null,

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java
@@ -81,6 +81,7 @@ public final class OkHttpHttpSender implements HttpSender {
       @Nullable SSLContext sslContext,
       @Nullable X509TrustManager trustManager,
       @Nullable ExecutorService executorService,
+      @Nullable List<String> enabledProtocols,
       long maxResponseBodySize) {
     int callTimeoutMillis = (int) Math.min(timeout.toMillis(), Integer.MAX_VALUE);
     int connectTimeoutMillis = (int) Math.min(connectTimeout.toMillis(), Integer.MAX_VALUE);
@@ -111,17 +112,28 @@ public final class OkHttpHttpSender implements HttpSender {
     boolean isPlainHttp = endpoint.getScheme().equals("http");
     if (isPlainHttp) {
       builder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));
-    } else if (sslContext != null) {
-      X509TrustManager effectiveTrustManager = trustManager;
+    } else {
+      if (enabledProtocols != null) {
+        ConnectionSpec spec =
+            new ConnectionSpec.Builder(ConnectionSpec.COMPATIBLE_TLS)
+                .tlsVersions(enabledProtocols.toArray(new String[0]))
+                .build();
 
-      if (effectiveTrustManager == null) {
-        try {
-          effectiveTrustManager = TlsUtil.defaultTrustManager();
-        } catch (SSLException e) {
-          throw new IllegalStateException("Unable to initialize default trust manager", e);
-        }
+        builder.connectionSpecs(Collections.singletonList(spec));
       }
-      builder.sslSocketFactory(sslContext.getSocketFactory(), effectiveTrustManager);
+
+      if (sslContext != null) {
+        X509TrustManager effectiveTrustManager = trustManager;
+
+        if (effectiveTrustManager == null) {
+          try {
+            effectiveTrustManager = TlsUtil.defaultTrustManager();
+          } catch (SSLException e) {
+            throw new IllegalStateException("Unable to initialize default trust manager", e);
+          }
+        }
+        builder.sslSocketFactory(sslContext.getSocketFactory(), effectiveTrustManager);
+      }
     }
 
     this.client = builder.build();

--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderProvider.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderProvider.java
@@ -31,6 +31,7 @@ public final class OkHttpHttpSenderProvider implements HttpSenderProvider {
         httpSenderConfig.getSslContext(),
         httpSenderConfig.getTrustManager(),
         httpSenderConfig.getExecutorService(),
+        httpSenderConfig.getEnabledProtocols(),
         httpSenderConfig.getMaxResponseBodySize());
   }
 }

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSenderTest.java
@@ -53,6 +53,7 @@ class OkHttpHttpSenderTest {
             null,
             null,
             executor,
+            null,
             Long.MAX_VALUE);
 
     AtomicReference<HttpResponse> responseRef = new AtomicReference<>();
@@ -216,6 +217,7 @@ class OkHttpHttpSenderTest {
         null,
         null,
         executorService,
+        null,
         Long.MAX_VALUE);
   }
 
@@ -248,6 +250,7 @@ class OkHttpHttpSenderTest {
                     sslContext,
                     null,
                     null,
+                    null,
                     Long.MAX_VALUE))
         .doesNotThrowAnyException();
   }
@@ -274,6 +277,7 @@ class OkHttpHttpSenderTest {
                       null,
                       null,
                       sslContext,
+                      null,
                       null,
                       null,
                       Long.MAX_VALUE))

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSuppressionTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSuppressionTest.java
@@ -47,6 +47,7 @@ class OkHttpHttpSuppressionTest extends AbstractOkHttpSuppressionTest<OkHttpHttp
         null,
         null,
         null,
+        null,
         Long.MAX_VALUE);
   }
 }

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/HttpSenderConfig.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/export/HttpSenderConfig.java
@@ -87,6 +87,11 @@ public interface HttpSenderConfig {
   @Nullable
   ExecutorService getExecutorService();
 
+  @Nullable
+  default List<String> getEnabledProtocols() {
+    return null;
+  }
+
   /**
    * The maximum number of bytes to read from a response body. Defaults to 4 MiB.
    *


### PR DESCRIPTION
Relates to #7573

## Summary

This draft adds `setEnabledProtocols(List<String>)` to OTLP HTTP exporter builders.

The configured protocols are passed to HTTP senders:

* OkHttp uses them to configure its `ConnectionSpec`.
* JDK HTTP client applies them through `SSLParameters`

When unset, existing TLS behavior remains unchanged

## Motivation

Some environments require enabling TLS protocols that are not part of OkHttp's default `MODERN_TLS` configuration. This provides an explicit opt-in without changing defaults.

## Security

No legacy protocols are enabled by default. Users must explicitly configure the protocols they want to allow.

## Open questions

This draft currently covers HTTP senders only. Feedback is welcome on:

* whether this API is the right abstraction
* whether gRPC senders should share the same configuration