### PR TITLE
feat(sdk-metrics): align PeriodicMetricReader export timeout semantics

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-sdk-metrics.txt
@@ -1,4 +1,6 @@
 Comparing source compatibility of opentelemetry-sdk-metrics-1.65.0-SNAPSHOT.jar against opentelemetry-sdk-metrics-1.64.0.jar
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder setExporterTimeout(long, java.util.concurrent.TimeUnit)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder setExporterTimeout(java.time.Duration)
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.sdk.metrics.export.PeriodicMetricReaderBuilder setInternalTelemetryVersion(io.opentelemetry.sdk.common.InternalTelemetryVersion)

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -214,32 +214,66 @@ public final class PeriodicMetricReader implements MetricReader {
 
     private Scheduled() {}
 
+    private CompletableResultCode withTimeout(CompletableResultCode result) {
+      if (result.isDone() || exporterTimeoutNanos == Long.MAX_VALUE) {
+        return result;
+      }
+      CompletableResultCode timeoutResult = new CompletableResultCode();
+      ScheduledFuture<?> timeoutFuture =
+          scheduler.schedule(timeoutResult::fail, exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+      result.whenComplete(
+          () -> {
+            if (timeoutFuture != null) {
+              timeoutFuture.cancel(false);
+            }
+            if (result.isSuccess()) {
+              timeoutResult.succeed();
+            } else {
+              timeoutResult.fail();
+            }
+          });
+      return timeoutResult;
+    }
+
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
-        CompletableResultCode result = exporter.export(metricData);
-        result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
-        return result.isSuccess()
-            ? CompletableResultCode.ofSuccess()
-            : CompletableResultCode.ofFailure();
+        return withTimeout(exporter.export(metricData));
       }
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
       CompletableResultCode sequentialResult = new CompletableResultCode();
       AtomicBoolean anyFailed = new AtomicBoolean(false);
       Iterator<Collection<MetricData>> batchIterator = batches.iterator();
-      while (batchIterator.hasNext()) {
-        Collection<MetricData> currentBatch = batchIterator.next();
-        CompletableResultCode currentResult = exporter.export(currentBatch);
-        currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
-        if (!currentResult.isSuccess()) {
-          anyFailed.set(true);
-        }
-      }
-      if (anyFailed.get()) {
-        sequentialResult.fail();
-      } else {
-        sequentialResult.succeed();
-      }
+      Runnable exportNext =
+          new Runnable() {
+            @Override
+            public void run() {
+              while (batchIterator.hasNext()) {
+                Collection<MetricData> currentBatch = batchIterator.next();
+                CompletableResultCode currentResult = withTimeout(exporter.export(currentBatch));
+                if (currentResult.isDone()) {
+                  if (!currentResult.isSuccess()) {
+                    anyFailed.set(true);
+                  }
+                } else {
+                  currentResult.whenComplete(
+                      () -> {
+                        if (!currentResult.isSuccess()) {
+                          anyFailed.set(true);
+                        }
+                        this.run();
+                      });
+                  return;
+                }
+              }
+              if (anyFailed.get()) {
+                sequentialResult.fail();
+              } else {
+                sequentialResult.succeed();
+              }
+            }
+          };
+      exportNext.run();
       return sequentialResult;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -264,6 +264,10 @@ public final class PeriodicMetricReader implements MetricReader {
         return result;
       }
 
+      if (result.isDone()) {
+        return result;
+      }
+
       try {
         CompletableResultCode timeoutResult = new CompletableResultCode();
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -223,17 +222,15 @@ public final class PeriodicMetricReader implements MetricReader {
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
       CompletableResultCode sequentialResult = new CompletableResultCode();
-      AtomicBoolean anyFailed = new AtomicBoolean(false);
-      Iterator<Collection<MetricData>> batchIterator = batches.iterator();
-      while (batchIterator.hasNext()) {
-        Collection<MetricData> currentBatch = batchIterator.next();
+      boolean anyFailed = false;
+      for (Collection<MetricData> currentBatch : batches) {
         CompletableResultCode currentResult = exporter.export(currentBatch);
         currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
         if (!currentResult.isSuccess()) {
-          anyFailed.set(true);
+          anyFailed = true;
         }
       }
-      if (anyFailed.get()) {
+      if (anyFailed) {
         sequentialResult.fail();
       } else {
         sequentialResult.succeed();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -11,7 +11,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.internal.ComponentId;
-import io.opentelemetry.sdk.common.internal.DaemonThreadFactory;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -20,7 +19,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +49,6 @@ public final class PeriodicMetricReader implements MetricReader {
   private final long intervalNanos;
   private final long exporterTimeoutNanos;
   private final ScheduledExecutorService scheduler;
-  private final ScheduledExecutorService timeoutExecutor;
   private final Scheduled scheduled;
   private final Object lock = new Object();
   private final InternalTelemetryVersion internalTelemetryVersion;
@@ -84,9 +82,6 @@ public final class PeriodicMetricReader implements MetricReader {
     this.intervalNanos = intervalNanos;
     this.exporterTimeoutNanos = exporterTimeoutNanos;
     this.scheduler = scheduler;
-    this.timeoutExecutor =
-        Executors.newSingleThreadScheduledExecutor(
-            new DaemonThreadFactory("PeriodicMetricReader-timeout"));
     this.maxExportBatchSize = maxExportBatchSize;
     this.scheduled = new Scheduled();
     this.internalTelemetryVersion = internalTelemetryVersion;
@@ -154,13 +149,6 @@ public final class PeriodicMetricReader implements MetricReader {
       // reset the interrupted status
       Thread.currentThread().interrupt();
     } finally {
-      timeoutExecutor.shutdown();
-      try {
-        timeoutExecutor.awaitTermination(5, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        timeoutExecutor.shutdownNow();
-        Thread.currentThread().interrupt();
-      }
       CompletableResultCode shutdownResult = scheduled.shutdown();
       shutdownResult.whenComplete(
           () -> {
@@ -275,34 +263,35 @@ public final class PeriodicMetricReader implements MetricReader {
       if (exporterTimeoutNanos == Long.MAX_VALUE) {
         return result;
       }
-      CompletableResultCode timeoutResult = new CompletableResultCode();
-      AtomicBoolean timedOut = new AtomicBoolean(false);
-      ScheduledFuture<?> timeoutFuture =
-          timeoutExecutor.schedule(
-              () -> {
-                if (!result.isDone()) {
-                  timedOut.set(true);
+
+      try {
+        CompletableResultCode timeoutResult = new CompletableResultCode();
+
+        ScheduledFuture<?> timeoutFuture =
+            scheduler.schedule(
+                () -> {
                   logger.log(
                       Level.WARNING, "Export timed out after " + exporterTimeoutNanos + "ns");
                   timeoutResult.fail();
-                }
-              },
-              exporterTimeoutNanos,
-              TimeUnit.NANOSECONDS);
-      result.whenComplete(
-          () -> {
-            if (timeoutFuture != null) {
+                },
+                exporterTimeoutNanos,
+                TimeUnit.NANOSECONDS);
+
+        result.whenComplete(
+            () -> {
               timeoutFuture.cancel(false);
-            }
-            if (!timedOut.get()) {
               if (result.isSuccess()) {
                 timeoutResult.succeed();
               } else {
                 timeoutResult.fail();
               }
-            }
-          });
-      return timeoutResult;
+            });
+
+        return timeoutResult;
+      } catch (RejectedExecutionException e) {
+        // Scheduler is shutting down, return original result without timeout enforcement
+        return result;
+      }
     }
 
     void setMeterProvider(MeterProvider meterProvider) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -46,6 +46,7 @@ public final class PeriodicMetricReader implements MetricReader {
 
   private final MetricExporter exporter;
   private final long intervalNanos;
+  private final long exporterTimeoutNanos;
   private final ScheduledExecutorService scheduler;
   private final Scheduled scheduled;
   private final Object lock = new Object();
@@ -72,11 +73,13 @@ public final class PeriodicMetricReader implements MetricReader {
   PeriodicMetricReader(
       MetricExporter exporter,
       long intervalNanos,
+      long exporterTimeoutNanos,
       ScheduledExecutorService scheduler,
       int maxExportBatchSize,
       InternalTelemetryVersion internalTelemetryVersion) {
     this.exporter = exporter;
     this.intervalNanos = intervalNanos;
+    this.exporterTimeoutNanos = exporterTimeoutNanos;
     this.scheduler = scheduler;
     this.maxExportBatchSize = maxExportBatchSize;
     this.scheduled = new Scheduled();
@@ -213,43 +216,30 @@ public final class PeriodicMetricReader implements MetricReader {
 
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
-        return exporter.export(metricData);
+        CompletableResultCode result = exporter.export(metricData);
+        result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        return result.isSuccess()
+            ? CompletableResultCode.ofSuccess()
+            : CompletableResultCode.ofFailure();
       }
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
       CompletableResultCode sequentialResult = new CompletableResultCode();
       AtomicBoolean anyFailed = new AtomicBoolean(false);
       Iterator<Collection<MetricData>> batchIterator = batches.iterator();
-      Runnable exportNext =
-          new Runnable() {
-            @Override
-            public void run() {
-              while (batchIterator.hasNext()) {
-                Collection<MetricData> currentBatch = batchIterator.next();
-                CompletableResultCode currentResult = exporter.export(currentBatch);
-                if (currentResult.isDone()) {
-                  if (!currentResult.isSuccess()) {
-                    anyFailed.set(true);
-                  }
-                } else {
-                  currentResult.whenComplete(
-                      () -> {
-                        if (!currentResult.isSuccess()) {
-                          anyFailed.set(true);
-                        }
-                        this.run();
-                      });
-                  return;
-                }
-              }
-              if (anyFailed.get()) {
-                sequentialResult.fail();
-              } else {
-                sequentialResult.succeed();
-              }
-            }
-          };
-      exportNext.run();
+      while (batchIterator.hasNext()) {
+        Collection<MetricData> currentBatch = batchIterator.next();
+        CompletableResultCode currentResult = exporter.export(currentBatch);
+        currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        if (!currentResult.isSuccess()) {
+          anyFailed.set(true);
+        }
+      }
+      if (anyFailed.get()) {
+        sequentialResult.fail();
+      } else {
+        sequentialResult.succeed();
+      }
       return sequentialResult;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.internal.ComponentId;
+import io.opentelemetry.sdk.common.internal.DaemonThreadFactory;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -18,6 +19,8 @@ import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +50,7 @@ public final class PeriodicMetricReader implements MetricReader {
   private final long intervalNanos;
   private final long exporterTimeoutNanos;
   private final ScheduledExecutorService scheduler;
+  private final ScheduledExecutorService timeoutExecutor;
   private final Scheduled scheduled;
   private final Object lock = new Object();
   private final InternalTelemetryVersion internalTelemetryVersion;
@@ -80,6 +84,9 @@ public final class PeriodicMetricReader implements MetricReader {
     this.intervalNanos = intervalNanos;
     this.exporterTimeoutNanos = exporterTimeoutNanos;
     this.scheduler = scheduler;
+    this.timeoutExecutor =
+        Executors.newSingleThreadScheduledExecutor(
+            new DaemonThreadFactory("PeriodicMetricReader-timeout"));
     this.maxExportBatchSize = maxExportBatchSize;
     this.scheduled = new Scheduled();
     this.internalTelemetryVersion = internalTelemetryVersion;
@@ -147,6 +154,13 @@ public final class PeriodicMetricReader implements MetricReader {
       // reset the interrupted status
       Thread.currentThread().interrupt();
     } finally {
+      timeoutExecutor.shutdown();
+      try {
+        timeoutExecutor.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        timeoutExecutor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
       CompletableResultCode shutdownResult = scheduled.shutdown();
       shutdownResult.whenComplete(
           () -> {
@@ -216,30 +230,79 @@ public final class PeriodicMetricReader implements MetricReader {
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
         CompletableResultCode result = exporter.export(metricData);
-        if (exporterTimeoutNanos != Long.MAX_VALUE) {
-          result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
-        }
-        return result;
+        return applyTimeout(result);
       }
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
       CompletableResultCode sequentialResult = new CompletableResultCode();
-      boolean anyFailed = false;
-      for (Collection<MetricData> currentBatch : batches) {
-        CompletableResultCode currentResult = exporter.export(currentBatch);
-        if (exporterTimeoutNanos != Long.MAX_VALUE) {
-          currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
-        }
-        if (!currentResult.isSuccess()) {
-          anyFailed = true;
-        }
-      }
-      if (anyFailed) {
-        sequentialResult.fail();
-      } else {
-        sequentialResult.succeed();
-      }
+      AtomicBoolean anyFailed = new AtomicBoolean(false);
+      Iterator<Collection<MetricData>> batchIterator = batches.iterator();
+      Runnable exportNext =
+          new Runnable() {
+            @Override
+            public void run() {
+              while (batchIterator.hasNext()) {
+                Collection<MetricData> currentBatch = batchIterator.next();
+                CompletableResultCode currentResult = exporter.export(currentBatch);
+                CompletableResultCode timeoutResult = applyTimeout(currentResult);
+                if (timeoutResult.isDone()) {
+                  if (!timeoutResult.isSuccess()) {
+                    anyFailed.set(true);
+                  }
+                } else {
+                  timeoutResult.whenComplete(
+                      () -> {
+                        if (!timeoutResult.isSuccess()) {
+                          anyFailed.set(true);
+                        }
+                        this.run();
+                      });
+                  return;
+                }
+              }
+              if (anyFailed.get()) {
+                sequentialResult.fail();
+              } else {
+                sequentialResult.succeed();
+              }
+            }
+          };
+      exportNext.run();
       return sequentialResult;
+    }
+
+    private CompletableResultCode applyTimeout(CompletableResultCode result) {
+      if (exporterTimeoutNanos == Long.MAX_VALUE) {
+        return result;
+      }
+      CompletableResultCode timeoutResult = new CompletableResultCode();
+      AtomicBoolean timedOut = new AtomicBoolean(false);
+      ScheduledFuture<?> timeoutFuture =
+          timeoutExecutor.schedule(
+              () -> {
+                if (!result.isDone()) {
+                  timedOut.set(true);
+                  logger.log(
+                      Level.WARNING, "Export timed out after " + exporterTimeoutNanos + "ns");
+                  timeoutResult.fail();
+                }
+              },
+              exporterTimeoutNanos,
+              TimeUnit.NANOSECONDS);
+      result.whenComplete(
+          () -> {
+            if (timeoutFuture != null) {
+              timeoutFuture.cancel(false);
+            }
+            if (!timedOut.get()) {
+              if (result.isSuccess()) {
+                timeoutResult.succeed();
+              } else {
+                timeoutResult.fail();
+              }
+            }
+          });
+      return timeoutResult;
     }
 
     void setMeterProvider(MeterProvider meterProvider) {

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -214,66 +214,30 @@ public final class PeriodicMetricReader implements MetricReader {
 
     private Scheduled() {}
 
-    private CompletableResultCode withTimeout(CompletableResultCode result) {
-      if (result.isDone() || exporterTimeoutNanos == Long.MAX_VALUE) {
-        return result;
-      }
-      CompletableResultCode timeoutResult = new CompletableResultCode();
-      ScheduledFuture<?> timeoutFuture =
-          scheduler.schedule(timeoutResult::fail, exporterTimeoutNanos, TimeUnit.NANOSECONDS);
-      result.whenComplete(
-          () -> {
-            if (timeoutFuture != null) {
-              timeoutFuture.cancel(false);
-            }
-            if (result.isSuccess()) {
-              timeoutResult.succeed();
-            } else {
-              timeoutResult.fail();
-            }
-          });
-      return timeoutResult;
-    }
-
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
-        return withTimeout(exporter.export(metricData));
+        CompletableResultCode result = exporter.export(metricData);
+        result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        return result;
       }
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
       CompletableResultCode sequentialResult = new CompletableResultCode();
       AtomicBoolean anyFailed = new AtomicBoolean(false);
       Iterator<Collection<MetricData>> batchIterator = batches.iterator();
-      Runnable exportNext =
-          new Runnable() {
-            @Override
-            public void run() {
-              while (batchIterator.hasNext()) {
-                Collection<MetricData> currentBatch = batchIterator.next();
-                CompletableResultCode currentResult = withTimeout(exporter.export(currentBatch));
-                if (currentResult.isDone()) {
-                  if (!currentResult.isSuccess()) {
-                    anyFailed.set(true);
-                  }
-                } else {
-                  currentResult.whenComplete(
-                      () -> {
-                        if (!currentResult.isSuccess()) {
-                          anyFailed.set(true);
-                        }
-                        this.run();
-                      });
-                  return;
-                }
-              }
-              if (anyFailed.get()) {
-                sequentialResult.fail();
-              } else {
-                sequentialResult.succeed();
-              }
-            }
-          };
-      exportNext.run();
+      while (batchIterator.hasNext()) {
+        Collection<MetricData> currentBatch = batchIterator.next();
+        CompletableResultCode currentResult = exporter.export(currentBatch);
+        currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        if (!currentResult.isSuccess()) {
+          anyFailed.set(true);
+        }
+      }
+      if (anyFailed.get()) {
+        sequentialResult.fail();
+      } else {
+        sequentialResult.succeed();
+      }
       return sequentialResult;
     }
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -216,7 +216,9 @@ public final class PeriodicMetricReader implements MetricReader {
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
         CompletableResultCode result = exporter.export(metricData);
-        result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        if (exporterTimeoutNanos != Long.MAX_VALUE) {
+          result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        }
         return result;
       }
       Collection<Collection<MetricData>> batches =
@@ -225,7 +227,9 @@ public final class PeriodicMetricReader implements MetricReader {
       boolean anyFailed = false;
       for (Collection<MetricData> currentBatch : batches) {
         CompletableResultCode currentResult = exporter.export(currentBatch);
-        currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        if (exporterTimeoutNanos != Long.MAX_VALUE) {
+          currentResult.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        }
         if (!currentResult.isSuccess()) {
           anyFailed = true;
         }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java
@@ -217,8 +217,7 @@ public final class PeriodicMetricReader implements MetricReader {
 
     private CompletableResultCode exportMetrics(Collection<MetricData> metricData) {
       if (maxExportBatchSize == 0) {
-        CompletableResultCode result = exporter.export(metricData);
-        return applyTimeout(result);
+        return exporter.export(metricData);
       }
       Collection<Collection<MetricData>> batches =
           MetricExportBatcher.batchMetrics(metricData, maxExportBatchSize);
@@ -232,15 +231,14 @@ public final class PeriodicMetricReader implements MetricReader {
               while (batchIterator.hasNext()) {
                 Collection<MetricData> currentBatch = batchIterator.next();
                 CompletableResultCode currentResult = exporter.export(currentBatch);
-                CompletableResultCode timeoutResult = applyTimeout(currentResult);
-                if (timeoutResult.isDone()) {
-                  if (!timeoutResult.isSuccess()) {
+                if (currentResult.isDone()) {
+                  if (!currentResult.isSuccess()) {
                     anyFailed.set(true);
                   }
                 } else {
-                  timeoutResult.whenComplete(
+                  currentResult.whenComplete(
                       () -> {
-                        if (!timeoutResult.isSuccess()) {
+                        if (!currentResult.isSuccess()) {
                           anyFailed.set(true);
                         }
                         this.run();
@@ -332,13 +330,19 @@ public final class PeriodicMetricReader implements MetricReader {
             exportAvailable.set(true);
             flushResult.succeed();
           } else {
-            CompletableResultCode result = exportMetrics(metricData);
-            result.whenComplete(
+            CompletableResultCode rawResult = exportMetrics(metricData);
+            CompletableResultCode timeoutResult = applyTimeout(rawResult);
+            // Use raw result for backpressure to prevent concurrent exports
+            rawResult.whenComplete(
                 () -> {
-                  if (!result.isSuccess()) {
+                  exportAvailable.set(true);
+                });
+            // Use timeout result for reporting to caller
+            timeoutResult.whenComplete(
+                () -> {
+                  if (!timeoutResult.isSuccess()) {
                     logger.log(Level.WARNING, "Exporter failed");
                   }
-                  exportAvailable.set(true);
                   flushResult.succeed();
                 });
           }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -61,8 +61,7 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
-   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
@@ -72,8 +71,7 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
-   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -61,7 +61,8 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
+   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
@@ -71,7 +72,8 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
+   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -63,8 +63,6 @@ public final class PeriodicMetricReaderBuilder {
   /**
    * Sets the timeout for the underlying exporter. If unset, defaults to {@value
    * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
-   *
-   * @since 1.40.0
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
@@ -76,8 +74,6 @@ public final class PeriodicMetricReaderBuilder {
   /**
    * Sets the timeout for the underlying exporter. If unset, defaults to {@value
    * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
-   *
-   * @since 1.40.0
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -106,7 +106,7 @@ public final class PeriodicMetricReaderBuilder {
     ScheduledExecutorService executor = this.executor;
     if (executor == null) {
       executor =
-          Executors.newScheduledThreadPool(1, new DaemonThreadFactory("PeriodicMetricReader"));
+          Executors.newScheduledThreadPool(2, new DaemonThreadFactory("PeriodicMetricReader"));
     }
     return new PeriodicMetricReader(
         metricExporter,

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 public final class PeriodicMetricReaderBuilder {
 
   static final long DEFAULT_SCHEDULE_DELAY_MINUTES = 1;
-  static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
 
   private final MetricExporter metricExporter;
 
@@ -61,8 +60,10 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
-   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to the configured interval.
+   *
+   * <p>When {@link #setMaxExportBatchSize(int)} is configured, the timeout applies to each
+   * individual export(batch) invocation, not the aggregate export cycle.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(long timeout, TimeUnit unit) {
     requireNonNull(unit, "unit");
@@ -72,8 +73,10 @@ public final class PeriodicMetricReaderBuilder {
   }
 
   /**
-   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
-   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   * Sets the timeout for the underlying exporter. If unset, defaults to the configured interval.
+   *
+   * <p>When {@link #setMaxExportBatchSize(int)} is configured, the timeout applies to each
+   * individual export(batch) invocation, not the aggregate export cycle.
    */
   public PeriodicMetricReaderBuilder setExporterTimeout(Duration timeout) {
     requireNonNull(timeout, "timeout");
@@ -111,9 +114,7 @@ public final class PeriodicMetricReaderBuilder {
     return new PeriodicMetricReader(
         metricExporter,
         intervalNanos,
-        exporterTimeoutNanos != null
-            ? exporterTimeoutNanos
-            : Math.min(intervalNanos, TimeUnit.MILLISECONDS.toNanos(DEFAULT_EXPORT_TIMEOUT_MILLIS)),
+        exporterTimeoutNanos != null ? exporterTimeoutNanos : intervalNanos,
         executor,
         maxExportBatchSize,
         internalTelemetryVersion);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -32,7 +32,7 @@ public final class PeriodicMetricReaderBuilder {
 
   private long intervalNanos = TimeUnit.MINUTES.toNanos(DEFAULT_SCHEDULE_DELAY_MINUTES);
 
-  private long exporterTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_EXPORT_TIMEOUT_MILLIS);
+  @Nullable private Long exporterTimeoutNanos;
 
   @Nullable private ScheduledExecutorService executor;
 
@@ -111,7 +111,9 @@ public final class PeriodicMetricReaderBuilder {
     return new PeriodicMetricReader(
         metricExporter,
         intervalNanos,
-        exporterTimeoutNanos,
+        exporterTimeoutNanos != null
+            ? exporterTimeoutNanos
+            : Math.min(intervalNanos, TimeUnit.MILLISECONDS.toNanos(DEFAULT_EXPORT_TIMEOUT_MILLIS)),
         executor,
         maxExportBatchSize,
         internalTelemetryVersion);

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderBuilder.java
@@ -24,12 +24,15 @@ import javax.annotation.Nullable;
 public final class PeriodicMetricReaderBuilder {
 
   static final long DEFAULT_SCHEDULE_DELAY_MINUTES = 1;
+  static final int DEFAULT_EXPORT_TIMEOUT_MILLIS = 30_000;
 
   private final MetricExporter metricExporter;
 
   private InternalTelemetryVersion internalTelemetryVersion = InternalTelemetryVersion.LATEST;
 
   private long intervalNanos = TimeUnit.MINUTES.toNanos(DEFAULT_SCHEDULE_DELAY_MINUTES);
+
+  private long exporterTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(DEFAULT_EXPORT_TIMEOUT_MILLIS);
 
   @Nullable private ScheduledExecutorService executor;
 
@@ -55,6 +58,30 @@ public final class PeriodicMetricReaderBuilder {
   public PeriodicMetricReaderBuilder setInterval(Duration interval) {
     requireNonNull(interval, "interval");
     return setInterval(interval.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
+   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   *
+   * @since 1.40.0
+   */
+  public PeriodicMetricReaderBuilder setExporterTimeout(long timeout, TimeUnit unit) {
+    requireNonNull(unit, "unit");
+    checkArgument(timeout >= 0, "timeout must be non-negative");
+    exporterTimeoutNanos = timeout == 0 ? Long.MAX_VALUE : unit.toNanos(timeout);
+    return this;
+  }
+
+  /**
+   * Sets the timeout for the underlying exporter. If unset, defaults to {@value
+   * DEFAULT_EXPORT_TIMEOUT_MILLIS}ms.
+   *
+   * @since 1.40.0
+   */
+  public PeriodicMetricReaderBuilder setExporterTimeout(Duration timeout) {
+    requireNonNull(timeout, "timeout");
+    return setExporterTimeout(timeout.toNanos(), TimeUnit.NANOSECONDS);
   }
 
   /** Sets the {@link ScheduledExecutorService} to schedule reads on. */
@@ -86,7 +113,12 @@ public final class PeriodicMetricReaderBuilder {
           Executors.newScheduledThreadPool(1, new DaemonThreadFactory("PeriodicMetricReader"));
     }
     return new PeriodicMetricReader(
-        metricExporter, intervalNanos, executor, maxExportBatchSize, internalTelemetryVersion);
+        metricExporter,
+        intervalNanos,
+        exporterTimeoutNanos,
+        executor,
+        maxExportBatchSize,
+        internalTelemetryVersion);
   }
 
   /** Sets the internal telemetry version used to control self-observability metrics. */

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -799,6 +800,38 @@ class PeriodicMetricReaderTest {
     } finally {
       reader.shutdown();
     }
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  void export_alreadyCompleted_doesNotScheduleTimeout() {
+    ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+    ScheduledFuture mockFuture = mock(ScheduledFuture.class);
+    when(mockScheduler.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
+        .thenReturn(mockFuture);
+
+    MetricExporter fastExporter = mock(MetricExporter.class);
+    when(fastExporter.export(any())).thenReturn(CompletableResultCode.ofSuccess());
+    when(fastExporter.flush()).thenReturn(CompletableResultCode.ofSuccess());
+    when(fastExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    when(fastExporter.getAggregationTemporality(any()))
+        .thenReturn(AggregationTemporality.CUMULATIVE);
+
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(fastExporter)
+            .setInterval(Duration.ofMillis(50))
+            .setExporterTimeout(Duration.ofSeconds(1))
+            .setExecutor(mockScheduler)
+            .build();
+
+    reader.register(collectionRegistration);
+
+    reader.forceFlush();
+
+    // Verify scheduleAtFixedRate was called (for periodic export)
+    verify(mockScheduler, times(1)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+    // Verify schedule (for timeout) was never called because the export completed synchronously
+    verify(mockScheduler, never()).schedule(any(Runnable.class), anyLong(), any());
   }
 
   @Test

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -771,14 +771,14 @@ class PeriodicMetricReaderTest {
     // This test verifies that by default, a 30-second timeout is applied
     // We test this by having an exporter that takes less than 30 seconds
     // and ensuring it completes successfully
-    SlowMetricExporter slowExporter = new SlowMetricExporter(100); // 100ms delay
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(100); // 100ms delay
     PeriodicMetricReader reader =
-        PeriodicMetricReader.builder(slowExporter).setInterval(Duration.ofMillis(50)).build();
+        PeriodicMetricReader.builder(delayingExporter).setInterval(Duration.ofMillis(50)).build();
 
     reader.register(collectionRegistration);
     try {
       // Wait for an export to complete - should succeed since 100ms < 30s
-      assertThat(slowExporter.waitForExport()).isTrue();
+      assertThat(delayingExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -786,16 +786,16 @@ class PeriodicMetricReaderTest {
 
   @Test
   void explicitTimeout_exporterCompletesBeforeTimeout() throws Exception {
-    FastMetricExporter fastExporter = new FastMetricExporter();
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(0); // 0ms = fast
     PeriodicMetricReader reader =
-        PeriodicMetricReader.builder(fastExporter)
+        PeriodicMetricReader.builder(delayingExporter)
             .setInterval(Duration.ofMillis(50))
             .setExporterTimeout(Duration.ofSeconds(1)) // 1 second timeout
             .build();
 
     reader.register(collectionRegistration);
     try {
-      assertThat(fastExporter.waitForExport()).isTrue();
+      assertThat(delayingExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -803,9 +803,9 @@ class PeriodicMetricReaderTest {
 
   @Test
   void explicitTimeout_withBatching_completesBeforeTimeout() throws Exception {
-    FastMetricExporter fastExporter = new FastMetricExporter();
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(0); // 0ms = fast
     PeriodicMetricReader reader =
-        PeriodicMetricReader.builder(fastExporter)
+        PeriodicMetricReader.builder(delayingExporter)
             .setInterval(Duration.ofMillis(50))
             .setExporterTimeout(Duration.ofSeconds(1))
             .setMaxExportBatchSize(2)
@@ -813,7 +813,7 @@ class PeriodicMetricReaderTest {
 
     reader.register(collectionRegistration);
     try {
-      assertThat(fastExporter.waitForExport()).isTrue();
+      assertThat(delayingExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -821,16 +821,16 @@ class PeriodicMetricReaderTest {
 
   @Test
   void explicitTimeout_zeroMeansNoTimeout() throws Exception {
-    SlowMetricExporter slowExporter = new SlowMetricExporter(100);
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(100);
     PeriodicMetricReader reader =
-        PeriodicMetricReader.builder(slowExporter)
+        PeriodicMetricReader.builder(delayingExporter)
             .setInterval(Duration.ofMillis(50))
             .setExporterTimeout(Duration.ZERO) // No timeout
             .build();
 
     reader.register(collectionRegistration);
     try {
-      assertThat(slowExporter.waitForExport()).isTrue();
+      assertThat(delayingExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -839,7 +839,8 @@ class PeriodicMetricReaderTest {
   @Test
   void timeoutEnforcement_failsSlowExporter() throws Exception {
     // Exporter that completes asynchronously after a delay longer than timeout
-    AsyncSlowMetricExporter slowExporter = new AsyncSlowMetricExporter(100); // 100ms delay
+    DelayingMetricExporter slowExporter =
+        new DelayingMetricExporter(100, /* async= */ true); // 100ms async delay
     PeriodicMetricReader reader =
         PeriodicMetricReader.builder(slowExporter)
             .setInterval(Duration.ofMillis(50))
@@ -849,7 +850,7 @@ class PeriodicMetricReaderTest {
     reader.register(collectionRegistration);
     try {
       // Wait for export to be attempted
-      assertThat(slowExporter.exportStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(slowExporter.waitForExport()).isTrue();
       // Wait for timeout to occur
       Thread.sleep(100);
       // Export should have been attempted but timed out
@@ -860,13 +861,19 @@ class PeriodicMetricReaderTest {
   }
 
   // Helper test classes for timeout testing
-  private static class AsyncSlowMetricExporter implements MetricExporter {
+  private static class DelayingMetricExporter implements MetricExporter {
     private final long delayMs;
     private final AtomicInteger exportCount = new AtomicInteger();
-    private final CountDownLatch exportStarted = new CountDownLatch(1);
+    private final CountDownLatch exportLatch = new CountDownLatch(1);
+    private final boolean async;
 
-    AsyncSlowMetricExporter(long delayMs) {
+    DelayingMetricExporter(long delayMs) {
+      this(delayMs, /* async= */ false);
+    }
+
+    DelayingMetricExporter(long delayMs, boolean async) {
       this.delayMs = delayMs;
+      this.async = async;
     }
 
     @Override
@@ -877,88 +884,30 @@ class PeriodicMetricReaderTest {
     @Override
     public CompletableResultCode export(Collection<MetricData> metrics) {
       exportCount.incrementAndGet();
-      exportStarted.countDown();
-      CompletableResultCode result = new CompletableResultCode();
-      new Thread(
-              () -> {
-                try {
-                  Thread.sleep(delayMs);
-                  result.succeed();
-                } catch (InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                  result.fail();
-                }
-              })
-          .start();
-      return result;
-    }
-
-    @Override
-    public CompletableResultCode flush() {
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode shutdown() {
-      return CompletableResultCode.ofSuccess();
-    }
-  }
-
-  private static class SlowMetricExporter implements MetricExporter {
-    private final long delayMs;
-    private final AtomicInteger exportCount = new AtomicInteger();
-    private final CountDownLatch exportLatch = new CountDownLatch(1);
-
-    SlowMetricExporter(long delayMs) {
-      this.delayMs = delayMs;
-    }
-
-    @Override
-    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
-      return AggregationTemporality.CUMULATIVE;
-    }
-
-    @Override
-    public CompletableResultCode export(Collection<MetricData> metrics) {
-      try {
-        Thread.sleep(delayMs);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
+      if (async) {
+        CompletableResultCode result = new CompletableResultCode();
+        new Thread(
+                () -> {
+                  try {
+                    Thread.sleep(delayMs);
+                    result.succeed();
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    result.fail();
+                  }
+                })
+            .start();
+        exportLatch.countDown();
+        return result;
+      } else {
+        try {
+          Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        exportLatch.countDown();
+        return CompletableResultCode.ofSuccess();
       }
-      exportCount.incrementAndGet();
-      exportLatch.countDown();
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode flush() {
-      return CompletableResultCode.ofSuccess();
-    }
-
-    @Override
-    public CompletableResultCode shutdown() {
-      return CompletableResultCode.ofSuccess();
-    }
-
-    boolean waitForExport() throws InterruptedException {
-      return exportLatch.await(5, TimeUnit.SECONDS);
-    }
-  }
-
-  private static class FastMetricExporter implements MetricExporter {
-    private final AtomicInteger exportCount = new AtomicInteger();
-    private final CountDownLatch exportLatch = new CountDownLatch(1);
-
-    @Override
-    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
-      return AggregationTemporality.CUMULATIVE;
-    }
-
-    @Override
-    public CompletableResultCode export(Collection<MetricData> metrics) {
-      exportCount.incrementAndGet();
-      exportLatch.countDown();
-      return CompletableResultCode.ofSuccess();
     }
 
     @Override

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -771,9 +771,7 @@ class PeriodicMetricReaderTest {
     // and ensuring it completes successfully
     SlowMetricExporter slowExporter = new SlowMetricExporter(100); // 100ms delay
     PeriodicMetricReader reader =
-        PeriodicMetricReader.builder(slowExporter)
-            .setInterval(Duration.ofMillis(50))
-            .build();
+        PeriodicMetricReader.builder(slowExporter).setInterval(Duration.ofMillis(50)).build();
 
     reader.register(collectionRegistration);
     try {

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -768,17 +768,37 @@ class PeriodicMetricReaderTest {
   }
 
   @Test
-  void defaultBehavior_applies30SecondTimeout() throws Exception {
-    // This test verifies that by default, a 30-second timeout is applied
-    // We test this by having an exporter that takes less than 30 seconds
+  void defaultTimeout_defaultsToInterval() throws Exception {
+    // This test verifies that by default, the timeout equals the configured interval
+    // We test this by having an exporter that takes less than the interval
     // and ensuring it completes successfully
-    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(100); // 100ms delay
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(25); // 25ms delay
     PeriodicMetricReader reader =
         PeriodicMetricReader.builder(delayingExporter).setInterval(Duration.ofMillis(50)).build();
 
     reader.register(collectionRegistration);
     try {
-      // Wait for an export to complete - should succeed since 100ms < 30s
+      // Wait for an export to complete - should succeed since 25ms < 50ms interval
+      assertThat(delayingExporter.waitForExport()).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void explicitTimeout_preservedWithLargeInterval() throws Exception {
+    // Test that explicit timeout is preserved even with a large interval (5 minutes)
+    DelayingMetricExporter delayingExporter = new DelayingMetricExporter(25); // 25ms delay
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(delayingExporter)
+            .setInterval(Duration.ofMinutes(5)) // Large interval
+            .setExporterTimeout(Duration.ofSeconds(1)) // Explicit small timeout
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      // Force a flush to trigger export - should succeed since 25ms < 1s timeout
+      assertThat(reader.forceFlush().join(5, TimeUnit.SECONDS).isSuccess()).isTrue();
       assertThat(delayingExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -717,6 +717,198 @@ class PeriodicMetricReaderTest {
                 + "}");
   }
 
+  @Test
+  void setExporterTimeout_configuresTimeout() {
+    PeriodicMetricReaderBuilder builder =
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(5, TimeUnit.SECONDS);
+    assertThat(builder).isNotNull();
+  }
+
+  @Test
+  void setExporterTimeout_withDuration_configuresTimeout() {
+    PeriodicMetricReaderBuilder builder =
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(Duration.ofSeconds(5));
+    assertThat(builder).isNotNull();
+  }
+
+  @Test
+  void setExporterTimeout_zeroMeansNoTimeout() {
+    PeriodicMetricReaderBuilder builder =
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(0, TimeUnit.SECONDS);
+    assertThat(builder).isNotNull();
+  }
+
+  @Test
+  void setExporterTimeout_negativeThrowsException() {
+    assertThatThrownBy(
+            () ->
+                PeriodicMetricReader.builder(metricExporter)
+                    .setExporterTimeout(-1, TimeUnit.SECONDS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("timeout must be non-negative");
+  }
+
+  @Test
+  void setExporterTimeout_nullUnitThrowsException() {
+    assertThatThrownBy(
+            () -> PeriodicMetricReader.builder(metricExporter).setExporterTimeout(5, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("unit");
+  }
+
+  @Test
+  void setExporterTimeout_nullDurationThrowsException() {
+    assertThatThrownBy(
+            () -> PeriodicMetricReader.builder(metricExporter).setExporterTimeout((Duration) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("timeout");
+  }
+
+  @Test
+  void defaultBehavior_applies30SecondTimeout() throws Exception {
+    // This test verifies that by default, a 30-second timeout is applied
+    // We test this by having an exporter that takes less than 30 seconds
+    // and ensuring it completes successfully
+    SlowMetricExporter slowExporter = new SlowMetricExporter(100); // 100ms delay
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(slowExporter)
+            .setInterval(Duration.ofMillis(50))
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      // Wait for an export to complete - should succeed since 100ms < 30s
+      assertThat(slowExporter.waitForExport(1)).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void explicitTimeout_exporterCompletesBeforeTimeout() throws Exception {
+    FastMetricExporter fastExporter = new FastMetricExporter();
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(fastExporter)
+            .setInterval(Duration.ofMillis(50))
+            .setExporterTimeout(1, TimeUnit.SECONDS) // 1 second timeout
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      assertThat(fastExporter.waitForExport(1)).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void explicitTimeout_withBatching_completesBeforeTimeout() throws Exception {
+    FastMetricExporter fastExporter = new FastMetricExporter();
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(fastExporter)
+            .setInterval(Duration.ofMillis(50))
+            .setExporterTimeout(1, TimeUnit.SECONDS)
+            .setMaxExportBatchSize(2)
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      assertThat(fastExporter.waitForExport(1)).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void explicitTimeout_zeroMeansNoTimeout() throws Exception {
+    SlowMetricExporter slowExporter = new SlowMetricExporter(100);
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(slowExporter)
+            .setInterval(Duration.ofMillis(50))
+            .setExporterTimeout(0, TimeUnit.SECONDS) // No timeout
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      assertThat(slowExporter.waitForExport(1)).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  // Helper test classes for timeout testing
+  private static class SlowMetricExporter implements MetricExporter {
+    private final long delayMs;
+    private final AtomicInteger exportCount = new AtomicInteger();
+    private final CountDownLatch exportLatch = new CountDownLatch(1);
+
+    SlowMetricExporter(long delayMs) {
+      this.delayMs = delayMs;
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+      return AggregationTemporality.CUMULATIVE;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+      try {
+        Thread.sleep(delayMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      exportCount.incrementAndGet();
+      exportLatch.countDown();
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    boolean waitForExport(int count) throws InterruptedException {
+      return exportLatch.await(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static class FastMetricExporter implements MetricExporter {
+    private final AtomicInteger exportCount = new AtomicInteger();
+    private final CountDownLatch exportLatch = new CountDownLatch(1);
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+      return AggregationTemporality.CUMULATIVE;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+      exportCount.incrementAndGet();
+      exportLatch.countDown();
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    boolean waitForExport(int count) throws InterruptedException {
+      return exportLatch.await(5, TimeUnit.SECONDS);
+    }
+  }
+
   private static class WaitingMetricExporter implements MetricExporter {
 
     private final AtomicBoolean hasShutdown = new AtomicBoolean(false);

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -720,21 +720,23 @@ class PeriodicMetricReaderTest {
   @Test
   void setExporterTimeout_configuresTimeout() {
     PeriodicMetricReaderBuilder builder =
-        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(5, TimeUnit.SECONDS);
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(Duration.ofSeconds(5));
     assertThat(builder).isNotNull();
   }
 
   @Test
-  void setExporterTimeout_withDuration_configuresTimeout() {
+  @SuppressWarnings("PreferJavaTimeOverload")
+  void setExporterTimeout_withTimeUnit_overload() {
+    // Keep at least one test for the long + TimeUnit public API to verify that overload works
     PeriodicMetricReaderBuilder builder =
-        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(Duration.ofSeconds(5));
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(5, TimeUnit.SECONDS);
     assertThat(builder).isNotNull();
   }
 
   @Test
   void setExporterTimeout_zeroMeansNoTimeout() {
     PeriodicMetricReaderBuilder builder =
-        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(0, TimeUnit.SECONDS);
+        PeriodicMetricReader.builder(metricExporter).setExporterTimeout(Duration.ZERO);
     assertThat(builder).isNotNull();
   }
 
@@ -743,7 +745,7 @@ class PeriodicMetricReaderTest {
     assertThatThrownBy(
             () ->
                 PeriodicMetricReader.builder(metricExporter)
-                    .setExporterTimeout(-1, TimeUnit.SECONDS))
+                    .setExporterTimeout(Duration.ofSeconds(-1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("timeout must be non-negative");
   }
@@ -776,7 +778,7 @@ class PeriodicMetricReaderTest {
     reader.register(collectionRegistration);
     try {
       // Wait for an export to complete - should succeed since 100ms < 30s
-      assertThat(slowExporter.waitForExport(1)).isTrue();
+      assertThat(slowExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -788,12 +790,12 @@ class PeriodicMetricReaderTest {
     PeriodicMetricReader reader =
         PeriodicMetricReader.builder(fastExporter)
             .setInterval(Duration.ofMillis(50))
-            .setExporterTimeout(1, TimeUnit.SECONDS) // 1 second timeout
+            .setExporterTimeout(Duration.ofSeconds(1)) // 1 second timeout
             .build();
 
     reader.register(collectionRegistration);
     try {
-      assertThat(fastExporter.waitForExport(1)).isTrue();
+      assertThat(fastExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -805,13 +807,13 @@ class PeriodicMetricReaderTest {
     PeriodicMetricReader reader =
         PeriodicMetricReader.builder(fastExporter)
             .setInterval(Duration.ofMillis(50))
-            .setExporterTimeout(1, TimeUnit.SECONDS)
+            .setExporterTimeout(Duration.ofSeconds(1))
             .setMaxExportBatchSize(2)
             .build();
 
     reader.register(collectionRegistration);
     try {
-      assertThat(fastExporter.waitForExport(1)).isTrue();
+      assertThat(fastExporter.waitForExport()).isTrue();
     } finally {
       reader.shutdown();
     }
@@ -823,18 +825,85 @@ class PeriodicMetricReaderTest {
     PeriodicMetricReader reader =
         PeriodicMetricReader.builder(slowExporter)
             .setInterval(Duration.ofMillis(50))
-            .setExporterTimeout(0, TimeUnit.SECONDS) // No timeout
+            .setExporterTimeout(Duration.ZERO) // No timeout
             .build();
 
     reader.register(collectionRegistration);
     try {
-      assertThat(slowExporter.waitForExport(1)).isTrue();
+      assertThat(slowExporter.waitForExport()).isTrue();
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void timeoutEnforcement_failsSlowExporter() throws Exception {
+    // Exporter that completes asynchronously after a delay longer than timeout
+    AsyncSlowMetricExporter slowExporter = new AsyncSlowMetricExporter(100); // 100ms delay
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(slowExporter)
+            .setInterval(Duration.ofMillis(50))
+            .setExporterTimeout(Duration.ofMillis(10)) // 10ms timeout
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      // Wait for export to be attempted
+      assertThat(slowExporter.exportStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      // Wait for timeout to occur
+      Thread.sleep(100);
+      // Export should have been attempted but timed out
+      assertThat(slowExporter.exportCount.get()).isGreaterThan(0);
     } finally {
       reader.shutdown();
     }
   }
 
   // Helper test classes for timeout testing
+  private static class AsyncSlowMetricExporter implements MetricExporter {
+    private final long delayMs;
+    private final AtomicInteger exportCount = new AtomicInteger();
+    private final CountDownLatch exportStarted = new CountDownLatch(1);
+
+    AsyncSlowMetricExporter(long delayMs) {
+      this.delayMs = delayMs;
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+      return AggregationTemporality.CUMULATIVE;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+      exportCount.incrementAndGet();
+      exportStarted.countDown();
+      CompletableResultCode result = new CompletableResultCode();
+      new Thread(
+              () -> {
+                try {
+                  Thread.sleep(delayMs);
+                  result.succeed();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  result.fail();
+                }
+              })
+          .start();
+      return result;
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+      return CompletableResultCode.ofSuccess();
+    }
+  }
+
   private static class SlowMetricExporter implements MetricExporter {
     private final long delayMs;
     private final AtomicInteger exportCount = new AtomicInteger();
@@ -871,7 +940,7 @@ class PeriodicMetricReaderTest {
       return CompletableResultCode.ofSuccess();
     }
 
-    boolean waitForExport(int count) throws InterruptedException {
+    boolean waitForExport() throws InterruptedException {
       return exportLatch.await(5, TimeUnit.SECONDS);
     }
   }
@@ -902,7 +971,7 @@ class PeriodicMetricReaderTest {
       return CompletableResultCode.ofSuccess();
     }
 
-    boolean waitForExport(int count) throws InterruptedException {
+    boolean waitForExport() throws InterruptedException {
       return exportLatch.await(5, TimeUnit.SECONDS);
     }
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReaderTest.java
@@ -39,6 +39,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -908,6 +911,80 @@ class PeriodicMetricReaderTest {
       Thread.sleep(100);
       // Export should have been attempted but timed out
       assertThat(slowExporter.exportCount.get()).isGreaterThan(0);
+      // Verify timeout warning was logged (proves timeout actually occurred)
+      assertThat(logCapturer.getEvents())
+          .anyMatch(e -> e.getMessage().contains("Export timed out"));
+    } finally {
+      reader.shutdown();
+    }
+  }
+
+  @Test
+  void timeoutDoesNotReleaseBackpressure() throws Exception {
+    // Test that timeout firing does not allow concurrent exports
+    // The raw export must complete before the next export can start
+    CountDownLatch exportStarted = new CountDownLatch(1);
+    CountDownLatch exportComplete = new CountDownLatch(1);
+
+    AtomicInteger exportCount = new AtomicInteger();
+
+    MetricExporter slowExporter =
+        new MetricExporter() {
+          @Override
+          public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+          }
+
+          @Override
+          public CompletableResultCode export(Collection<MetricData> metrics) {
+            exportCount.incrementAndGet();
+            exportStarted.countDown();
+            try {
+              // Simulate slow export that takes longer than timeout
+              Thread.sleep(200);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            exportComplete.countDown();
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+          }
+        };
+
+    PeriodicMetricReader reader =
+        PeriodicMetricReader.builder(slowExporter)
+            .setInterval(Duration.ofMillis(20)) // Short interval
+            .setExporterTimeout(Duration.ofMillis(10)) // Short timeout
+            .build();
+
+    reader.register(collectionRegistration);
+    try {
+      // Wait for first export to start
+      assertThat(exportStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      // Wait for timeout to fire (reader perspective)
+      Thread.sleep(50);
+
+      // Critical: Only ONE export should have started despite timeout firing
+      // because backpressure is tied to raw export completion, not timeout completion
+      assertThat(exportCount.get()).isEqualTo(1);
+
+      // Wait for raw export to complete
+      assertThat(exportComplete.await(5, TimeUnit.SECONDS)).isTrue();
+
+      // Now the next export can proceed
+      Thread.sleep(50);
+
+      // At this point, a second export may have started
+      // But we proved that the timeout did NOT release backpressure prematurely
     } finally {
       reader.shutdown();
     }
@@ -919,6 +996,7 @@ class PeriodicMetricReaderTest {
     private final AtomicInteger exportCount = new AtomicInteger();
     private final CountDownLatch exportLatch = new CountDownLatch(1);
     private final boolean async;
+    @Nullable private final ExecutorService executor;
 
     DelayingMetricExporter(long delayMs) {
       this(delayMs, /* async= */ false);
@@ -927,6 +1005,7 @@ class PeriodicMetricReaderTest {
     DelayingMetricExporter(long delayMs, boolean async) {
       this.delayMs = delayMs;
       this.async = async;
+      this.executor = async ? Executors.newSingleThreadExecutor() : null;
     }
 
     @Override
@@ -939,7 +1018,9 @@ class PeriodicMetricReaderTest {
       exportCount.incrementAndGet();
       if (async) {
         CompletableResultCode result = new CompletableResultCode();
-        new Thread(
+        @SuppressWarnings("FutureReturnValueIgnored")
+        Future<?> unused =
+            executor.submit(
                 () -> {
                   try {
                     Thread.sleep(delayMs);
@@ -948,8 +1029,7 @@ class PeriodicMetricReaderTest {
                     Thread.currentThread().interrupt();
                     result.fail();
                   }
-                })
-            .start();
+                });
         exportLatch.countDown();
         return result;
       } else {
@@ -970,6 +1050,14 @@ class PeriodicMetricReaderTest {
 
     @Override
     public CompletableResultCode shutdown() {
+      if (executor != null) {
+        executor.shutdown();
+        try {
+          executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
       return CompletableResultCode.ofSuccess();
     }
 


### PR DESCRIPTION
Fixes #8311

## Summary

Align `PeriodicMetricReader` export timeout behavior with the Metrics specification by enforcing an exporter timeout for each export batch.

## Changes

* Added configurable exporter timeout support to `PeriodicMetricReaderBuilder`
* Uses the configured export interval as the default exporter timeout when no explicit timeout is provided
* Enforced the configured timeout for each export batch in `PeriodicMetricReader`
* Preserved existing batching behavior while ensuring timed-out exports are reported as failures
* Ensured export backpressure remains active until the underlying exporter operation completes, preventing concurrent exports after a timeout
* Added regression tests for timeout behavior and export backpressure

## Testing

* Ran the relevant Gradle build and tests
* Verified the updated timeout and backpressure behavior
* Ran Spotless checks
* Ran `git diff --check`

## Notes

This change updates export timeout behavior without affecting metric collection or normal scheduling semantics.
