### PR TITLE
Remove stray token from addLogRecordProcessorCustomizer Javadoc

### DIFF
--- a/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
+++ b/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/AutoConfiguredOpenTelemetrySdkBuilder.java
@@ -367,9 +367,9 @@ public final class AutoConfiguredOpenTelemetrySdkBuilder implements AutoConfigur
    * Adds a {@link BiFunction} to invoke for all autoconfigured {@link
    * io.opentelemetry.sdk.logs.LogRecordProcessor}s. The return value of the {@link BiFunction} will
    * replace the passed-in argument. In contrast to {@link
-   * #addLogRecordExporterCustomizer(BiFunction)} (BiFunction)} this allows modifications to happen
-   * before batching occurs. As a result, it is possible to efficiently filter logs, add artificial
-   * logs or delay logs for enhancing them with external, delayed data.
+   * #addLogRecordExporterCustomizer(BiFunction)} this allows modifications to happen before
+   * batching occurs. As a result, it is possible to efficiently filter logs, add artificial logs or
+   * delay logs for enhancing them with external, delayed data.
    *
    * <p>Multiple calls will execute the customizers in order.
    */


### PR DESCRIPTION
<!-- No issue: trivial Javadoc typo fix, issue not required -->

## Description

- The Javadoc for `AutoConfiguredOpenTelemetrySdkBuilder.addLogRecordProcessorCustomizer()` had a duplicated ` (BiFunction)}` right after the `{@link #addLogRecordExporterCustomizer(BiFunction)}` reference, which leaked into the generated Javadoc as stray text.
- Removed the stray token. The sibling `addSpanProcessorCustomizer()` Javadoc already uses this clean form (`In contrast to {@link #addSpanExporterCustomizer(BiFunction)} this allows...`).

## Testing done

- Docs-only, test-exempt: no test added.
- `./gradlew :sdk-extensions:autoconfigure:spotlessApply` then `./gradlew :sdk-extensions:autoconfigure:check` — BUILD SUCCESSFUL (compile, spotlessCheck, ErrorProne/NullAway, jApiCmp all passed).
- No public API change, so no apidiff update.

