### PR TITLE
Fix inaccurate ServiceInstanceIdResourceProvider class Javadoc

### DIFF
--- a/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/resources/ServiceInstanceIdResourceProvider.java
+++ b/sdk-extensions/incubator/src/main/java/io/opentelemetry/sdk/extension/incubator/resources/ServiceInstanceIdResourceProvider.java
@@ -14,8 +14,9 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.UUID;
 
 /**
- * does not implement {@link ResourceProvider}, because it depends on all attributes discovered by
- * the other providers.
+ * A {@link ConditionalResourceProvider} for {@code service.instance.id}. It implements {@link
+ * ConditionalResourceProvider} rather than a plain {@link ResourceProvider} because it depends on
+ * the attributes discovered by the other providers.
  */
 public final class ServiceInstanceIdResourceProvider implements ConditionalResourceProvider {
 


### PR DESCRIPTION
Fixes #8646

## Description

- The class Javadoc claimed the provider "does not implement `ResourceProvider`", which is false: it implements `ConditionalResourceProvider`, and `ConditionalResourceProvider extends ResourceProvider`.
- The old text was also a subjectless sentence fragment.
- Rewrote it to explain the provider uses `ConditionalResourceProvider` rather than a plain `ResourceProvider` because it runs after the other providers have discovered their attributes.
- Javadoc-only; no code, signature, or behavior change.

## Testing done

- Docs-only, test-exempt: no test added. `./gradlew :sdk-extensions:incubator:check` passed (spotless + ErrorProne/NullAway + jApiCmp + tests).
- No apidiff change (alpha module, Javadoc-only).

