### PR TITLE
 Fix ReadOnlyArrayMap.containsValue to handle null 

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/ReadOnlyArrayMap.java
@@ -72,7 +72,8 @@ public final class ReadOnlyArrayMap<K, V> extends AbstractMap<K, V> {
   @Override
   public boolean containsValue(Object o) {
     for (int i = 0; i < array.size(); i += 2) {
-      if (value(i + 1).equals(o)) {
+      V value = value(i + 1);
+      if (o == null ? value == null : o.equals(value)) {
         return true;
       }
     }

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
@@ -31,8 +31,10 @@ class ReadOnlyArrayMapTest {
   @Test
   void containsValueNull() {
     Map<String, String> map = ReadOnlyArrayMap.wrap(Arrays.asList("a", null));
+    Map<String, String> mapWithoutNull = ReadOnlyArrayMap.wrap(Arrays.asList("a", "b"));
 
     assertThat(map.containsValue(null)).isTrue();
     assertThat(map.containsValue("b")).isFalse();
+    assertThat(mapWithoutNull.containsValue(null)).isFalse();
   }
 }

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
@@ -35,5 +35,4 @@ class ReadOnlyArrayMapTest {
     assertThat(map.containsValue(null)).isTrue();
     assertThat(map.containsValue("b")).isFalse();
   }
-
 }

--- a/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/ReadOnlyArrayMapTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.api.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.testing.EqualsTester;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,4 +27,13 @@ class ReadOnlyArrayMapTest {
         .addEqualityGroup(empty, empty)
         .testEquals();
   }
+
+  @Test
+  void containsValueNull() {
+    Map<String, String> map = ReadOnlyArrayMap.wrap(Arrays.asList("a", null));
+
+    assertThat(map.containsValue(null)).isTrue();
+    assertThat(map.containsValue("b")).isFalse();
+  }
+
 }


### PR DESCRIPTION
Previously, containsValue() assumed stored values were non-null when comparing values, which could result in incorrect behavior when the map contained a null value. The comparison has been updated to be null-safe while preserving the existing behavior for non-null values.

I'm happy to make any changes if needed.

Closes #8651 