### PR TITLE
Fix Handle null context in Baggage.fromContext() and Baggage.fromContextOrNull()

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -68,7 +68,7 @@ public interface Baggage extends ImplicitContextKeyed {
   @Nullable
   static Baggage fromContextOrNull(Context context) {
     if (context == null) {
-      ApiUsageLogger.logNullParam(Context.class, "fromContextOrNull", "context");
+      ApiUsageLogger.logNullParam(Baggage.class, "fromContextOrNull", "context");
       return null;
     }
     return context.get(BaggageContextKey.KEY);

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.api.baggage;
 
+import io.opentelemetry.common.impl.ApiUsageLogger;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ImplicitContextKeyed;
 import java.util.Map;
@@ -52,6 +53,10 @@ public interface Baggage extends ImplicitContextKeyed {
    * Baggage} if there is no baggage in the context.
    */
   static Baggage fromContext(Context context) {
+    if (context == null) {
+      ApiUsageLogger.logNullParam(Baggage.class, "fromContext", "context");
+      return empty();
+    }
     Baggage baggage = context.get(BaggageContextKey.KEY);
     return baggage != null ? baggage : empty();
   }
@@ -62,6 +67,10 @@ public interface Baggage extends ImplicitContextKeyed {
    */
   @Nullable
   static Baggage fromContextOrNull(Context context) {
+    if (context == null) {
+      ApiUsageLogger.logNullParam(Context.class, "fromContextOrNull", "context");
+      return null;
+    }
     return context.get(BaggageContextKey.KEY);
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
@@ -7,11 +7,20 @@ package io.opentelemetry.api.baggage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
 
+@SuppressLogger(loggerName = "io.opentelemetry.usage")
 class BaggageContextTest {
+
+  @RegisterExtension
+  LogCapturer logCapturer =
+      LogCapturer.create().captureForLogger("io.opentelemetry.usage", Level.TRACE);
 
   @Test
   void testGetCurrentBaggage_Default() {
@@ -44,8 +53,16 @@ class BaggageContextTest {
 
   @Test
   void fromContext_null() {
-    assertThat(Baggage.fromContext(null)).isEqualTo(Baggage.empty());
-    assertThat(Baggage.fromContextOrNull(null)).isNull();
+    Baggage result = Baggage.fromContext(null);
+    assertThat(result).isEqualTo(Baggage.empty());
+    logCapturer.assertContains("context is null");
+  }
+
+  @Test
+  void fromContextOrNull_null() {
+    Baggage result = Baggage.fromContextOrNull(null);
+    assertThat(result).isNull();
+    logCapturer.assertContains("context is null");
   }
 
   @Test

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/BaggageContextTest.java
@@ -43,6 +43,12 @@ class BaggageContextTest {
   }
 
   @Test
+  void fromContext_null() {
+    assertThat(Baggage.fromContext(null)).isEqualTo(Baggage.empty());
+    assertThat(Baggage.fromContextOrNull(null)).isNull();
+  }
+
+  @Test
   void testGetBaggageWithoutDefault_DefaultContext() {
     Baggage baggage = Baggage.fromContextOrNull(Context.root());
     assertThat(baggage).isNull();


### PR DESCRIPTION
In [Baggage](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/baggage/Baggage.java), to add null checks to Baggage.fromContext(context) and Baggage.fromContextOrNull(context) with log using ApiUsageLogger and for Baggage.fromContext(context) now returns empty() when the context is null, also for Baggage.fromContextOrNull(context) returns null. Additionally, added unit tests to cover these scenarios.

I'm happy to update any changes if needed.

Closes #8665 