### PR TITLE
Fix invalid javadoc reference on the remote flag in SpanContext

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java
@@ -13,7 +13,7 @@ import javax.annotation.concurrent.Immutable;
  * A class that represents a span context. A span context contains the state that must propagate to
  * child {@link Span}s and across process boundaries. It contains the identifiers (a {@link TraceId
  * trace_id} and {@link SpanId span_id}) associated with the {@link Span}, {@link TraceFlags}, as
- * well as the {@link TraceState traceState} and the {@link boolean remote} flag.
+ * well as the {@link TraceState traceState} and the {@code remote} flag.
  *
  * <p>Implementations of this interface *must* be immutable and have well-defined value-based
  * equals/hashCode implementations. If an implementation does not strictly conform to these


### PR DESCRIPTION
No issue: trivial javadoc markup fix, issue not required (same as #8588).

## Description

- The `SpanContext` class javadoc links `{@link boolean remote}`, but `boolean` is a primitive type, so javadoc cannot resolve the reference.
- The generated `SpanContext.html` renders a collapsed `invalid reference` block instead of "the `remote` flag".
- Replace it with `{@code remote}`, matching how this file already refers to values rather than types. The neighbouring `{@link TraceState traceState}` resolves fine and is left as is.
- `-Xdoclint:all,-missing` does not flag this case, so the build stays green while the published javadoc keeps the broken widget.
- This is the only place in the repo that links a primitive type.

## Testing done

- Javadoc-only change, test-exempt: no test added.
- `./gradlew :api:all:check` passed.
- `./gradlew :api:all:javadoc --rerun-tasks`: `SpanContext.html` no longer contains `invalid-tag`; the sentence renders as "the `remote` flag".
- No public API change, so the apidiff file is unchanged.
- Not run: `*IT` and GraalVM native-image tests (outside `check`).

