### PR TITLE
Avoid exposing configuration values in errors

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/OtlpConfigUtil.java
@@ -165,7 +165,7 @@ public final class OtlpConfigUtil {
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables
         addHeader.accept(key, URLDecoder.decode(value, StandardCharsets.UTF_8.name()));
       } catch (Exception e) {
-        throw new ConfigurationException("Cannot decode header value: " + value, e);
+        throw new ConfigurationException("Cannot decode header value for header: " + key, e);
       }
     }
   }

--- a/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
+++ b/exporters/otlp/all/src/test/java/io/opentelemetry/exporter/otlp/internal/OtlpSpanExporterProviderTest.java
@@ -303,9 +303,10 @@ class OtlpSpanExporterProviderTest {
             () -> {
               provider.createExporter(
                   DefaultConfigProperties.createFromMap(
-                      Collections.singletonMap("otel.exporter.otlp.headers", "header-key=%-1")));
+                      Collections.singletonMap(
+                          "otel.exporter.otlp.headers", "header-key=Bearer%20s3cr3t%-1")));
             })
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("Cannot decode header value: %-1");
+        .hasMessage("Cannot decode header value for header: header-key");
   }
 }

--- a/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
+++ b/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/internal/DefaultConfigProperties.java
@@ -225,8 +225,7 @@ public final class DefaultConfigProperties implements ConfigProperties {
             entry -> {
               String[] split = entry.split("=", 2);
               if (split.length != 2 || StringUtils.isNullOrEmpty(split[0])) {
-                throw new ConfigurationException(
-                    "Invalid map property: " + name + "=" + config.get(name));
+                throw new ConfigurationException("Invalid map property: " + name);
               }
               return filterBlanksAndNulls(split);
             })

--- a/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
+++ b/sdk-extensions/autoconfigure-spi/src/test/java/io/opentelemetry/sdk/autoconfigure/spi/internal/ConfigPropertiesTest.java
@@ -161,16 +161,17 @@ class ConfigPropertiesTest {
   void invalidMap() {
     assertThatThrownBy(
             () ->
-                DefaultConfigProperties.createFromMap(Collections.singletonMap("map", "a=1,b"))
+                DefaultConfigProperties.createFromMap(
+                        Collections.singletonMap("map", "authorization=Bearer s3cr3t,malformed"))
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("Invalid map property: map=a=1,b");
+        .hasMessage("Invalid map property: map");
     assertThatThrownBy(
             () ->
                 DefaultConfigProperties.createFromMap(Collections.singletonMap("map", "a=1,=b"))
                     .getMap("map"))
         .isInstanceOf(ConfigurationException.class)
-        .hasMessage("Invalid map property: map=a=1,=b");
+        .hasMessage("Invalid map property: map");
   }
 
   @Test


### PR DESCRIPTION
Malformed map properties and URL-encoded OTLP headers included their raw values in configuration exceptions. These values can contain credentials that subsequently appear in startup logs.

This preserves the property or header name while omitting its value. Regression tests use sentinel credentials to verify the messages remain redacted.