### PR TITLE
Fix To Ignore empty baggage keys in ImmutableBaggage.put

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java
@@ -69,7 +69,7 @@ final class ImmutableBaggage extends ImmutableKeyValuePairs<String, BaggageEntry
 
     @Override
     public BaggageBuilder put(String key, String value, BaggageEntryMetadata entryMetadata) {
-      if ((key == null) || (value == null) || (entryMetadata == null)) {
+      if ((key == null) || key.isEmpty() || (value == null) || (entryMetadata == null)) {
         return this;
       }
       data.add(key);

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java
@@ -115,7 +115,9 @@ class ImmutableBaggageTest {
   void put_keyEmpty() {
     BaggageBuilder builder = ONE_ENTRY.toBuilder();
     builder.put("", "value");
-    assertThat(builder.build().getEntryValue("")).isEqualTo("value");
+    Baggage build = builder.build();
+    assertThat(build.getEntryValue("")).isNull();
+    assertThat(build).isEqualTo(ONE_ENTRY);
   }
 
   @Test


### PR DESCRIPTION
Previously, [ImmutableBaggage.put Line 72](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/baggage/ImmutableBaggage.java) accepted empty baggage keys, allowing entries with an empty key to be added to a Baggage. The implementation has been updated to ignore empty keys, aligning the behavior with the OpenTelemetry Baggage API specification. A test has also been updated to verify that attempting to add an empty key leaves the Baggage unchanged by updating [ImmutableBaggage.put_keyEmpty Line 115](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/test/java/io/opentelemetry/api/baggage/ImmutableBaggageTest.java).

I'm happy to discuss and update any changes if needed.

Closes #8657 