### PR TITLE
Reject mixing keyManager and sslContext in TlsConfigHelper

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
@@ -45,6 +45,9 @@ public class TlsConfigHelper {
    * @param trustedCertsPem Certificate in PEM format.
    */
   public void setTrustManagerFromCerts(byte[] trustedCertsPem) {
+    if (sslContext != null) {
+      throw new IllegalStateException("sslContext has been previously configured");
+    }
     if (trustManager != null) {
       throw new IllegalStateException("trustManager has been previously configured");
     }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/TlsConfigHelper.java
@@ -72,6 +72,9 @@ public class TlsConfigHelper {
     if (keyManager != null) {
       throw new IllegalStateException("keyManager has been previously configured");
     }
+    if (sslContext != null) {
+      throw new IllegalStateException("sslContext has been previously configured");
+    }
 
     try {
       keyManager = TlsUtil.keyManager(privateKeyPem, certificatePem);
@@ -94,6 +97,9 @@ public class TlsConfigHelper {
   public void setSslContext(SSLContext sslContext, X509TrustManager trustManager) {
     if (this.sslContext != null || this.trustManager != null) {
       throw new IllegalStateException("sslContext or trustManager has been previously configured");
+    }
+    if (this.keyManager != null) {
+      throw new IllegalStateException("keyManager has been previously configured");
     }
     this.trustManager = trustManager;
     this.sslContext = sslContext;

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -66,6 +66,16 @@ class TlsConfigHelperTest {
                     serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("keyManager has been previously configured");
+
+    helper = new TlsConfigHelper();
+    helper.setSslContext(
+        SSLContext.getInstance("TLS"), TlsUtil.trustManager(serverTls.certificate().getEncoded()));
+    assertThatThrownBy(
+            () ->
+                helper.setKeyManagerFromCerts(
+                    serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("sslContext has been previously configured");
   }
 
   @Test
@@ -93,5 +103,12 @@ class TlsConfigHelperTest {
     assertThatThrownBy(() -> helper.setSslContext(sslContext, trustManager))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("sslContext or trustManager has been previously configured");
+
+    helper = new TlsConfigHelper();
+    helper.setKeyManagerFromCerts(
+        serverTls.privateKey().getEncoded(), serverTls.certificate().getEncoded());
+    assertThatThrownBy(() -> helper.setSslContext(sslContext, trustManager))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("keyManager has been previously configured");
   }
 }

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/TlsConfigHelperTest.java
@@ -45,7 +45,7 @@ class TlsConfigHelperTest {
         SSLContext.getInstance("TLS"), TlsUtil.trustManager(serverTls.certificate().getEncoded()));
     assertThatThrownBy(() -> helper.setTrustManagerFromCerts(serverTls.certificate().getEncoded()))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("trustManager has been previously configured");
+        .hasMessageContaining("sslContext has been previously configured");
   }
 
   @Test


### PR DESCRIPTION
Fixes #8708

## Description

- `TlsConfigHelper.setSslContext` did not check `keyManager` and `setKeyManagerFromCerts` did not check `sslContext`, so both APIs could be used on one builder.
- Not a new restriction: the class Javadoc says these APIs may be used "but NOT both", and `OtlpHttpSpanExporterBuilder.setSslContext` tells users to "call this _or_ set raw certificate bytes, but not both".
- Code that now throws was already broken — senders pass `getSslContext()` and `getTrustManager()` to the transport and never read `getKeyManager()`, so the client certificate was silently dropped.
- `trustManager` is already guarded in both directions; `keyManager` was the only asymmetric case.
- Existing exception messages are unchanged; each missing direction is a separate `if`.

## Testing done

- Extended `TlsConfigHelperTest#createKeyManager_AlreadyExists_Throws` and `#setSslContext_AlreadyExists_Throws` with opposite-direction blocks, matching the trust manager tests.
- Both fail when the production change is reverted.
- `./gradlew :exporters:common:check` — 70 tests passed.
- No apidiff change: `io.opentelemetry.exporter.internal` is excluded from japicmp and no signature changed.
