### PR TITLE
Fix spelling typos in API and metrics test code

### DIFF
--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractDefaultMeterTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractDefaultMeterTest {
   void noopMeterProvider_builderDoesNotThrow() {
     MeterProvider provider = getMeterProvider();
     provider.meterBuilder("user-instrumentation").build();
-    provider.meterBuilder("advanced-instrumetnation").setInstrumentationVersion("1.0").build();
+    provider.meterBuilder("advanced-instrumentation").setInstrumentationVersion("1.0").build();
     provider.meterBuilder("schema-instrumentation").setSchemaUrl("myschema://url").build();
     provider
         .meterBuilder("schema-instrumentation")
@@ -181,7 +181,7 @@ public abstract class AbstractDefaultMeterTest {
   }
 
   @Test
-  void noopLongGauage_doesNotThrow() {
+  void noopLongGauge_doesNotThrow() {
     LongGauge gauge =
         meter
             .gaugeBuilder("temperature")
@@ -205,7 +205,7 @@ public abstract class AbstractDefaultMeterTest {
   }
 
   @Test
-  void noopObservableLongGauage_doesNotThrow() {
+  void noopObservableLongGauge_doesNotThrow() {
     meter
         .gaugeBuilder("temperature")
         .ofLongs()
@@ -219,7 +219,7 @@ public abstract class AbstractDefaultMeterTest {
   }
 
   @Test
-  void noopDoubleGauage_doesNotThrow() {
+  void noopDoubleGauge_doesNotThrow() {
     DoubleGauge gauge =
         meter
             .gaugeBuilder("temperature")
@@ -241,7 +241,7 @@ public abstract class AbstractDefaultMeterTest {
   }
 
   @Test
-  void noopObservableDoubleGauage_doesNotThrow() {
+  void noopObservableDoubleGauge_doesNotThrow() {
     meter
         .gaugeBuilder("temperature")
         .setDescription("The current temperature")

--- a/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
+++ b/api/testing-internal/src/main/java/io/opentelemetry/api/testing/internal/AbstractOpenTelemetryTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractOpenTelemetryTest {
     assertThat(GlobalOpenTelemetry.isSet()).isFalse();
     assertThat(GlobalOpenTelemetry.getOrNoop()).isSameAs(OpenTelemetry.noop());
 
-    // Calling GlobalOpenTelemetry.get() has the side affect of setting GlobalOpenTelemetry to an
+    // Calling GlobalOpenTelemetry.get() has the side effect of setting GlobalOpenTelemetry to an
     // (obfuscated) noop.
     // Call GlobalOpenTelemetry.get() using a utility method so we can later assert it was
     // responsible for setting GlobalOpenTelemetry.

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterTest.java
@@ -80,7 +80,7 @@ class SdkMeterTest {
     assertThat(sdkMeter.histogramBuilder("1").ofLongs().build())
         .isSameAs(NOOP_METER.histogramBuilder(NOOP_INSTRUMENT_NAME).ofLongs().build());
 
-    // Gauage
+    // Gauge
     assertThat(sdkMeter.gaugeBuilder("1").buildWithCallback(unused -> {}))
         .isSameAs(NOOP_METER.gaugeBuilder(NOOP_INSTRUMENT_NAME).buildWithCallback(unused -> {}));
     assertThat(sdkMeter.gaugeBuilder("1").ofLongs().buildWithCallback(unused -> {}))


### PR DESCRIPTION
No issue: trivial spelling fix, an issue is not required.

## Description

- Rename the four `Gauage` test methods in `AbstractDefaultMeterTest` to `Gauge`, matching the `LongGauge`/`DoubleGauge` types they exercise.
- Fix the scope name literal `"advanced-instrumetnation"` to `"advanced-instrumentation"` in the same class; the no-op `MeterProvider` discards the name.
- Fix `side affect` to `side effect` in an `AbstractOpenTelemetryTest` comment and `// Gauage` to `// Gauge` in a `SdkMeterTest` comment.
- Spelling only: no behavior, signature, public API, or asserted output changes. `api/testing-internal` is not published, so there is no API diff.

## Testing done

- Trivial typo, test-exempt: no test added.
- `./gradlew :api:testing-internal:check :api:all:test :api:incubator:test` passed; test-results XML shows the renamed methods ran under their new names in both subclasses.
- `./gradlew :sdk:metrics:test --tests "*SdkMeterTest" :sdk:metrics:spotlessCheck` passed.

