### PR TITLE
Rename double-remove TraceState tests and exercise a non-first entry

### DIFF
--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -306,29 +306,29 @@ class TraceStateTest {
   }
 
   @Test
-  void removeTwice() {
+  void removeSameKeyTwice() {
     assertThat(firstTraceState.toBuilder().remove(FIRST_KEY).remove(FIRST_KEY).build())
         .isEqualTo(TraceState.getDefault());
   }
 
   @Test
-  void removeTwice_KeepsRemainingEntry() {
+  void removeSameKeyTwice_KeepsRemainingEntry() {
     assertThat(multiValueTraceState.toBuilder().remove(FIRST_KEY).remove(FIRST_KEY).build().asMap())
         .containsExactly(entry(SECOND_KEY, SECOND_VALUE));
   }
 
   @Test
-  void removeTwice_KeepsRemainingEntries() {
+  void removeSameKeyTwice_KeepsRemainingEntries() {
     assertThat(
             TraceState.builder()
                 .put(FIRST_KEY, FIRST_VALUE)
                 .put(SECOND_KEY, SECOND_VALUE)
                 .put(THIRD_KEY, THIRD_VALUE)
-                .remove(FIRST_KEY)
-                .remove(FIRST_KEY)
+                .remove(SECOND_KEY)
+                .remove(SECOND_KEY)
                 .build()
                 .asMap())
-        .containsExactly(entry(THIRD_KEY, THIRD_VALUE), entry(SECOND_KEY, SECOND_VALUE));
+        .containsExactly(entry(THIRD_KEY, THIRD_VALUE), entry(FIRST_KEY, FIRST_VALUE));
   }
 
   @Test


### PR DESCRIPTION
## Description

- Follows up on two review comments left on #8613, which were submitted after that PR had already been merged.
- Renames `removeTwice`, `removeTwice_KeepsRemainingEntry` and `removeTwice_KeepsRemainingEntries` to `removeSameKeyTwice*`. All three remove the same key, which the previous names did not say.
- `removeSameKeyTwice_KeepsRemainingEntries` now removes `SECOND_KEY` rather than `FIRST_KEY`. `ArrayBasedTraceStateBuilder.remove` scans entries from the front, so removing the first key always matches on the first iteration; removing a middle key covers a later slot for the first time.
- Test-only: no production code, public API or asserted behavior changes.
- Comments being addressed: https://github.com/open-telemetry/opentelemetry-java/pull/8613#discussion_r3625280623 and https://github.com/open-telemetry/opentelemetry-java/pull/8613#discussion_r3625306202

## Testing done

- `./gradlew :api:all:test --tests "io.opentelemetry.api.trace.TraceStateTest"` — 41 tests passed, 0 skipped. The three renamed methods show up in the test report, so the rename did not drop them.
- `./gradlew :api:all:check` — passed (test, spotless, ErrorProne/NullAway, jApiCmp).
- jApiCmp produced no `docs/apidiffs/current_vs_latest/` update.

