### PR TITLE
Wire api/incubator test suites into check

### DIFF
--- a/api/incubator/build.gradle.kts
+++ b/api/incubator/build.gradle.kts
@@ -41,3 +41,9 @@ testing {
     }
   }
 }
+
+tasks {
+  check {
+    dependsOn(testing.suites)
+  }
+}


### PR DESCRIPTION
Fixes #8690

## Description

- `api/incubator/build.gradle.kts` registers the `testConvertToModel` JvmTestSuite but never wires it into `check`, so its 4 tests have not run in CI since #7453 added the suite (2025-07-10).
- The sources still compile and pass checkstyle, so nothing looks broken.
- Adds the `tasks { check { dependsOn(testing.suites) } }` block that `sdk/trace`, `sdk/logs`, `context` and seven other modules already use.
- `docs/knowledge/testing-patterns.md` states this rule, but it was added later, in #8303 (2026-06), so this module was never brought in line.
- Of the 14 modules registering a JvmTestSuite, 11 wire it. `:exporters:otlp:common` has the same gap; happy to follow up once this lands.

## Testing done

- Build wiring only: no production code, signature or public API change, so no test was added.
- `./gradlew :api:incubator:check --dry-run` now lists `:api:incubator:testConvertToModel`; it was absent before.
- `./gradlew :api:incubator:check` — 101 tests passed (97 existing plus the 4 from the newly wired suite).
- `docs/apidiffs/` is untouched.

