### PR TITLE
Support output_stream in declarative config of otlp_file/development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ exporter.
   ([#8609](https://github.com/open-telemetry/opentelemetry-java/pull/8609))
 * Logging: Include aggregation temporality in `LoggingMetricExporter` `toString`
   ([#8623](https://github.com/open-telemetry/opentelemetry-java/pull/8623))
+* Logging: Support the `output_stream` option when declaratively configuring `otlp_file/development`
+  ([#8676](https://github.com/open-telemetry/opentelemetry-java/pull/8676))
 
 #### Extensions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,6 @@ exporter.
   ([#8609](https://github.com/open-telemetry/opentelemetry-java/pull/8609))
 * Logging: Include aggregation temporality in `LoggingMetricExporter` `toString`
   ([#8623](https://github.com/open-telemetry/opentelemetry-java/pull/8623))
-* Logging: Support the `output_stream` option when declaratively configuring `otlp_file/development`
-  ([#8676](https://github.com/open-telemetry/opentelemetry-java/pull/8676))
 
 #### Extensions
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/OutputStreamConfigUtil.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/OutputStreamConfigUtil.java
@@ -44,7 +44,7 @@ public final class OutputStreamConfigUtil {
     if (outputStream == null) {
       return;
     }
-    if (STDOUT.equalsIgnoreCase(outputStream)) {
+    if (STDOUT.equals(outputStream)) {
       outputStreamConsumer.accept(System.out);
       return;
     }
@@ -67,16 +67,22 @@ public final class OutputStreamConfigUtil {
     try {
       uri = new URI(outputStream);
     } catch (URISyntaxException e) {
-      throw new ConfigurationException("Unrecognized output_stream: " + outputStream, e);
+      throw new ConfigurationException(unrecognized(outputStream), e);
     }
-    if (!FILE_SCHEME.equalsIgnoreCase(uri.getScheme())) {
-      throw new ConfigurationException("Unrecognized output_stream: " + outputStream);
+    if (!FILE_SCHEME.equals(uri.getScheme())) {
+      throw new ConfigurationException(unrecognized(outputStream));
     }
     try {
       return Paths.get(uri);
     } catch (IllegalArgumentException | FileSystemNotFoundException e) {
-      throw new ConfigurationException("Unrecognized output_stream: " + outputStream, e);
+      throw new ConfigurationException(unrecognized(outputStream), e);
     }
+  }
+
+  private static String unrecognized(String outputStream) {
+    return "Unrecognized output_stream: "
+        + outputStream
+        + ". Expected \"stdout\" or a file:// URI.";
   }
 
   private OutputStreamConfigUtil() {}

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/OutputStreamConfigUtil.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/OutputStreamConfigUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.exporter.logging.otlp.internal;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.function.Consumer;
+
+/**
+ * Utilities for configuring the output stream of the OTLP file exporters.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class OutputStreamConfigUtil {
+
+  private static final String STDOUT = "stdout";
+  private static final String FILE_SCHEME = "file";
+
+  /**
+   * Invoke the {@code outputStreamConsumer} with the configured output stream.
+   *
+   * <p>Recognized values are {@code stdout} and a file URI such as {@code
+   * file:///path/to/file.jsonl}. Missing parent directories of the file are created, and the file
+   * is appended to if it already exists.
+   */
+  @SuppressWarnings("SystemOut")
+  public static void configureOutputStream(
+      DeclarativeConfigProperties config, Consumer<OutputStream> outputStreamConsumer) {
+    String outputStream = config.getString("output_stream");
+    if (outputStream == null) {
+      return;
+    }
+    if (STDOUT.equalsIgnoreCase(outputStream)) {
+      outputStreamConsumer.accept(System.out);
+      return;
+    }
+    Path path = filePath(outputStream);
+    try {
+      Path parent = path.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      outputStreamConsumer.accept(
+          new BufferedOutputStream(
+              Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND)));
+    } catch (IOException e) {
+      throw new ConfigurationException("Unable to open output_stream: " + outputStream, e);
+    }
+  }
+
+  private static Path filePath(String outputStream) {
+    URI uri;
+    try {
+      uri = new URI(outputStream);
+    } catch (URISyntaxException e) {
+      throw new ConfigurationException("Unrecognized output_stream: " + outputStream, e);
+    }
+    if (!FILE_SCHEME.equalsIgnoreCase(uri.getScheme())) {
+      throw new ConfigurationException("Unrecognized output_stream: " + outputStream);
+    }
+    try {
+      return Paths.get(uri);
+    } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+      throw new ConfigurationException("Unrecognized output_stream: " + outputStream, e);
+    }
+  }
+
+  private OutputStreamConfigUtil() {}
+}

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/logs/OtlpStdoutLogRecordExporterComponentProvider.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/logs/OtlpStdoutLogRecordExporterComponentProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.logging.otlp.internal.logs;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.exporter.internal.IncubatingExporterBuilderUtil;
+import io.opentelemetry.exporter.logging.otlp.internal.OutputStreamConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
@@ -32,6 +33,7 @@ public final class OtlpStdoutLogRecordExporterComponentProvider implements Compo
   public LogRecordExporter create(DeclarativeConfigProperties config) {
     OtlpStdoutLogRecordExporterBuilder builder = OtlpStdoutLogRecordExporter.builder();
     IncubatingExporterBuilderUtil.configureExporterMemoryMode(config, builder::setMemoryMode);
+    OutputStreamConfigUtil.configureOutputStream(config, builder::setOutput);
     return builder.build();
   }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/metrics/OtlpStdoutMetricExporterComponentProvider.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/metrics/OtlpStdoutMetricExporterComponentProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.logging.otlp.internal.metrics;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.exporter.internal.IncubatingExporterBuilderUtil;
+import io.opentelemetry.exporter.logging.otlp.internal.OutputStreamConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
@@ -36,6 +37,7 @@ public final class OtlpStdoutMetricExporterComponentProvider implements Componen
         config, builder::setAggregationTemporalitySelector);
     IncubatingExporterBuilderUtil.configureOtlpHistogramDefaultAggregation(
         config, builder::setDefaultAggregationSelector);
+    OutputStreamConfigUtil.configureOutputStream(config, builder::setOutput);
     return builder.build();
   }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/traces/OtlpStdoutSpanExporterComponentProvider.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/internal/traces/OtlpStdoutSpanExporterComponentProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.exporter.logging.otlp.internal.traces;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.exporter.internal.IncubatingExporterBuilderUtil;
+import io.opentelemetry.exporter.logging.otlp.internal.OutputStreamConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
@@ -32,6 +33,7 @@ public final class OtlpStdoutSpanExporterComponentProvider implements ComponentP
   public SpanExporter create(DeclarativeConfigProperties config) {
     OtlpStdoutSpanExporterBuilder builder = OtlpStdoutSpanExporter.builder();
     IncubatingExporterBuilderUtil.configureExporterMemoryMode(config, builder::setMemoryMode);
+    OutputStreamConfigUtil.configureOutputStream(config, builder::setOutput);
     return builder.build();
   }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
@@ -363,7 +363,8 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
     return Stream.of(
         Arguments.argumentSet("no scheme", "not-a-stream"),
         Arguments.argumentSet("unsupported scheme", "http://example.com/traces.jsonl"),
-        Arguments.argumentSet("relative file uri", "file://traces.jsonl"));
+        Arguments.argumentSet("relative file uri", "file://traces.jsonl"),
+        Arguments.argumentSet("malformed file uri", "file:///with space.jsonl"));
   }
 
   @ParameterizedTest

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -304,16 +303,10 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
         .isEqualTo(MemoryMode.REUSABLE_DATA);
   }
 
-  static Stream<Arguments> outputStreamStdoutTestCases() {
-    return Stream.of(
-        Arguments.argumentSet("stdout", "stdout"), Arguments.argumentSet("upper case", "STDOUT"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("outputStreamStdoutTestCases")
-  void componentProviderConfigOutputStreamStdout(String value) {
+  @Test
+  void componentProviderConfigOutputStreamStdout() {
     DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
-    when(properties.getString("output_stream")).thenReturn(value);
+    when(properties.getString("output_stream")).thenReturn("stdout");
 
     assertThat(exporterFromComponentProvider(properties))
         .extracting("jsonWriter")
@@ -323,22 +316,16 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
 
   static Stream<Arguments> outputStreamFileTestCases() {
     return Stream.of(
-        Arguments.argumentSet("file uri", "test.jsonl", (UnaryOperator<String>) uri -> uri),
-        Arguments.argumentSet(
-            "authority-less file uri with upper case scheme",
-            "test.jsonl",
-            (UnaryOperator<String>) uri -> uri.replaceFirst("^file://", "FILE:")),
-        Arguments.argumentSet(
-            "missing parent directory", "missing/test.jsonl", (UnaryOperator<String>) uri -> uri));
+        Arguments.argumentSet("file uri", "test.jsonl"),
+        Arguments.argumentSet("missing parent directory", "missing/test.jsonl"));
   }
 
   @ParameterizedTest
   @MethodSource("outputStreamFileTestCases")
-  void componentProviderConfigOutputStreamFile(String relativePath, UnaryOperator<String> uriForm)
-      throws Exception {
+  void componentProviderConfigOutputStreamFile(String relativePath) throws Exception {
     Path file = tempDir.resolve(relativePath);
     DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
-    when(properties.getString("output_stream")).thenReturn(uriForm.apply(file.toUri().toString()));
+    when(properties.getString("output_stream")).thenReturn(file.toUri().toString());
 
     T exporter = exporterFromComponentProvider(properties);
     testDataExporter.export(exporter);
@@ -362,6 +349,8 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
   static Stream<Arguments> outputStreamUnrecognizedTestCases() {
     return Stream.of(
         Arguments.argumentSet("no scheme", "not-a-stream"),
+        Arguments.argumentSet("upper case stdout", "STDOUT"),
+        Arguments.argumentSet("upper case file scheme", "FILE:///test.jsonl"),
         Arguments.argumentSet("unsupported scheme", "http://example.com/traces.jsonl"),
         Arguments.argumentSet("relative file uri", "file://traces.jsonl"),
         Arguments.argumentSet("malformed file uri", "file:///with space.jsonl"));
@@ -375,7 +364,8 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
 
     assertThatExceptionOfType(ConfigurationException.class)
         .isThrownBy(() -> exporterFromComponentProvider(properties))
-        .withMessage("Unrecognized output_stream: " + value);
+        .withMessage(
+            "Unrecognized output_stream: " + value + ". Expected \"stdout\" or a file:// URI.");
   }
 
   @Test

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableList;
 import io.github.netmikey.logunit.api.LogCapturer;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.common.export.MemoryMode;
@@ -30,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -300,6 +302,91 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
     assertThat(exporterFromComponentProvider(properties))
         .extracting("memoryMode")
         .isEqualTo(MemoryMode.REUSABLE_DATA);
+  }
+
+  static Stream<Arguments> outputStreamStdoutTestCases() {
+    return Stream.of(
+        Arguments.argumentSet("stdout", "stdout"), Arguments.argumentSet("upper case", "STDOUT"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("outputStreamStdoutTestCases")
+  void componentProviderConfigOutputStreamStdout(String value) {
+    DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
+    when(properties.getString("output_stream")).thenReturn(value);
+
+    assertThat(exporterFromComponentProvider(properties))
+        .extracting("jsonWriter")
+        .extracting(Object::toString)
+        .isEqualTo("StreamJsonWriter{outputStream=stdout}");
+  }
+
+  static Stream<Arguments> outputStreamFileTestCases() {
+    return Stream.of(
+        Arguments.argumentSet("file uri", "test.jsonl", (UnaryOperator<String>) uri -> uri),
+        Arguments.argumentSet(
+            "authority-less file uri with upper case scheme",
+            "test.jsonl",
+            (UnaryOperator<String>) uri -> uri.replaceFirst("^file://", "FILE:")),
+        Arguments.argumentSet(
+            "missing parent directory", "missing/test.jsonl", (UnaryOperator<String>) uri -> uri));
+  }
+
+  @ParameterizedTest
+  @MethodSource("outputStreamFileTestCases")
+  void componentProviderConfigOutputStreamFile(String relativePath, UnaryOperator<String> uriForm)
+      throws Exception {
+    Path file = tempDir.resolve(relativePath);
+    DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
+    when(properties.getString("output_stream")).thenReturn(uriForm.apply(file.toUri().toString()));
+
+    T exporter = exporterFromComponentProvider(properties);
+    testDataExporter.export(exporter);
+
+    String output = new String(Files.readAllBytes(file), StandardCharsets.UTF_8).trim();
+    JSONAssert.assertEquals(
+        "Got \n" + output,
+        testDataExporter.getExpectedJson(/* withWrapper= */ true),
+        output,
+        false);
+
+    // an exporter created later for the same path appends instead of truncating
+    testDataExporter.shutdown(exporter);
+    T secondExporter = exporterFromComponentProvider(properties);
+    testDataExporter.export(secondExporter);
+    testDataExporter.shutdown(secondExporter);
+    assertThat(new String(Files.readAllBytes(file), StandardCharsets.UTF_8).trim().split("\n"))
+        .hasSize(2);
+  }
+
+  static Stream<Arguments> outputStreamUnrecognizedTestCases() {
+    return Stream.of(
+        Arguments.argumentSet("no scheme", "not-a-stream"),
+        Arguments.argumentSet("unsupported scheme", "http://example.com/traces.jsonl"),
+        Arguments.argumentSet("relative file uri", "file://traces.jsonl"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("outputStreamUnrecognizedTestCases")
+  void componentProviderConfigOutputStreamUnrecognized(String value) {
+    DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
+    when(properties.getString("output_stream")).thenReturn(value);
+
+    assertThatExceptionOfType(ConfigurationException.class)
+        .isThrownBy(() -> exporterFromComponentProvider(properties))
+        .withMessage("Unrecognized output_stream: " + value);
+  }
+
+  @Test
+  void componentProviderConfigOutputStreamNotOpenable() {
+    DeclarativeConfigProperties properties = spy(DeclarativeConfigProperties.empty());
+    // the path exists but is a directory, so it cannot be opened for writing
+    when(properties.getString("output_stream")).thenReturn(tempDir.toUri().toString());
+
+    assertThatExceptionOfType(ConfigurationException.class)
+        .isThrownBy(() -> exporterFromComponentProvider(properties))
+        .withMessageStartingWith("Unable to open output_stream: ")
+        .withCauseInstanceOf(IOException.class);
   }
 
   @SuppressWarnings("unchecked") // Each test subclass selects a provider that creates T.

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
@@ -96,6 +96,11 @@ class DeclarativeConfigurationCreateTest {
                 "cert_file: "
                     + clientCertificatePath.replace("\\", "\\\\")
                     + System.lineSeparator())
+            // Snippets write to file:///var/log/*.jsonl, which is not writable in tests. The
+            // value can be the last line of the file, so the line terminator is not matched.
+            .replaceAll(
+                "output_stream: file:.*",
+                "output_stream: " + tempDir.resolve("output.jsonl").toUri())
             // A snippet references a custom id generator named my_custom_id_generator. Replace with
             // one named test, which we provide via SPI
             .replace("my_custom_id_generator", "test");


### PR DESCRIPTION
Fixes #8675.

The OTLP file exporter builders already accept an arbitrary `OutputStream` and the generated config model already carries `output_stream`, but the declarative configuration component providers never read it so only stdout was reachable without writing code. The support table in `opentelemetry-configuration` reports Java as `not_implemented` for this option, while C++ and PHP report `supported`.

This wires the option through for spans, metrics and logs:

- `stdout` sets `System.out` explicitly, rather than relying on the default installed by the static `builder()` factory. Matching is case-insensitive, like the sibling options parsed in the same `create()` call.
- A file URI is resolved through `java.net.URI`, so both `file:///path` and the authority-less `file:/path` are accepted, with any scheme casing. Missing parent directories are created, the file is opened with `CREATE` + `APPEND` and the stream is wrapped in a `BufferedOutputStream`. `StreamJsonWriter` flushes after every record so buffering does not delay output.
- Anything else fails with a `ConfigurationException`, distinguishing an unusable value from a file that could not be opened.

Two choices worth confirming:

- Append rather than truncate follows the "Streaming appending" section of the file exporter spec, which does not state it outright.
- Creating missing parent directories avoids taking the whole application down at startup when the directory is created by another process, but it is a behaviour the spec does not mention.

Tests are added to `AbstractOtlpStdoutExporterTest` so they run for all three signals: `stdout`, a plain `file://` URI producing the expected JSON, the authority-less and upper case URI form, parent directory creation, an unrecognized value, and a path that cannot be opened.

`DeclarativeConfigurationCreateTest.parseAndCreate_Examples` needed one adjustment. The `ExperimentalOtlpFile*_file.yaml` snippets write to `file:///var/log/*.jsonl`, which is not writable in tests. The test already rewrites `ca_file`, `key_file` and `cert_file` to temp files for the same reason so `output_stream` is rewritten the same way.

Two limitations are left as-is, since addressing either would go beyond wiring up the option. I am happy to follow up if maintainers want them handled here:

- Pointing several signals at the same path opens one stream per signal and `StreamJsonWriter` does not synchronize so concurrent writes can interleave.
- The handle is held for the exporter's lifetime so external log rotation is not picked up.

## Verification

`./gradlew :exporters:logging-otlp:check` and `./gradlew :sdk-extensions:declarative-config:check` pass. `jApiCmp` reports no API change since the new class lives in an `internal` package so `docs/apidiffs` is unchanged.

Also verified end to end with a throwaway test that runs `DeclarativeConfiguration.parseAndCreate` on:

```yaml
file_format: "1.0"
tracer_provider:
  processors:
    - simple:
        exporter:
          otlp_file/development:
            output_stream: file:///tmp/traces.jsonl
```

and confirms the span is written as one JSON line to the file with nothing on stdout.
