### PR TITLE
Add toString to ComposableAnnotatingSampler

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSampler.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSampler.java
@@ -44,4 +44,9 @@ final class ComposableAnnotatingSampler implements ComposableSampler {
   public String getDescription() {
     return description;
   }
+
+  @Override
+  public String toString() {
+    return getDescription();
+  }
 }

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSamplerTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSamplerTest.java
@@ -33,6 +33,22 @@ class ComposableAnnotatingSamplerTest {
   }
 
   @Test
+  void descriptionInComposedSampler() {
+    // The annotating sampler must override toString() so that samplers composing it (which build
+    // their description by concatenating the nested sampler) surface its real description instead
+    // of
+    // an Object hash.
+    String description =
+        ComposableSampler.parentThreshold(
+                ComposableSampler.annotating(ComposableSampler.alwaysOn(), Attributes.empty()))
+            .getDescription();
+    assertThat(description)
+        .isEqualTo(
+            "ComposableParentThresholdSampler{rootSampler=ComposableAnnotatingSampler{ComposableAlwaysOnSampler,{}}}");
+    assertThat(description).doesNotContain("@");
+  }
+
+  @Test
   void setsAttributes() {
     SamplingIntent intent =
         ComposableSampler.annotating(ComposableSampler.alwaysOn(), ATTRIBUTES)

--- a/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSamplerTest.java
+++ b/sdk-extensions/incubator/src/test/java/io/opentelemetry/sdk/extension/incubator/trace/samplers/ComposableAnnotatingSamplerTest.java
@@ -36,8 +36,7 @@ class ComposableAnnotatingSamplerTest {
   void descriptionInComposedSampler() {
     // The annotating sampler must override toString() so that samplers composing it (which build
     // their description by concatenating the nested sampler) surface its real description instead
-    // of
-    // an Object hash.
+    // of an Object hash.
     String description =
         ComposableSampler.parentThreshold(
                 ComposableSampler.annotating(ComposableSampler.alwaysOn(), Attributes.empty()))


### PR DESCRIPTION
Fixes #8644

## Description

- `ComposableAnnotatingSampler` was the only one of the seven `ComposableSampler` implementations without a `toString()` override that returns `getDescription()`.
- `ComposableParentThresholdSampler` builds its description by concatenating its root sampler, so composing it with an annotating sampler surfaced an `Object` hash (`ComposableAnnotatingSampler@1a2b3c`) in the observable `getDescription()` output.
- Added the 3-line override, matching the six sibling samplers.

## Testing done

- Added `ComposableAnnotatingSamplerTest#descriptionInComposedSampler` asserting the composed `parentThreshold(annotating(...))` description contains the real annotating description and no `@` object hash — RED before the fix, GREEN after.
- `./gradlew :sdk-extensions:incubator:check` — passed.
- Package-private class in an `-alpha` module; no `docs/apidiffs/` change.

