### PR TITLE
Record processed logs before export complete and reject on shutdown

### DIFF
--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -159,6 +159,7 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     private final AtomicInteger logsNeeded = new AtomicInteger(Integer.MAX_VALUE);
     private final BlockingQueue<Boolean> signal;
     private final AtomicReference<CompletableResultCode> flushRequested = new AtomicReference<>();
+    private final AtomicBoolean isShutdown = new AtomicBoolean(false);
     private volatile boolean continueWork = true;
     private final ArrayList<LogRecordData> batch;
     private final long maxQueueSize;
@@ -186,9 +187,13 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     }
 
     private void addLog(ReadWriteLogRecord logData) {
+      if (isShutdown.get()) {
+        logProcessorInstrumentation.dropLogsAlreadyShutdown(1);
+        return;
+      }
       logProcessorInstrumentation.buildQueueMetricsOnce(maxQueueSize, queue::size);
       if (!queue.offer(logData)) {
-        logProcessorInstrumentation.dropLogs(1);
+        logProcessorInstrumentation.dropLogsQueueFull(1);
       } else {
         if (queue.size() >= logsNeeded.get()) {
           signal.offer(true);
@@ -251,6 +256,9 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
     }
 
     private CompletableResultCode shutdown() {
+      if (isShutdown.getAndSet(true)) {
+        return CompletableResultCode.ofSuccess();
+      }
       CompletableResultCode result = new CompletableResultCode();
 
       CompletableResultCode flushResult = forceFlush();
@@ -289,25 +297,18 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
         return;
       }
 
-      String error = null;
       try {
+        logProcessorInstrumentation.finishLogs(batch.size());
         CompletableResultCode result =
             logRecordExporter.export(Collections.unmodifiableList(batch));
         result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
         if (!result.isSuccess()) {
           logger.log(Level.FINE, "Exporter failed");
-          if (result.getFailureThrowable() != null) {
-            error = result.getFailureThrowable().getClass().getName();
-          } else {
-            error = "export_failed";
-          }
         }
       } catch (Throwable t) {
         ThrowableUtil.propagateIfFatal(t);
         logger.log(Level.WARNING, "Exporter threw an Exception", t);
-        error = t.getClass().getName();
       } finally {
-        logProcessorInstrumentation.finishLogs(batch.size(), error);
         batch.clear();
       }
     }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.java
@@ -49,7 +49,6 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       BatchLogRecordProcessor.class.getSimpleName() + "_WorkerThread";
 
   private final Worker worker;
-  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   /**
    * Returns a new Builder for {@link BatchLogRecordProcessor}.
@@ -94,9 +93,6 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
 
   @Override
   public CompletableResultCode shutdown() {
-    if (isShutdown.getAndSet(true)) {
-      return CompletableResultCode.ofSuccess();
-    }
     return worker.shutdown();
   }
 
@@ -298,6 +294,8 @@ public final class BatchLogRecordProcessor implements LogRecordProcessor {
       }
 
       try {
+        // We always increment for every export invocation, so we increment before the export call
+        // to make sure thrown errors don't affect it.
         logProcessorInstrumentation.finishLogs(batch.size());
         CompletableResultCode result =
             logRecordExporter.export(Collections.unmodifiableList(batch));

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LegacyLogRecordProcessorInstrumentation.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LegacyLogRecordProcessorInstrumentation.java
@@ -43,16 +43,18 @@ final class LegacyLogRecordProcessorInstrumentation implements LogRecordProcesso
   }
 
   @Override
-  public void dropLogs(int count) {
+  public void dropLogsQueueFull(int count) {
     processedLogs().add(count, droppedAttrs);
   }
 
   @Override
-  public void finishLogs(int count, @Nullable String error) {
-    // Legacy metrics only record when no error.
-    if (error == null) {
-      processedLogs().add(count, standardAttrs);
-    }
+  public void dropLogsAlreadyShutdown(int count) {
+    // Legacy did not record this metric.
+  }
+
+  @Override
+  public void finishLogs(int count) {
+    processedLogs().add(count, standardAttrs);
   }
 
   @Override

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordProcessorInstrumentation.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordProcessorInstrumentation.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
 import io.opentelemetry.sdk.common.internal.ComponentId;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 
 /** Metrics exported by span processors. */
 interface LogRecordProcessorInstrumentation {
@@ -27,10 +26,13 @@ interface LogRecordProcessorInstrumentation {
   }
 
   /** Records metrics for logs dropped because a queue is full. */
-  void dropLogs(int count);
+  void dropLogsQueueFull(int count);
 
-  /** Record metrics for logs processed, possibly with an error. */
-  void finishLogs(int count, @Nullable String error);
+  /** Record metrics for logs dropped since processor is shutdown. */
+  void dropLogsAlreadyShutdown(int count);
+
+  /** Record metrics for logs processed successfully. */
+  void finishLogs(int count);
 
   /** Registers metrics for processor queue capacity and size. */
   void buildQueueMetricsOnce(long capacity, LongCallable getSize);

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SemConvLogRecordProcessorInstrumentation.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SemConvLogRecordProcessorInstrumentation.java
@@ -27,7 +27,8 @@ final class SemConvLogRecordProcessorInstrumentation implements LogRecordProcess
 
   private final Supplier<MeterProvider> meterProvider;
   private final Attributes standardAttrs;
-  private final Attributes droppedAttrs;
+  private final Attributes queueFullAttrs;
+  private final Attributes shutdownAttrs;
 
   @Nullable private Meter meter;
   @Nullable private volatile LongCounter processedLogs;
@@ -42,7 +43,7 @@ final class SemConvLogRecordProcessorInstrumentation implements LogRecordProcess
             componentId.getTypeName(),
             SemConvAttributes.OTEL_COMPONENT_NAME,
             componentId.getComponentName());
-    droppedAttrs =
+    queueFullAttrs =
         Attributes.of(
             SemConvAttributes.OTEL_COMPONENT_TYPE,
             componentId.getTypeName(),
@@ -50,23 +51,29 @@ final class SemConvLogRecordProcessorInstrumentation implements LogRecordProcess
             componentId.getComponentName(),
             SemConvAttributes.ERROR_TYPE,
             "queue_full");
+    shutdownAttrs =
+        Attributes.of(
+            SemConvAttributes.OTEL_COMPONENT_TYPE,
+            componentId.getTypeName(),
+            SemConvAttributes.OTEL_COMPONENT_NAME,
+            componentId.getComponentName(),
+            SemConvAttributes.ERROR_TYPE,
+            "already_shutdown");
   }
 
   @Override
-  public void dropLogs(int count) {
-    processedLogs().add(count, droppedAttrs);
+  public void dropLogsQueueFull(int count) {
+    processedLogs().add(count, queueFullAttrs);
   }
 
   @Override
-  public void finishLogs(int count, @Nullable String error) {
-    if (error == null) {
-      processedLogs().add(count, standardAttrs);
-      return;
-    }
+  public void dropLogsAlreadyShutdown(int count) {
+    processedLogs().add(count, shutdownAttrs);
+  }
 
-    Attributes attributes =
-        standardAttrs.toBuilder().put(SemConvAttributes.ERROR_TYPE, error).build();
-    processedLogs().add(count, attributes);
+  @Override
+  public void finishLogs(int count) {
+    processedLogs().add(count, standardAttrs);
   }
 
   @Override

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
@@ -95,6 +95,8 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
       CompletableResultCode result;
 
       synchronized (exporterLock) {
+        // We always increment for every export invocation, so we increment before the export call
+        // to make sure thrown errors don't affect it.
         logProcessorInstrumentation.finishLogs(1);
         result = logRecordExporter.export(logs);
       }

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/SimpleLogRecordProcessor.java
@@ -85,11 +85,17 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
 
   @Override
   public void onEmit(Context context, ReadWriteLogRecord logRecord) {
+    if (isShutdown.get()) {
+      logProcessorInstrumentation.dropLogsAlreadyShutdown(1);
+      return;
+    }
+
     try {
       List<LogRecordData> logs = Collections.singletonList(logRecord.toLogRecordData());
       CompletableResultCode result;
 
       synchronized (exporterLock) {
+        logProcessorInstrumentation.finishLogs(1);
         result = logRecordExporter.export(logs);
       }
 
@@ -97,16 +103,9 @@ public final class SimpleLogRecordProcessor implements LogRecordProcessor {
       result.whenComplete(
           () -> {
             pendingExports.remove(result);
-            String error = null;
             if (!result.isSuccess()) {
               logger.log(Level.FINE, "Exporter failed");
-              if (result.getFailureThrowable() != null) {
-                error = result.getFailureThrowable().getClass().getName();
-              } else {
-                error = "export_failed";
-              }
             }
-            logProcessorInstrumentation.finishLogs(1, error);
           });
     } catch (RuntimeException e) {
       logger.log(Level.WARNING, "Exporter threw an Exception", e);

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderMetricsTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderMetricsTest.java
@@ -46,12 +46,11 @@ class SdkLoggerProviderMetricsTest {
         SdkMeterProvider.builder().registerMetricReader(metricReader).build();
 
     InMemoryLogRecordExporter exporter = InMemoryLogRecordExporter.create();
-    LoggerProvider loggerProvider =
+    SimpleLogRecordProcessor processor =
+        SimpleLogRecordProcessor.builder(exporter).setMeterProvider(() -> meterProvider).build();
+    SdkLoggerProvider loggerProvider =
         SdkLoggerProvider.builder()
-            .addLogRecordProcessor(
-                SimpleLogRecordProcessor.builder(exporter)
-                    .setMeterProvider(() -> meterProvider)
-                    .build())
+            .addLogRecordProcessor(processor)
             .setMeterProvider(() -> meterProvider)
             .build();
 
@@ -102,6 +101,42 @@ class SdkLoggerProviderMetricsTest {
                                                 "simple_log_processor/0",
                                                 OTEL_COMPONENT_TYPE,
                                                 "simple_log_processor")))));
+
+    // Logs rejected after to call to shutdown, regardless of completion so no join.
+    processor.shutdown();
+    logger.logRecordBuilder().emit();
+
+    assertThat(metricReader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.log.created")
+                    .hasLongSumSatisfying(
+                        s -> s.hasPointsSatisfying(p -> p.hasValue(3).hasAttributes())),
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.processor.log.processed")
+                    .hasLongSumSatisfying(
+                        s ->
+                            s.hasPointsSatisfying(
+                                p ->
+                                    p.hasValue(2)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "simple_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "simple_log_processor")),
+                                p ->
+                                    p.hasValue(1)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "simple_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "simple_log_processor",
+                                                ERROR_TYPE,
+                                                "already_shutdown")))));
   }
 
   @Test
@@ -134,11 +169,12 @@ class SdkLoggerProviderMetricsTest {
     // Will immediately be processed.
     logger.logRecordBuilder().emit();
     Thread.sleep(500); // give time to start processing a batch of size 1
-    // We haven't completed the export so this span is queued.
+    // We haven't completed the export so this log is queued.
     logger.logRecordBuilder().emit();
-    // Queue is full, this span is dropped.
+    // Queue is full, this log is dropped.
     logger.logRecordBuilder().emit();
 
+    // Export hasn't finished but processed metric is incremented
     assertThat(metricReader.collectAllMetrics())
         .satisfiesExactlyInAnyOrder(
             m ->
@@ -175,6 +211,14 @@ class SdkLoggerProviderMetricsTest {
                     .hasLongSumSatisfying(
                         s ->
                             s.hasPointsSatisfying(
+                                p ->
+                                    p.hasValue(1)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor")),
                                 p ->
                                     p.hasValue(1)
                                         .hasAttributes(
@@ -232,23 +276,13 @@ class SdkLoggerProviderMetricsTest {
                         s ->
                             s.hasPointsSatisfying(
                                 p ->
-                                    p.hasValue(1)
+                                    p.hasValue(2)
                                         .hasAttributes(
                                             Attributes.of(
                                                 OTEL_COMPONENT_NAME,
                                                 "batching_log_processor/0",
                                                 OTEL_COMPONENT_TYPE,
                                                 "batching_log_processor")),
-                                p ->
-                                    p.hasValue(1)
-                                        .hasAttributes(
-                                            Attributes.of(
-                                                OTEL_COMPONENT_NAME,
-                                                "batching_log_processor/0",
-                                                OTEL_COMPONENT_TYPE,
-                                                "batching_log_processor",
-                                                ERROR_TYPE,
-                                                "export_failed")),
                                 p ->
                                     p.hasValue(1)
                                         .hasAttributes(
@@ -266,7 +300,79 @@ class SdkLoggerProviderMetricsTest {
                         s -> s.hasPointsSatisfying(p -> p.hasValue(3).hasAttributes())));
 
     lenient().when(mockExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    // Logs rejected after to call to shutdown, regardless of completion so no join.
     processor.shutdown();
+
+    logger.logRecordBuilder().emit();
+    assertThat(metricReader.collectAllMetrics())
+        .satisfiesExactlyInAnyOrder(
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.processor.log.queue.capacity")
+                    .hasLongSumSatisfying(
+                        s ->
+                            s.hasPointsSatisfying(
+                                p ->
+                                    p.hasValue(1)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor")))),
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.processor.log.queue.size")
+                    .hasLongSumSatisfying(
+                        s ->
+                            s.hasPointsSatisfying(
+                                p ->
+                                    p.hasValue(0)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor")))),
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.processor.log.processed")
+                    .hasLongSumSatisfying(
+                        s ->
+                            s.hasPointsSatisfying(
+                                p ->
+                                    p.hasValue(2)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor")),
+                                p ->
+                                    p.hasValue(1)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor",
+                                                ERROR_TYPE,
+                                                "already_shutdown")),
+                                p ->
+                                    p.hasValue(1)
+                                        .hasAttributes(
+                                            Attributes.of(
+                                                OTEL_COMPONENT_NAME,
+                                                "batching_log_processor/0",
+                                                OTEL_COMPONENT_TYPE,
+                                                "batching_log_processor",
+                                                ERROR_TYPE,
+                                                "queue_full")))),
+            m ->
+                assertThat(m)
+                    .hasName("otel.sdk.log.created")
+                    .hasLongSumSatisfying(
+                        s -> s.hasPointsSatisfying(p -> p.hasValue(4).hasAttributes())));
   }
 
   @Test
@@ -305,9 +411,7 @@ class SdkLoggerProviderMetricsTest {
                                                 OTEL_COMPONENT_NAME,
                                                 "simple_log_processor/0",
                                                 OTEL_COMPONENT_TYPE,
-                                                "simple_log_processor",
-                                                ERROR_TYPE,
-                                                "export_failed")))),
+                                                "simple_log_processor")))),
             m ->
                 assertThat(m)
                     .hasName("otel.sdk.log.created")

--- a/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderMetricsTest.java
+++ b/sdk/logs/src/test/java/io/opentelemetry/sdk/logs/SdkLoggerProviderMetricsTest.java
@@ -102,7 +102,7 @@ class SdkLoggerProviderMetricsTest {
                                                 OTEL_COMPONENT_TYPE,
                                                 "simple_log_processor")))));
 
-    // Logs rejected after to call to shutdown, regardless of completion so no join.
+    // Logs rejected after the call to shutdown, regardless of completion so no join.
     processor.shutdown();
     logger.logRecordBuilder().emit();
 
@@ -300,7 +300,7 @@ class SdkLoggerProviderMetricsTest {
                         s -> s.hasPointsSatisfying(p -> p.hasValue(3).hasAttributes())));
 
     lenient().when(mockExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
-    // Logs rejected after to call to shutdown, regardless of completion so no join.
+    // Logs rejected after the call to shutdown, regardless of completion so no join.
     processor.shutdown();
 
     logger.logRecordBuilder().emit();


### PR DESCRIPTION
#8680

I will apply the same to spans after this one to confirm the pattern

On top of changing the order of recording, this implements handling of shutdown processor to emit `already_shutdown` and reject the log (a non-metric behavior change). For what it's worth, the behavior would have been less confusing if that `error.type` was there at the time 😂 