### PR TITLE
fix(api): handle null context in Baggage.fromContext and fromContextOrNull

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.baggage;
 
+import io.opentelemetry.common.impl.ApiUsageLogger;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ImplicitContextKeyed;
 import java.util.Map;
@@ -52,6 +53,10 @@ public interface Baggage extends ImplicitContextKeyed {
    * Baggage} if there is no baggage in the context.
    */
   static Baggage fromContext(Context context) {
+    if (context == null) {
+      ApiUsageLogger.logNullParam(Baggage.class, "fromContext", "context");
+      return empty();
+    }
     Baggage baggage = context.get(BaggageContextKey.KEY);
     return baggage != null ? baggage : empty();
   }
@@ -62,6 +67,10 @@ public interface Baggage extends ImplicitContextKeyed {
    */
   @Nullable
   static Baggage fromContextOrNull(Context context) {
+    if (context == null) {
+      ApiUsageLogger.logNullParam(Baggage.class, "fromContextOrNull", "context");
+      return null;
+    }
     return context.get(BaggageContextKey.KEY);
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
@@ -54,4 +54,14 @@ class BaggageContextTest {
     Context context = Context.root().with(baggage);
     assertThat(Baggage.fromContextOrNull(context)).isSameAs(baggage);
   }
+
+  @Test
+  void fromContext_null() {
+    assertThat(Baggage.fromContext(null)).isSameAs(Baggage.empty());
+  }
+
+  @Test
+  void fromContextOrNull_null() {
+    assertThat(Baggage.fromContextOrNull(null)).isNull();
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #8665

`Baggage.fromContext(null)` and `Baggage.fromContextOrNull(null)` threw `NullPointerException` because both dereferenced the supplied `Context` without a null guard. This is inconsistent with `Span.fromContext` and `Span.fromContextOrNull`, which already log via `ApiUsageLogger` and return a safe fallback.

## Fix

Apply the same pattern used by `Span`:

- `fromContext(null)` → logs via `ApiUsageLogger.logNullParam` and returns `Baggage.empty()`
- `fromContextOrNull(null)` → logs via `ApiUsageLogger.logNullParam` and returns `null`

## Tests

Added two tests in `BaggageContextTest`:

- `fromContext_null` — asserts `Baggage.empty()` is returned
- `fromContextOrNull_null` — asserts `null` is returned

Note: I could not run the Gradle build locally (no Java runtime on this machine), but the change is a direct copy of the established `Span.fromContext` / `Span.fromContextOrNull` null-handling pattern in the same codebase.