### PR TITLE
Use normalized key when building getMap error message in DefaultConfigProperties

### DIFF
--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -226,7 +226,10 @@ public final class DefaultConfigProperties implements ConfigProperties {
               String[] split = entry.split("=", 2);
               if (split.length != 2 || StringUtils.isNullOrEmpty(split[0])) {
                 throw new ConfigurationException(
-                    "Invalid map property: " + name + "=" + config.get(name));
+                    "Invalid map property: "
+                        + name
+                        + "="
+                        + config.get(ConfigUtil.normalizePropertyKey(name)));
               }
               return filterBlanksAndNulls(split);
             })

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -174,6 +174,16 @@ class ConfigPropertiesTest {
   }
 
   @Test
+  void invalidMapWithHyphenatedName() {
+    assertThatThrownBy(
+            () ->
+                DefaultConfigProperties.createFromMap(Collections.singletonMap("test-map", "a=1,b"))
+                    .getMap("test-map"))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessage("Invalid map property: test-map=a=1,b");
+  }
+
+  @Test
   void invalidDuration() {
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
Fixes #8642

## Description

- `DefaultConfigProperties.getMap(String)` printed `Invalid map property: <name>=null` when the name needed normalization (hyphens or upper case), because the error message looked the value up with `config.get(name)` while config keys are stored under `ConfigUtil.normalizePropertyKey(name)`.
- Change the message lookup to `config.get(ConfigUtil.normalizePropertyKey(name))`, matching the normalized-key lookup `getList` already uses (line 191).
- Internal method body only: no signature, return value, or public API change.

## Testing done

- Added `ConfigPropertiesTest#invalidMapWithHyphenatedName`: a malformed map value under a hyphenated name (`test-map` = `a=1,b`) now reports `Invalid map property: test-map=a=1,b`; before the fix it reported `test-map=null` (verified failing before, passing after).
- Existing `invalidMap` (name `map`) still passes — normalization is idempotent for already-normalized names.
- `./gradlew :sdk-extensions:autoconfigure-spi:check` — passed; `ConfigPropertiesTest` 17 tests passed. jApiCmp unchanged (internal method body only), no apidiff to commit.

