### PR TITLE
docs: document legacy metrics

### DIFF
--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
@@ -17,6 +17,9 @@ import java.util.logging.Logger;
  * A {@link LogRecordExporter} which writes {@linkplain LogRecordData logs} to a {@link Logger} in
  * OTLP JSON format. Each log line will include a single {@code ResourceLogs}.
  *
+ * <p>Note: This class is superseded by {@code OtlpStdoutLogRecordExporter}, which allows
+ * configuring a custom logger or output stream.
+ *
  * @since 1.19.0
  */
 public final class OtlpJsonLoggingLogRecordExporter implements LogRecordExporter {

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  * A {@link LogRecordExporter} which writes {@linkplain LogRecordData logs} to a {@link Logger} in
  * OTLP JSON format. Each log line will include a single {@code ResourceLogs}.
  *
- * <p>Note: This class is superseded by {@code OtlpStdoutLogRecordExporter}, which allows
+ * <p>Note: This class is superseded by {@link OtlpStdoutLogRecordExporter}, which allows
  * configuring a custom logger or output stream.
  *
  * @since 1.19.0

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -19,8 +19,8 @@ import java.util.logging.Logger;
  * A {@link MetricExporter} which writes {@linkplain MetricData metrics} to a {@link Logger} in OTLP
  * JSON format. Each log line will include a single {@code ResourceMetrics}.
  *
- * <p>Note: This class is superseded by {@code OtlpStdoutMetricExporter}, which allows configuring
- * a custom logger or output stream.
+ * <p>Note: This class is superseded by {@code OtlpStdoutMetricExporter}, which allows configuring a
+ * custom logger or output stream.
  */
 public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -18,6 +18,9 @@ import java.util.logging.Logger;
 /**
  * A {@link MetricExporter} which writes {@linkplain MetricData metrics} to a {@link Logger} in OTLP
  * JSON format. Each log line will include a single {@code ResourceMetrics}.
+ *
+ * <p>Note: This class is superseded by {@code OtlpStdoutMetricExporter}, which allows configuring
+ * a custom logger or output stream.
  */
 public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
  * A {@link MetricExporter} which writes {@linkplain MetricData metrics} to a {@link Logger} in OTLP
  * JSON format. Each log line will include a single {@code ResourceMetrics}.
  *
- * <p>Note: This class is superseded by {@code OtlpStdoutMetricExporter}, which allows configuring a
+ * <p>Note: This class is superseded by {@link OtlpStdoutMetricExporter}, which allows configuring a
  * custom logger or output stream.
  */
 public final class OtlpJsonLoggingMetricExporter implements MetricExporter {

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -17,8 +17,8 @@ import java.util.logging.Logger;
  * A {@link SpanExporter} which writes {@linkplain SpanData spans} to a {@link Logger} in OTLP JSON
  * format. Each log line will include a single {@code ResourceSpans}.
  *
- * <p>Note: This class is superseded by {@code OtlpStdoutSpanExporter}, which allows configuring
- * a custom logger or output stream.
+ * <p>Note: This class is superseded by {@code OtlpStdoutSpanExporter}, which allows configuring a
+ * custom logger or output stream.
  */
 public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
 

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  * A {@link SpanExporter} which writes {@linkplain SpanData spans} to a {@link Logger} in OTLP JSON
  * format. Each log line will include a single {@code ResourceSpans}.
  *
- * <p>Note: This class is superseded by {@code OtlpStdoutSpanExporter}, which allows configuring a
+ * <p>Note: This class is superseded by {@link OtlpStdoutSpanExporter}, which allows configuring a
  * custom logger or output stream.
  */
 public final class OtlpJsonLoggingSpanExporter implements SpanExporter {

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -16,6 +16,9 @@ import java.util.logging.Logger;
 /**
  * A {@link SpanExporter} which writes {@linkplain SpanData spans} to a {@link Logger} in OTLP JSON
  * format. Each log line will include a single {@code ResourceSpans}.
+ *
+ * <p>Note: This class is superseded by {@code OtlpStdoutSpanExporter}, which allows configuring
+ * a custom logger or output stream.
  */
 public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
 


### PR DESCRIPTION
Fixes #8370

## Summary

Document that the legacy OTLP JSON logging exporters are superseded by the corresponding `OtlpStdout*Exporter` implementations.

The updated Javadocs clarify that the legacy exporters use `java.util.logging` and direct users to the stdout exporters when they need to configure a custom logger (for example, SLF4J) or a custom output stream.

## Changes

* Updated `OtlpJsonLoggingMetricExporter` Javadoc
* Updated `OtlpJsonLoggingSpanExporter` Javadoc
* Updated `OtlpJsonLoggingLogRecordExporter` Javadoc

## Notes

* Documentation-only change
* No behavioral or API changes
