### PR TITLE
Record error.type on failed collections in PeriodicMetricReader

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -275,6 +275,12 @@ public final class PeriodicMetricReader implements MetricReader {
           Collection<MetricData> metricData;
           try {
             metricData = collectionRegistration.collectAllMetrics();
+          } catch (Throwable t) {
+            // Record the failure on the self-observability sample before it propagates to the
+            // outer handler; otherwise error.type is never set and collection failures are
+            // reported as successful collections.
+            error = t.getClass().getName();
+            throw t;
           } finally {
             long durationNanos = CLOCK.nanoTime() - startNanoTime;
             instrumentation.recordCollection(durationNanos / 1_000_000_000.0, error);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -276,9 +276,6 @@ public final class PeriodicMetricReader implements MetricReader {
           try {
             metricData = collectionRegistration.collectAllMetrics();
           } catch (Throwable t) {
-            // Record the failure on the self-observability sample before it propagates to the
-            // outer handler; otherwise error.type is never set and collection failures are
-            // reported as successful collections.
             error = t.getClass().getName();
             throw t;
           } finally {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderMetricsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderMetricsTest.java
@@ -12,10 +12,13 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.common.internal.SemConvAttributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class SdkMeterProviderMetricsTest {
@@ -57,6 +60,46 @@ class SdkMeterProviderMetricsTest {
                                                 SemConvAttributes.OTEL_COMPONENT_NAME,
                                                 "periodic_metric_reader/0"))));
               });
+    }
+  }
+
+  @Test
+  void collectionFailureIsRecordedWithErrorType() {
+    InMemoryMetricExporter metricExporter = InMemoryMetricExporter.create();
+    AtomicBoolean shouldFail = new AtomicBoolean(true);
+    // Fail the first collection, then succeed so the recorded self-observability sample can be
+    // exported on the following flush.
+    MetricProducer failingProducer =
+        resource -> {
+          if (shouldFail.getAndSet(false)) {
+            throw new IllegalStateException("boom");
+          }
+          return Collections.emptyList();
+        };
+    try (SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder()
+            .registerMetricReader(PeriodicMetricReader.create(metricExporter))
+            .registerMetricProducer(failingProducer)
+            .build()) {
+
+      meterProvider.forceFlush().join(10, TimeUnit.SECONDS);
+      metricExporter.reset();
+      // Export again to export the metric reader's self-observability metric.
+      meterProvider.forceFlush().join(10, TimeUnit.SECONDS);
+
+      assertThat(metricExporter.getFinishedMetricItems())
+          .anySatisfy(
+              m ->
+                  assertThat(m)
+                      .hasName("otel.sdk.metric_reader.collection.duration")
+                      .hasHistogramSatisfying(
+                          h ->
+                              h.hasPointsSatisfying(
+                                  p ->
+                                      p.hasAttributesSatisfying(
+                                          equalTo(
+                                              SemConvAttributes.ERROR_TYPE,
+                                              "java.lang.IllegalStateException")))));
     }
   }
 }


### PR DESCRIPTION
## Problem

In `PeriodicMetricReader.Scheduled.doRun()` the self-observability sample for
`otel.sdk.metric_reader.collection.duration` is always recorded with a `null` error:

```java
long startNanoTime = CLOCK.nanoTime();
String error = null;
Collection<MetricData> metricData;
try {
  metricData = collectionRegistration.collectAllMetrics();
} finally {
  long durationNanos = CLOCK.nanoTime() - startNanoTime;
  instrumentation.recordCollection(durationNanos / 1_000_000_000.0, error);
}
```

`error` is declared, initialized to `null`, and never assigned anywhere in the method, so
`MetricReaderInstrumentation.recordCollection`'s `if (error != null)` branch that attaches the
`error.type` attribute is unreachable from this caller. When `collectAllMetrics()` throws, the
`finally` still records the sample — as a **successful** collection with no `error.type` — and
the exception propagates to the outer `catch (Throwable)`. The self-observability histogram
therefore reports error-free collections while the reader is exporting nothing, which is
exactly the signal an operator would use to detect the outage.

The sibling `BatchSpanProcessor.exportCurrentBatch()` uses the same `String error = null; …
finally { instrumentation…(…, error); }` shape but assigns `error` on each failure path.

## Fix

Set `error` to the throwable's class name before it propagates:

```java
try {
  metricData = collectionRegistration.collectAllMetrics();
} catch (Throwable t) {
  error = t.getClass().getName();
  throw t;
} finally {
  ...
}
```

The rethrow keeps the existing control flow — the exception still reaches the same outer
`catch (Throwable)` — so the only change is that the recorded sample now carries `error.type`.
(`ThrowableUtil.propagateIfFatal` is intentionally not added: the outer catch already handles
all throwables, so it would be a no-op here.)

## Tests

`SdkMeterProviderMetricsTest.collectionFailureIsRecordedWithErrorType`: registers a
`MetricProducer` that throws on the first `produce()` then succeeds, flushes twice, and asserts
the exported `otel.sdk.metric_reader.collection.duration` point carries
`error.type = java.lang.IllegalStateException`. It fails against the current code (the point has
no `error.type`) and passes with the fix. Full `:sdk:metrics:test` suite and
`:sdk:metrics:spotlessCheck` pass; errorprone/NullAway clean.
