### PR TITLE
Fix copy-paste leftovers in public API javadoc

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java
@@ -48,7 +48,7 @@ public interface DoubleHistogramBuilder {
     return this;
   }
 
-  /** Sets the Counter for recording {@code long} values. */
+  /** Sets the Histogram for recording {@code long} values. */
   LongHistogramBuilder ofLongs();
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/metrics/LongUpDownCounterBuilder.java
@@ -33,7 +33,7 @@ public interface LongUpDownCounterBuilder {
    */
   LongUpDownCounterBuilder setUnit(String unit);
 
-  /** Sets the Counter for recording {@code double} values. */
+  /** Sets the UpDownCounter for recording {@code double} values. */
   DoubleUpDownCounterBuilder ofDoubles();
 
   /**

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceFlags.java
@@ -71,7 +71,7 @@ public interface TraceFlags {
    * Returns {@code true} if the sampling bit is on for this {@link TraceFlags}, otherwise {@code
    * false}.
    *
-   * @return {@code true} if the sampling bit is on for this {@link TraceFlags}, otherwise {@code *
+   * @return {@code true} if the sampling bit is on for this {@link TraceFlags}, otherwise {@code
    *     false}.
    */
   boolean isSampled();
@@ -92,7 +92,7 @@ public interface TraceFlags {
   /**
    * Returns the lowercase hex (base16) representation of this {@link TraceFlags}.
    *
-   * @return the byte representation of the {@link TraceFlags}.
+   * @return the lowercase hex (base16) representation of the {@link TraceFlags}.
    */
   String asHex();
 

--- a/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/TraceId.java
@@ -70,7 +70,7 @@ public final class TraceId {
    * given bytes representation, or {@link #getInvalid()} if input is {@code null} or the given byte
    * array is too short.
    *
-   * <p>It converts the first 26 bytes of the given byte array.
+   * <p>It converts the first 16 bytes of the given byte array.
    *
    * @param traceIdBytes the bytes (16-byte array) representation of the {@code TraceId}.
    * @return the lowercase hex (base16) representation of the {@code TraceId}.
@@ -86,7 +86,7 @@ public final class TraceId {
   }
 
   /**
-   * Returns the bytes (16-byte array) representation of the {@code TraceId} converted from the
+   * Returns the lowercase hex (base16) representation of the {@code TraceId} converted from the
    * given two {@code long} values representing the lower and higher parts.
    *
    * <p>There is no restriction on the specified values, other than the already established validity


### PR DESCRIPTION
No issue: docs-only javadoc fix, submitting directly.

## Description

Six javadoc lines in stable public API describe something the method does not do. Each fix reuses a sibling member's wording.

- `DoubleHistogramBuilder#ofLongs`: "Sets the Counter" → Histogram (cf. `DoubleGaugeBuilder#ofLongs`).
- `LongUpDownCounterBuilder#ofDoubles`: "Sets the Counter" → UpDownCounter (copied from `LongCounterBuilder#ofDoubles`, where it is correct).
- `TraceId#fromBytes`: "first 26 bytes" → 16, matching `BYTES_LENGTH` and the `@param` right below (cf. `SpanId#fromBytes`, "first 8 bytes").
- `TraceFlags#isSampled`: a `*` trapped inside `{@code}` rendered as `otherwise * false` (cf. `isTraceIdRandom`, same file).
- `TraceFlags#asHex`: `@return` said "the byte representation", copied from `asByte`; returns `String`.
- `TraceId#fromLongs`: summary said "the bytes (16-byte array) representation"; returns `String`, and its own `@return` already says hex (cf. `SpanId#fromLong`).

## Testing done

- Docs-only, test-exempt: no test added.
- `./gradlew :api:all:check` passed.
- `./gradlew :api:all:javadoc --rerun-tasks`: the stray `*` is gone from `TraceFlags.html`, and `TraceId.html` now reads "lowercase hex (base16) representation" for `fromLongs`.
- No apidiff change: javadoc does not reach bytecode.
- Not run: `*IT` and GraalVM native-image tests (outside `check`).

