### PR TITLE
Bound jaeger-baggage parsing work by tokens rather than accepted entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Fix `TraceStateBuilder.remove` corrupting the builder when the same key is removed twice
   ([#8613](https://github.com/open-telemetry/opentelemetry-java/pull/8613))
 
+#### Extensions
+
+* Trace propagators: Stop parsing a `jaeger-baggage` header after 64 tokens, including malformed
+  tokens ([#PR](https://github.com/open-telemetry/opentelemetry-java/pull/PR))
+
 ### SDK
 
 #### Exporters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 #### Extensions
 
 * Trace propagators: Stop parsing a `jaeger-baggage` header after 64 tokens, including malformed
-  tokens ([#PR](https://github.com/open-telemetry/opentelemetry-java/pull/PR))
+  tokens ([#8702](https://github.com/open-telemetry/opentelemetry-java/pull/8702))
 
 ### SDK
 

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -78,6 +78,10 @@ public final class JaegerPropagator implements TextMapPropagator {
   private static final int MAX_BAGGAGE_ENTRIES = 64;
   private static final int MAX_BAGGAGE_BYTES = 8192;
 
+  // Bounds the parse work for a single jaeger-baggage header. Counts malformed tokens, which are
+  // not bounded by MAX_BAGGAGE_ENTRIES because they add no entry.
+  private static final int MAX_BAGGAGE_HEADER_TOKENS = MAX_BAGGAGE_ENTRIES;
+
   private static final Collection<String> FIELDS = Collections.singletonList(PROPAGATION_HEADER);
   private static final JaegerPropagator INSTANCE = new JaegerPropagator();
 
@@ -284,6 +288,7 @@ public final class JaegerPropagator implements TextMapPropagator {
               parseBaggageHeader(
                   value,
                   builder,
+                  MAX_BAGGAGE_HEADER_TOKENS,
                   MAX_BAGGAGE_ENTRIES - entriesAdded,
                   MAX_BAGGAGE_BYTES - bytesAdded);
           entriesAdded += counts[0];
@@ -299,21 +304,25 @@ public final class JaegerPropagator implements TextMapPropagator {
   }
 
   /**
-   * Parses a single {@code jaeger-baggage} header, stopping after {@code maxTokens} tokens or once
-   * the next entry would exceed {@code maxBytes}. The token bound is per header and counts
-   * malformed tokens, so a header of entirely malformed tokens cannot keep the loop running to the
-   * end of the input.
+   * Parses a single {@code jaeger-baggage} header, stopping after {@code maxTokens} tokens, after
+   * {@code maxEntries} entries have been added, or once the next entry would exceed {@code
+   * maxBytes}.
+   *
+   * <p>{@code maxTokens} bounds the parse work and counts malformed tokens, so a header of entirely
+   * malformed tokens cannot keep the loop running to the end of the input. {@code maxEntries} is a
+   * separate acceptance bound, so malformed tokens do not consume the caller's remaining entry
+   * budget.
    *
    * <p>Returns a two-element array of {@code [entriesAdded, bytesAdded]}, reflecting what was
    * actually added to {@code builder}.
    */
   private static int[] parseBaggageHeader(
-      String header, BaggageBuilder builder, int maxTokens, int maxBytes) {
+      String header, BaggageBuilder builder, int maxTokens, int maxEntries, int maxBytes) {
     int entriesAdded = 0;
     int bytesAdded = 0;
     int tokensParsed = 0;
     for (String part : header.split("\\s*,\\s*")) {
-      if (tokensParsed >= maxTokens) {
+      if (tokensParsed >= maxTokens || entriesAdded >= maxEntries) {
         break;
       }
       tokensParsed++;

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -298,15 +298,24 @@ public final class JaegerPropagator implements TextMapPropagator {
     return baggage.isEmpty() ? null : baggage;
   }
 
-  /** Returns a two-element array of {@code [entriesAdded, bytesAdded]}. */
+  /**
+   * Parses a single {@code jaeger-baggage} header, stopping after {@code maxEntries} tokens or once
+   * {@code maxBytes} is exceeded. The token bound is per header and counts malformed tokens, so a
+   * header of entirely malformed tokens cannot keep the loop running to the end of the input.
+   *
+   * <p>Returns a two-element array of {@code [entriesAdded, bytesAdded]}, reflecting what was
+   * actually added to {@code builder}.
+   */
   private static int[] parseBaggageHeader(
       String header, BaggageBuilder builder, int maxEntries, int maxBytes) {
     int entriesAdded = 0;
     int bytesAdded = 0;
+    int tokensParsed = 0;
     for (String part : header.split("\\s*,\\s*")) {
-      if (entriesAdded >= maxEntries || bytesAdded > maxBytes) {
+      if (tokensParsed >= maxEntries || bytesAdded > maxBytes) {
         break;
       }
+      tokensParsed++;
       String[] kv = part.split("\\s*=\\s*");
       if (kv.length == 2) {
         if (bytesAdded + kv[0].length() + kv[1].length() > maxBytes) {
@@ -315,7 +324,7 @@ public final class JaegerPropagator implements TextMapPropagator {
         builder.put(kv[0], kv[1]);
         entriesAdded++;
         bytesAdded += kv[0].length() + kv[1].length();
-      } else {
+      } else if (logger.isLoggable(Level.FINE)) {
         logger.fine("malformed token in " + BAGGAGE_HEADER + " header: " + part);
       }
     }

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java
@@ -299,20 +299,21 @@ public final class JaegerPropagator implements TextMapPropagator {
   }
 
   /**
-   * Parses a single {@code jaeger-baggage} header, stopping after {@code maxEntries} tokens or once
-   * {@code maxBytes} is exceeded. The token bound is per header and counts malformed tokens, so a
-   * header of entirely malformed tokens cannot keep the loop running to the end of the input.
+   * Parses a single {@code jaeger-baggage} header, stopping after {@code maxTokens} tokens or once
+   * the next entry would exceed {@code maxBytes}. The token bound is per header and counts
+   * malformed tokens, so a header of entirely malformed tokens cannot keep the loop running to the
+   * end of the input.
    *
    * <p>Returns a two-element array of {@code [entriesAdded, bytesAdded]}, reflecting what was
    * actually added to {@code builder}.
    */
   private static int[] parseBaggageHeader(
-      String header, BaggageBuilder builder, int maxEntries, int maxBytes) {
+      String header, BaggageBuilder builder, int maxTokens, int maxBytes) {
     int entriesAdded = 0;
     int bytesAdded = 0;
     int tokensParsed = 0;
     for (String part : header.split("\\s*,\\s*")) {
-      if (tokensParsed >= maxEntries || bytesAdded > maxBytes) {
+      if (tokensParsed >= maxTokens) {
         break;
       }
       tokensParsed++;

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
@@ -549,12 +549,33 @@ class JaegerPropagatorTest {
     headerCarrier.put(BAGGAGE_HEADER, jaegerHeader.toString());
     Map<String, String> bigValueCarrier = new LinkedHashMap<>();
     bigValueCarrier.put(BAGGAGE_PREFIX + "k", fillChars('v', 8192));
+    // 64 malformed tokens exhaust the per-header parse budget, so the trailing valid entry is not
+    // extracted. With 63, the budget still has room for it.
+    Map<String, String> malformedCarrier = new LinkedHashMap<>();
+    malformedCarrier.put(BAGGAGE_HEADER, malformedTokens(64) + "k0=v0");
+    Map<String, String> malformedUnderLimitCarrier = new LinkedHashMap<>();
+    malformedUnderLimitCarrier.put(BAGGAGE_HEADER, malformedTokens(63) + "k0=v0");
     return Stream.of(
         Arguments.argumentSet(
             "65 prefix keys truncated to 64", prefixCarrier, baggageWithEntries(0, 64)),
         Arguments.argumentSet(
             "65 header entries truncated to 64", headerCarrier, baggageWithEntries(0, 64)),
-        Arguments.argumentSet("large value exceeds byte limit", bigValueCarrier, Baggage.empty()));
+        Arguments.argumentSet("large value exceeds byte limit", bigValueCarrier, Baggage.empty()),
+        Arguments.argumentSet(
+            "64 malformed tokens exhaust the entry limit", malformedCarrier, Baggage.empty()),
+        Arguments.argumentSet(
+            "63 malformed tokens leave room for one entry",
+            malformedUnderLimitCarrier,
+            baggageWithEntries(0, 1)));
+  }
+
+  /** Returns {@code count} malformed (no {@code =}) comma-terminated baggage tokens. */
+  private static String malformedTokens(int count) {
+    StringBuilder header = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      header.append("malformed").append(i).append(",");
+    }
+    return header.toString();
   }
 
   /**

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
@@ -555,6 +555,13 @@ class JaegerPropagatorTest {
     malformedCarrier.put(BAGGAGE_HEADER, malformedTokens(64) + "k0=v0");
     Map<String, String> malformedUnderLimitCarrier = new LinkedHashMap<>();
     malformedUnderLimitCarrier.put(BAGGAGE_HEADER, malformedTokens(63) + "k0=v0");
+    // Malformed tokens consume the per-header token budget, not the remaining entry budget, so the
+    // trailing valid entry still fills the last of the 64 entry slots.
+    Map<String, String> prefixThenMalformedCarrier = new LinkedHashMap<>();
+    for (int i = 0; i < 63; i++) {
+      prefixThenMalformedCarrier.put(BAGGAGE_PREFIX + "k" + i, "v" + i);
+    }
+    prefixThenMalformedCarrier.put(BAGGAGE_HEADER, malformedTokens(1) + "k63=v63");
     return Stream.of(
         Arguments.argumentSet(
             "65 prefix keys truncated to 64", prefixCarrier, baggageWithEntries(0, 64)),
@@ -566,7 +573,11 @@ class JaegerPropagatorTest {
         Arguments.argumentSet(
             "63 malformed tokens leave room for one entry",
             malformedUnderLimitCarrier,
-            baggageWithEntries(0, 1)));
+            baggageWithEntries(0, 1)),
+        Arguments.argumentSet(
+            "malformed token does not consume the remaining entry budget",
+            prefixThenMalformedCarrier,
+            baggageWithEntries(0, 64)));
   }
 
   /** Returns {@code count} malformed (no {@code =}) comma-terminated baggage tokens. */

--- a/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
+++ b/extensions/trace-propagators/src/test/java/io/opentelemetry/extension/trace/propagation/JaegerPropagatorTest.java
@@ -562,7 +562,7 @@ class JaegerPropagatorTest {
             "65 header entries truncated to 64", headerCarrier, baggageWithEntries(0, 64)),
         Arguments.argumentSet("large value exceeds byte limit", bigValueCarrier, Baggage.empty()),
         Arguments.argumentSet(
-            "64 malformed tokens exhaust the entry limit", malformedCarrier, Baggage.empty()),
+            "64 malformed tokens exhaust the token budget", malformedCarrier, Baggage.empty()),
         Arguments.argumentSet(
             "63 malformed tokens leave room for one entry",
             malformedUnderLimitCarrier,


### PR DESCRIPTION
`JaegerPropagator.parseBaggageHeader` only incremented `entriesAdded` for well-formed `key=value` tokens, so the `maxEntries` loop guard never engaged for a header consisting entirely of malformed tokens (e.g. `a,a,a,...`) and the loop ran to the end of the input. This bounds the loop on tokens parsed instead, so the per-header parse budget applies regardless of token validity.

Also guards the malformed-token log message with `isLoggable`, since its string concatenation was previously evaluated on every malformed token whether or not `FINE` was enabled.

This is a user-visible behavior change for pathological input: a header of 64+ malformed tokens followed by a valid entry no longer extracts that entry. Tests cover both sides of the boundary (63 vs. 64 malformed tokens).

Found while analyzing GHSA-r3rj-5mf2-3rcg. That report claimed the `String.split` pre-tokenization in this method is a DoS vector; I don't think it is (allocation is linear in the input at a flat ~17x, bounded by the transport header limit, and `JaegerPropagator` is deprecated and not a default propagator), so I've left the `split` in place and am closing that advisory separately. These two items are ordinary code quality fixes, not a security fix.
