### PR TITLE
Fix ObfuscatedLoggerProvider Javadoc copy-paste example

### DIFF
--- a/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
+++ b/sdk/all/src/main/java/io/opentelemetry/sdk/OpenTelemetrySdk.java
@@ -202,7 +202,7 @@ public class OpenTelemetrySdk implements OpenTelemetry, Closeable {
    *
    * <p>Static global providers are obfuscated when they are returned from the API to prevent users
    * from casting them to their SDK specific implementation. For example, we do not want users to
-   * use patterns like {@code (SdkMeterProvider) openTelemetry.getMeterProvider()}.
+   * use patterns like {@code (SdkLoggerProvider) openTelemetry.getLogsBridge()}.
    */
   @ThreadSafe
   // Visible for testing


### PR DESCRIPTION
## Description

- `ObfuscatedLoggerProvider`'s class Javadoc example was copy-pasted from `ObfuscatedMeterProvider` and still referenced `(SdkMeterProvider) openTelemetry.getMeterProvider()`.
- Changed it to `(SdkLoggerProvider) openTelemetry.getLogsBridge()`, the pattern this class actually guards against — it wraps `SdkLoggerProvider` and is exposed via `getLogsBridge()`.
- The sibling classes (`ObfuscatedTracerProvider`, `ObfuscatedMeterProvider`) each point at their own type; only the logger one was wrong.
- Introduced in https://github.com/open-telemetry/opentelemetry-java/pull/5341.

## Testing done

- Docs-only, test-exempt: Javadoc text only, no behavior/signature/public API change.
- `./gradlew :sdk:all:check` passed (test + spotlessCheck + ErrorProne/NullAway + jApiCmp).
- jApiCmp reported no public API changes, so no apidiff update; no CHANGELOG entry (not user-facing).

