### PR TITLE
Fix ExtendedLongCounter class javadoc to link LongCounter

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongCounter.java
@@ -6,10 +6,9 @@
 package io.opentelemetry.api.incubator.metrics;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.LongCounter;
 
-/** Extended {@link DoubleCounter} with experimental APIs. */
+/** Extended {@link LongCounter} with experimental APIs. */
 public interface ExtendedLongCounter extends LongCounter {
 
   /**


### PR DESCRIPTION
<!-- No issue: docs-only cleanup, issue not required -->

## Description

- `ExtendedLongCounter` extends `LongCounter`, but its class javadoc reads `Extended {@link DoubleCounter} with experimental APIs` — a copy-paste slip from when the file was added in #6502.
- The published javadoc summary therefore names the wrong instrument type and links readers to the opposite one.
- Point the link at `LongCounter`, matching the other 19 `Extended*` interfaces in this package, which all link their own supertype.
- Drop the now-unused `DoubleCounter` import; it existed only for that javadoc link.
- Same kind of fix as #8602 (copy-paste class javadoc on the OTLP `AnyValue` stateless marshalers).

## Testing done

- Docs-only, test-exempt: only a javadoc comment and an unused import change, so bytecode and signatures are unchanged.
- `./gradlew :api:incubator:check` — 97 tests passed (spotless, checkstyle, ErrorProne/NullAway, jApiCmp included).
- `./gradlew :api:incubator:javadoc` — succeeded with no warnings.
- No `docs/apidiffs/current_vs_latest/` change was produced; the jar is identical.

