### PR TITLE
Fix StringEncoder javadoc Java version and Android condition

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoder.java
@@ -18,9 +18,10 @@ import javax.annotation.Nullable;
  * this priority order:
  *
  * <ul>
- *   <li>{@code UnsafeStringEncoder} - High-performance Java 8+ implementation using
- *       sun.misc.Unsafe. Only attempted when the Java version is detected to be below 23, to avoid
- *       the JEP 498 deprecation warning.
+ *   <li>{@code UnsafeStringEncoder} - High-performance Java 9+ implementation using sun.misc.Unsafe
+ *       to read the compact string fields of {@code String}. Only attempted when the Java version
+ *       is detected to be below 23, to avoid the JEP 498 deprecation warning, and not on Android,
+ *       where {@code String} does not have those fields.
  *   <li>{@code VarHandleStringEncoder} - High-performance Java 9+ implementation using VarHandle.
  *       Requires {@code --add-opens=java.base/java.lang=ALL-UNNAMED}.
  *   <li>{@code FallbackStringEncoder} - Implementation using standard Java operations

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoderHolder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/StringEncoderHolder.java
@@ -71,7 +71,7 @@ public final class StringEncoderHolder {
     if (!proactivelyAvoidUnsafe()) {
       StringEncoder unsafeImpl = createUnsafeEncoder();
       if (unsafeImpl != null) {
-        logger.log(Level.FINE, "Using UnsafeStringEncoder for optimized Java 8+ performance");
+        logger.log(Level.FINE, "Using UnsafeStringEncoder for optimized Java 9+ performance");
         return unsafeImpl;
       }
     }

--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/UnsafeStringEncoder.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/marshal/UnsafeStringEncoder.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 import sun.misc.Unsafe;
 
 /**
- * StringEncoder implementation using sun.misc.Unsafe for high performance on Java 8+.
+ * StringEncoder implementation using sun.misc.Unsafe for high performance on Java 9+.
  *
  * <p>This implementation provides optimized string operations by directly accessing String internal
  * fields using Unsafe operations. It's only created if Unsafe is available and all required field


### PR DESCRIPTION
Fixes #8709

## Description

- The javadoc called `UnsafeStringEncoder` a "Java 8+" implementation, but `createIfAvailable()` needs the `String.value` (`byte[]`) and `String.coder` fields, which Java 8 does not have, so Java 8 always falls back. The inline comment on the `coder` lookup already says "this only exists in Java 9+".
- That wording came from #7701 and was carried over unchanged when #8621 reordered the same bullet.
- Separately, #8637 added an Android (Dalvik) early return to `createUnsafeEncoder()`, but the bullet still listed only the Java version condition. Added it to the same sentence.
- Updated the matching wording in the `UnsafeStringEncoder` javadoc and the `StringEncoderHolder` log message.

## Testing done

- Docs-only, test-exempt: javadoc and one non-asserted `Level.FINE` log message; no behavior or API change.
- `./gradlew :exporters:common:check` passed — 70 tests (61 `test`, 8 `testSenderProvider`, 1 `testWithoutUnsafe`), 0 failures.
- No apidiff update: all touched classes are japicmp-excluded `io.opentelemetry.exporter.internal.*`.
