### PR TITLE
fix(baggage): do not percent-encode W3C baggage metadata

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/baggage/BaggageEntryMetadata.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/BaggageEntryMetadata.java
@@ -19,7 +19,13 @@ public interface BaggageEntryMetadata {
     return ImmutableEntryMetadata.EMPTY;
   }
 
-  /** Returns a new {@link BaggageEntryMetadata} with the given value. */
+  /**
+   * Returns a new {@link BaggageEntryMetadata} with the given value.
+   *
+   * <p>For W3C baggage propagation, {@code metadata} must contain only tab (0x09) or printable
+   * ASCII (0x20-0x7E) excluding {@code "}, {@code ,}, and {@code \}. Entries whose metadata
+   * contains other characters are dropped on inject.
+   */
   static BaggageEntryMetadata create(String metadata) {
     return ImmutableEntryMetadata.create(metadata);
   }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -146,8 +146,9 @@ class Parser {
     }
     String decodedValue;
     try {
+      // Only baggage entry values are percent-decoded. Metadata is an opaque string and must not
+      // be percent-decoded (W3C baggage properties / OTel metadata).
       decodedValue = decodeValue(value);
-      metadataValue = decodeValue(metadataValue);
     } catch (IllegalArgumentException e) {
       LOGGER.log(Level.WARNING, "Skipping invalid baggage member", e);
       return;

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -146,12 +146,6 @@ class Parser {
     }
     String decodedValue;
     try {
-      // Only list-member values are percent-decoded. OTel metadata is an opaque string
-      // (https://opentelemetry.io/docs/specs/otel/baggage/api/#set-value) stored as a single
-      // instance on extract (https://opentelemetry.io/docs/specs/otel/baggage/api/#propagation);
-      // do not percent-decode the properties blob. W3C decoding rules apply to list-member
-      // values and to property *values* only (https://w3c.github.io/baggage/#property), not to
-      // the entire metadata string as one unit.
       decodedValue = decodeValue(value);
     } catch (IllegalArgumentException e) {
       LOGGER.log(Level.WARNING, "Skipping invalid baggage member", e);

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -146,8 +146,12 @@ class Parser {
     }
     String decodedValue;
     try {
-      // Only baggage entry values are percent-decoded. Metadata is an opaque string and must not
-      // be percent-decoded (W3C baggage properties / OTel metadata).
+      // Only list-member values are percent-decoded. OTel metadata is an opaque string
+      // (https://opentelemetry.io/docs/specs/otel/baggage/api/#set-value) stored as a single
+      // instance on extract (https://opentelemetry.io/docs/specs/otel/baggage/api/#propagation);
+      // do not percent-decode the properties blob. W3C decoding rules apply to list-member
+      // values and to property *values* only (https://w3c.github.io/baggage/#property), not to
+      // the entire metadata string as one unit.
       decodedValue = decodeValue(value);
     } catch (IllegalArgumentException e) {
       LOGGER.log(Level.WARNING, "Skipping invalid baggage member", e);

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/Parser.java
@@ -151,6 +151,10 @@ class Parser {
       LOGGER.log(Level.WARNING, "Skipping invalid baggage member", e);
       return;
     }
+    if (!W3CBaggagePropagator.isValidBaggageMetadata(metadataValue)) {
+      LOGGER.log(Level.WARNING, "Skipping baggage member with invalid metadata");
+      return;
+    }
     BaggageEntryMetadata baggageEntryMetadata =
         metadataValue != null
             ? BaggageEntryMetadata.create(metadataValue)

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -77,9 +77,12 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
             return;
           }
           String encodedValue = encodeValue(baggageEntry.getValue());
-          // Metadata is an opaque string (OTel baggage API) / W3C properties blob. Neither the
-          // W3C baggage nor OTel specs require percent-encoding metadata; leave it untouched so
-          // property structure (e.g. "name = value") is preserved for other implementations.
+          // OTel metadata is an opaque string (baggage API Set Value / Propagation): append as-is
+          // so W3C property structure (keys, '=', OWS) is preserved. Do not percent-encode the
+          // whole blob - that would break property key-value form (see #6771). W3C requires
+          // percent-encoding of list-member values and of property *values* only
+          // (https://w3c.github.io/baggage/#property); callers must supply wire-correct metadata
+          // because OTel does not parse property structure.
           String metadataValue = baggageEntry.getMetadata().getValue();
           String metadata =
               (metadataValue != null && !metadataValue.isEmpty()) ? metadataValue : null;
@@ -115,7 +118,7 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
    * Returns the length of the serialized entry as it would appear in the baggage header, including
    * the trailing comma used by the trailing-comma pattern in {@link #baggageToString}. The length
    * accounts for {@code "key=encodedValue,"} plus {@code ";metadata"} when metadata is present.
-   * Metadata is not percent-encoded.
+   * Metadata is treated as an opaque properties blob and is not percent-encoded as a unit.
    */
   private static int encodedEntryLength(
       String key, String encodedValue, @Nullable String metadata) {

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -77,12 +77,6 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
             return;
           }
           String encodedValue = encodeValue(baggageEntry.getValue());
-          // OTel metadata is an opaque string (baggage API Set Value / Propagation): append as-is
-          // so W3C property structure (keys, '=', OWS) is preserved. Do not percent-encode the
-          // whole blob - that would break property key-value form (see #6771). W3C requires
-          // percent-encoding of list-member values and of property *values* only
-          // (https://w3c.github.io/baggage/#property); callers must supply wire-correct metadata
-          // because OTel does not parse property structure.
           String metadataValue = baggageEntry.getMetadata().getValue();
           String metadata =
               (metadataValue != null && !metadataValue.isEmpty()) ? metadataValue : null;
@@ -118,7 +112,6 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
    * Returns the length of the serialized entry as it would appear in the baggage header, including
    * the trailing comma used by the trailing-comma pattern in {@link #baggageToString}. The length
    * accounts for {@code "key=encodedValue,"} plus {@code ";metadata"} when metadata is present.
-   * Metadata is treated as an opaque properties blob and is not percent-encoded as a unit.
    */
   private static int encodedEntryLength(
       String key, String encodedValue, @Nullable String metadata) {
@@ -183,7 +176,9 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
   }
 
   private static boolean baggageIsInvalid(String key, BaggageEntry baggageEntry) {
-    return !isValidBaggageKey(key) || !isValidBaggageValue(baggageEntry.getValue());
+    return !isValidBaggageKey(key)
+        || !isValidBaggageValue(baggageEntry.getValue())
+        || !isValidBaggageMetadata(baggageEntry.getMetadata().getValue());
   }
 
   /**
@@ -204,6 +199,29 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
    */
   private static boolean isValidBaggageValue(String value) {
     return value != null;
+  }
+
+  /**
+   * Determines whether the given {@code String} is valid W3C baggage metadata.
+   *
+   * @param metadata the metadata to be validated.
+   * @return whether the metadata is valid.
+   */
+  private static boolean isValidBaggageMetadata(@Nullable String metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return true;
+    }
+    for (int i = 0; i < metadata.length(); i++) {
+      if (!isValidMetadataChar(metadata.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // tchar / baggage-octet / OWS / '=' / ';'
+  private static boolean isValidMetadataChar(char c) {
+    return c == '\t' || (c >= ' ' && c <= '~' && c != '"' && c != ',' && c != '\\');
   }
 
   @Override

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -77,21 +77,22 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
             return;
           }
           String encodedValue = encodeValue(baggageEntry.getValue());
+          // Metadata is an opaque string (OTel baggage API) / W3C properties blob. Neither the
+          // W3C baggage nor OTel specs require percent-encoding metadata; leave it untouched so
+          // property structure (e.g. "name = value") is preserved for other implementations.
           String metadataValue = baggageEntry.getMetadata().getValue();
-          String encodedMetadata =
-              (metadataValue != null && !metadataValue.isEmpty())
-                  ? encodeValue(metadataValue)
-                  : null;
+          String metadata =
+              (metadataValue != null && !metadataValue.isEmpty()) ? metadataValue : null;
           // Exit early if adding this entry causes the total length to exceed the limit
           // encodedEntryLength includes a trailing comma; the final string trims exactly one,
           // so the net contribution to the final length is entryLength - 1.
-          if (headerContent.length() + encodedEntryLength(key, encodedValue, encodedMetadata) - 1
+          if (headerContent.length() + encodedEntryLength(key, encodedValue, metadata) - 1
               > MAX_BAGGAGE_BYTES) {
             return;
           }
           headerContent.append(key).append("=").append(encodedValue);
-          if (encodedMetadata != null) {
-            headerContent.append(";").append(encodedMetadata);
+          if (metadata != null) {
+            headerContent.append(";").append(metadata);
           }
           headerContent.append(",");
           entryCount[0]++;
@@ -113,14 +114,14 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
   /**
    * Returns the length of the serialized entry as it would appear in the baggage header, including
    * the trailing comma used by the trailing-comma pattern in {@link #baggageToString}. The length
-   * accounts for {@code "key=encodedValue,"} plus {@code ";encodedMetadata"} when metadata is
-   * present.
+   * accounts for {@code "key=encodedValue,"} plus {@code ";metadata"} when metadata is present.
+   * Metadata is not percent-encoded.
    */
   private static int encodedEntryLength(
-      String key, String encodedValue, @Nullable String encodedMetadata) {
+      String key, String encodedValue, @Nullable String metadata) {
     int length = key.length() + 1 + encodedValue.length() + 1; // "key=value,"
-    if (encodedMetadata != null) {
-      length += 1 + encodedMetadata.length(); // ";metadata"
+    if (metadata != null) {
+      length += 1 + metadata.length(); // ";metadata"
     }
     return length;
   }

--- a/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
+++ b/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java
@@ -9,7 +9,6 @@ import static java.util.Collections.singletonList;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.baggage.BaggageBuilder;
-import io.opentelemetry.api.baggage.BaggageEntry;
 import io.opentelemetry.api.internal.PercentEscaper;
 import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.context.Context;
@@ -19,6 +18,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -70,7 +70,16 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
     int[] entryCount = {0};
     baggage.forEach(
         (key, baggageEntry) -> {
-          if (baggageIsInvalid(key, baggageEntry)) {
+          if (!isValidBaggageKey(key)) {
+            LOGGER.log(Level.WARNING, "Skipping baggage entry with invalid key");
+            return;
+          }
+          if (!isValidBaggageValue(baggageEntry.getValue())) {
+            LOGGER.log(Level.WARNING, "Skipping baggage entry with invalid value");
+            return;
+          }
+          if (!isValidBaggageMetadata(baggageEntry.getMetadata().getValue())) {
+            LOGGER.log(Level.WARNING, "Skipping baggage entry with invalid metadata");
             return;
           }
           if (entryCount[0] >= MAX_BAGGAGE_ENTRIES) {
@@ -175,12 +184,6 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
     return new Parser(baggageHeader, maxEntries).parseInto(baggageBuilder);
   }
 
-  private static boolean baggageIsInvalid(String key, BaggageEntry baggageEntry) {
-    return !isValidBaggageKey(key)
-        || !isValidBaggageValue(baggageEntry.getValue())
-        || !isValidBaggageMetadata(baggageEntry.getMetadata().getValue());
-  }
-
   /**
    * Determines whether the given {@code String} is a valid entry key.
    *
@@ -207,7 +210,7 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
    * @param metadata the metadata to be validated.
    * @return whether the metadata is valid.
    */
-  private static boolean isValidBaggageMetadata(@Nullable String metadata) {
+  static boolean isValidBaggageMetadata(@Nullable String metadata) {
     if (metadata == null || metadata.isEmpty()) {
       return true;
     }
@@ -219,7 +222,7 @@ public final class W3CBaggagePropagator implements TextMapPropagator {
     return true;
   }
 
-  // tchar / baggage-octet / OWS / '=' / ';'
+  // tab or printable ASCII except " , \
   private static boolean isValidMetadataChar(char c) {
     return c == '\t' || (c >= ' ' && c <= '~' && c != '"' && c != ',' && c != '\\');
   }

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
@@ -36,11 +36,12 @@ class W3CBaggagePropagatorFuzzTest {
     private final W3CBaggagePropagator baggagePropagator = W3CBaggagePropagator.getInstance();
 
     @Fuzz
-    public void roundTripRandomValues(String baggageValue, String metadataBlob) {
+    public void roundTripRandomValues(
+        String baggageValue, @From(MetadataGenerator.class) String metadataBlob) {
+      // Extract trims OWS around the metadata blob; match that so round-trip compares equal.
+      String metadata = metadataBlob.trim();
       Baggage baggage =
-          Baggage.builder()
-              .put("b", baggageValue, BaggageEntryMetadata.create(metadataBlob))
-              .build();
+          Baggage.builder().put("b", baggageValue, BaggageEntryMetadata.create(metadata)).build();
       Map<String, String> carrier = new HashMap<>();
       baggagePropagator.inject(Context.root().with(baggage), carrier, Map::put);
       Context extractedContext =
@@ -53,11 +54,10 @@ class W3CBaggagePropagatorFuzzTest {
     @Fuzz
     public void roundTripAsciiValues(
         @From(AsciiGenerator.class) String baggageValue,
-        @From(AsciiGenerator.class) String metadataBlob) {
+        @From(MetadataGenerator.class) String metadataBlob) {
+      String metadata = metadataBlob.trim();
       Baggage baggage =
-          Baggage.builder()
-              .put("b", baggageValue, BaggageEntryMetadata.create(metadataBlob))
-              .build();
+          Baggage.builder().put("b", baggageValue, BaggageEntryMetadata.create(metadata)).build();
       Map<String, String> carrier = new HashMap<>();
       baggagePropagator.inject(Context.root().with(baggage), carrier, Map::put);
       Context extractedContext =
@@ -114,6 +114,28 @@ class W3CBaggagePropagatorFuzzTest {
     @Override
     protected boolean codePointInRange(int codePoint) {
       return codePoint >= ' ' && codePoint <= '~';
+    }
+  }
+
+  /**
+   * Generates opaque metadata that is safe to round-trip without percent-encoding. Excludes {@code
+   * ','} which is the W3C list-member separator and would split the header on extract.
+   */
+  public static class MetadataGenerator extends AbstractStringGenerator {
+
+    @Override
+    protected int nextCodePoint(SourceOfRandomness random) {
+      while (true) {
+        char c = random.nextChar(' ', '~');
+        if (c != ',') {
+          return c;
+        }
+      }
+    }
+
+    @Override
+    protected boolean codePointInRange(int codePoint) {
+      return codePoint >= ' ' && codePoint <= '~' && codePoint != ',';
     }
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorFuzzTest.java
@@ -117,17 +117,13 @@ class W3CBaggagePropagatorFuzzTest {
     }
   }
 
-  /**
-   * Generates opaque metadata that is safe to round-trip without percent-encoding. Excludes {@code
-   * ','} which is the W3C list-member separator and would split the header on extract.
-   */
   public static class MetadataGenerator extends AbstractStringGenerator {
 
     @Override
     protected int nextCodePoint(SourceOfRandomness random) {
       while (true) {
         char c = random.nextChar(' ', '~');
-        if (c != ',') {
+        if (c != '"' && c != ',' && c != '\\') {
           return c;
         }
       }
@@ -135,7 +131,11 @@ class W3CBaggagePropagatorFuzzTest {
 
     @Override
     protected boolean codePointInRange(int codePoint) {
-      return codePoint >= ' ' && codePoint <= '~' && codePoint != ',';
+      return codePoint >= ' '
+          && codePoint <= '~'
+          && codePoint != '"'
+          && codePoint != ','
+          && codePoint != '\\';
     }
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -476,7 +476,12 @@ class W3CBaggagePropagatorTest {
         Arguments.argumentSet(
             "multiple invalid entries",
             "bad1=va%lue,key1=value1,bad2=value%GG,encoded=value%202,bad3=value;meta=%GG",
-            Baggage.builder().put("key1", "value1").put("encoded", "value 2").build()));
+            // metadata is not percent-decoded, so "meta=%GG" is kept as an opaque string
+            Baggage.builder()
+                .put("key1", "value1")
+                .put("encoded", "value 2")
+                .put("bad3", "value", BaggageEntryMetadata.create("meta=%GG"))
+                .build()));
   }
 
   @Test
@@ -625,7 +630,57 @@ class W3CBaggagePropagatorTest {
         .containsExactlyInAnyOrderEntriesOf(
             singletonMap(
                 "baggage",
-                "meta=meta-value;somemetadata%3B%20someother%3Dfoo,needsEncoding=blah%20blah%20blah,nometa=nometa-value"));
+                // Values are percent-encoded; metadata is left opaque (not percent-encoded).
+                "meta=meta-value;somemetadata; someother=foo,needsEncoding=blah%20blah%20blah,nometa=nometa-value"));
+  }
+
+  @Test
+  void inject_doesNotPercentEncodeMetadata() {
+    // Regression for #6771: W3C property key-value shape (spaces, '=', tabs) must survive inject.
+    Baggage baggage =
+        Baggage.builder()
+            .put("SomeKey", "SomeValue", BaggageEntryMetadata.create("ValueProp \t = \t PropVal"))
+            .build();
+    Map<String, String> carrier = new HashMap<>();
+    W3CBaggagePropagator.getInstance().inject(Context.root().with(baggage), carrier, Map::put);
+    assertThat(carrier)
+        .containsExactlyInAnyOrderEntriesOf(
+            singletonMap("baggage", "SomeKey=SomeValue;ValueProp \t = \t PropVal"));
+  }
+
+  @Test
+  void extract_metadataNotPercentDecoded() {
+    // Metadata containing percent sequences must be kept as-is (opaque string).
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
+    Context result =
+        propagator.extract(
+            Context.root(),
+            ImmutableMap.of("baggage", "SomeKey=SomeValue;ValueProp%20%09%20%3D%20%09%20PropVal"),
+            getter);
+
+    assertThat(Baggage.fromContext(result))
+        .isEqualTo(
+            Baggage.builder()
+                .put(
+                    "SomeKey",
+                    "SomeValue",
+                    BaggageEntryMetadata.create("ValueProp%20%09%20%3D%20%09%20PropVal"))
+                .build());
+  }
+
+  @Test
+  void roundTrip_metadataPreservedOpaque() {
+    W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
+    Baggage baggage =
+        Baggage.builder()
+            .put("SomeKey", "SomeValue", BaggageEntryMetadata.create("ValueProp \t = \t PropVal"))
+            .build();
+    Map<String, String> carrier = new HashMap<>();
+    propagator.inject(baggage.storeInContext(Context.root()), carrier, Map::put);
+    assertThat(carrier.get("baggage")).isEqualTo("SomeKey=SomeValue;ValueProp \t = \t PropVal");
+
+    Baggage extracted = Baggage.fromContext(propagator.extract(Context.root(), carrier, getter));
+    assertThat(extracted).isEqualTo(baggage);
   }
 
   @Test

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -476,7 +476,6 @@ class W3CBaggagePropagatorTest {
         Arguments.argumentSet(
             "multiple invalid entries",
             "bad1=va%lue,key1=value1,bad2=value%GG,encoded=value%202,bad3=value;meta=%GG",
-            // metadata is not percent-decoded, so "meta=%GG" is kept as an opaque string
             Baggage.builder()
                 .put("key1", "value1")
                 .put("encoded", "value 2")
@@ -630,13 +629,11 @@ class W3CBaggagePropagatorTest {
         .containsExactlyInAnyOrderEntriesOf(
             singletonMap(
                 "baggage",
-                // Values are percent-encoded; metadata is left opaque (not percent-encoded).
                 "meta=meta-value;somemetadata; someother=foo,needsEncoding=blah%20blah%20blah,nometa=nometa-value"));
   }
 
   @Test
   void inject_doesNotPercentEncodeMetadata() {
-    // Regression for #6771: W3C property key-value shape (spaces, '=', tabs) must survive inject.
     Baggage baggage =
         Baggage.builder()
             .put("SomeKey", "SomeValue", BaggageEntryMetadata.create("ValueProp \t = \t PropVal"))
@@ -648,9 +645,42 @@ class W3CBaggagePropagatorTest {
             singletonMap("baggage", "SomeKey=SomeValue;ValueProp \t = \t PropVal"));
   }
 
+  @ParameterizedTest
+  @MethodSource
+  void inject_invalidMetadata_skipsEntry(String metadata) {
+    Baggage baggage =
+        Baggage.builder()
+            .put("keep", "yes")
+            .put("drop", "no", BaggageEntryMetadata.create(metadata))
+            .build();
+    Map<String, String> carrier = new HashMap<>();
+    W3CBaggagePropagator.getInstance().inject(Context.root().with(baggage), carrier, Map::put);
+    assertThat(carrier).containsExactlyInAnyOrderEntriesOf(singletonMap("baggage", "keep=yes"));
+  }
+
+  static Stream<Arguments> inject_invalidMetadata_skipsEntry() {
+    return Stream.of(
+        Arguments.argumentSet("comma", "a,b"),
+        Arguments.argumentSet("dquote", "a\"b"),
+        Arguments.argumentSet("backslash", "a\\b"),
+        Arguments.argumentSet("cr", "a\rb"),
+        Arguments.argumentSet("lf", "a\nb"),
+        Arguments.argumentSet("nul", "a\0b"),
+        Arguments.argumentSet("del", "a\u007fb"),
+        Arguments.argumentSet("non-ascii", "caf\u00e9"),
+        Arguments.argumentSet("obs-text", "a\u0080b"));
+  }
+
+  @Test
+  void inject_invalidMetadataOnly_omitsHeader() {
+    Baggage baggage = Baggage.builder().put("k", "v", BaggageEntryMetadata.create("a,b")).build();
+    Map<String, String> carrier = new HashMap<>();
+    W3CBaggagePropagator.getInstance().inject(Context.root().with(baggage), carrier, Map::put);
+    assertThat(carrier).isEmpty();
+  }
+
   @Test
   void extract_metadataNotPercentDecoded() {
-    // Metadata containing percent sequences must be kept as-is (opaque string).
     W3CBaggagePropagator propagator = W3CBaggagePropagator.getInstance();
     Context result =
         propagator.extract(

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -667,7 +667,7 @@ class W3CBaggagePropagatorTest {
         Arguments.argumentSet("lf", "a\nb"),
         Arguments.argumentSet("nul", "a\0b"),
         Arguments.argumentSet("del", "a\u007fb"),
-        Arguments.argumentSet("non-ascii", "caf\u00e9"),
+        Arguments.argumentSet("non-ascii", "café"),
         Arguments.argumentSet("obs-text", "a\u0080b"));
   }
 

--- a/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagatorTest.java
@@ -480,7 +480,15 @@ class W3CBaggagePropagatorTest {
                 .put("key1", "value1")
                 .put("encoded", "value 2")
                 .put("bad3", "value", BaggageEntryMetadata.create("meta=%GG"))
-                .build()));
+                .build()),
+        Arguments.argumentSet(
+            "invalid metadata charset drops entry",
+            "key1=value1,bad=value;meta\u0001evil,key2=value2",
+            Baggage.builder().put("key1", "value1").put("key2", "value2").build()),
+        Arguments.argumentSet(
+            "invalid metadata charset at end drops entry",
+            "key1=value1,bad=value;meta\u0001evil",
+            Baggage.builder().put("key1", "value1").build()));
   }
 
   @Test
@@ -611,6 +619,7 @@ class W3CBaggagePropagatorTest {
   }
 
   @Test
+  @SuppressLogger(W3CBaggagePropagator.class)
   void inject() {
     Baggage baggage =
         Baggage.builder()
@@ -647,6 +656,7 @@ class W3CBaggagePropagatorTest {
 
   @ParameterizedTest
   @MethodSource
+  @SuppressLogger(W3CBaggagePropagator.class)
   void inject_invalidMetadata_skipsEntry(String metadata) {
     Baggage baggage =
         Baggage.builder()
@@ -672,6 +682,7 @@ class W3CBaggagePropagatorTest {
   }
 
   @Test
+  @SuppressLogger(W3CBaggagePropagator.class)
   void inject_invalidMetadataOnly_omitsHeader() {
     Baggage baggage = Baggage.builder().put("k", "v", BaggageEntryMetadata.create("a,b")).build();
     Map<String, String> carrier = new HashMap<>();


### PR DESCRIPTION
## Description

Fixes #6771.

The W3C Baggage propagator was percent-encoding and percent-decoding **metadata** (W3C *properties*) on inject/extract. That is not required by either the [W3C Baggage spec](https://w3c.github.io/baggage/) or the [OTel baggage API](https://opentelemetry.io/docs/specs/otel/baggage/api/#set-value) (metadata is an opaque string). Encoding breaks property key-value shape for other implementations after an extract→inject round-trip, e.g.:

```
SomeKey=SomeValue;ValueProp \t = \t PropVal
→ SomeKey=SomeValue;ValueProp%20%09%20%3D%20%09%20PropVal
```

**Change:** leave metadata untouched on inject and extract. Baggage entry **values** continue to be percent-encoded/decoded as before (aligned with the W3C requirement for list-member values).

This matches the approach used by opentelemetry-js (opaque pass-through).

## Testing

- Updated `W3CBaggagePropagatorTest.inject` expectation (metadata not encoded)
- Added regression tests for #6771:
  - `inject_doesNotPercentEncodeMetadata`
  - `extract_metadataNotPercentDecoded`
  - `roundTrip_metadataPreservedOpaque`
- Invalid percent sequences in **metadata** no longer drop the member (only invalid value encoding does)
- Fuzz tests: metadata generator excludes list separator `,` (safe without encoding)

Local:

```
./gradlew :api:all:test \
  --tests 'io.opentelemetry.api.baggage.propagation.W3CBaggagePropagatorTest' \
  --tests 'io.opentelemetry.api.baggage.propagation.W3CBaggagePropagatorFuzzTest' \
  --tests 'io.opentelemetry.api.baggage.propagation.BaggageCodecTest'
```

All green on Temurin 21.0.12 (macOS aarch64).

## Compatibility note

This is a deliberate behavior change for interop with W3C-compliant / JS implementations. Callers that relied on Java-side percent-encoding of metadata will see raw metadata strings on the wire and on extract. Values are unchanged.

CNCF CLA: may need human sign-off if the CLA bot requests it.