### PR TITLE
Fix broken spec data model link in ImmutableSummaryData javadoc

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableSummaryData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/data/ImmutableSummaryData.java
@@ -16,7 +16,7 @@ import javax.annotation.concurrent.Immutable;
  * A summary metric point.
  *
  * <p>See:
- * https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#summary
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#summary
  *
  * <p><i>Note: This is called "DoubleSummary" to reflect which primitives are used to record it,
  * however "Summary" is the equivalent OTLP type.</i>


### PR DESCRIPTION
<!-- No issue: trivial Javadoc dead-link fix, issue not required -->

## Description

- The class javadoc "See:" link pointed to `datamodel.md#summary`, which 404s; the spec file is `data-model.md`.
- Fixed the filename to `data-model.md`, so the link now resolves to the spec's summary section.
- Mirrors the sibling `ImmutableHistogramData`, which already links to `data-model.md#histogram`.

## Testing done

- Docs-only trivial typo, test-exempt: no test added; behavior, signature, public API, and observable output are unchanged.
- `./gradlew :sdk:metrics:check` passed (`:sdk:metrics:test` 698 tests). Internal package, japicmp-exempt: no apidiff change. No CHANGELOG entry (not user-facing).

