### PR TITLE
Output severity text in SystemOutLogRecordExporter

### DIFF
--- a/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
+++ b/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporter.java
@@ -65,6 +65,7 @@ public class SystemOutLogRecordExporter implements LogRecordExporter {
   static void formatLog(StringBuilder stringBuilder, LogRecordData log) {
     InstrumentationScopeInfo instrumentationScopeInfo = log.getInstrumentationScopeInfo();
     Value<?> body = log.getBodyValue();
+    String severityText = log.getSeverityText();
     String eventName = log.getEventName();
     stringBuilder
         .append(
@@ -73,6 +74,9 @@ public class SystemOutLogRecordExporter implements LogRecordExporter {
                     .atZone(ZoneOffset.UTC)))
         .append(" ")
         .append(log.getSeverity());
+    if (severityText != null && !severityText.isEmpty()) {
+      stringBuilder.append(" [severityText: ").append(severityText).append("]");
+    }
     if (eventName != null && !eventName.isEmpty()) {
       stringBuilder.append(" [eventName: ").append(eventName).append("]");
     }

--- a/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
+++ b/exporters/logging/src/test/java/io/opentelemetry/exporter/logging/SystemOutLogRecordExporterTest.java
@@ -54,6 +54,34 @@ class SystemOutLogRecordExporterTest {
   }
 
   @Test
+  void formatWithSeverityText() {
+    long timestamp =
+        LocalDateTime.of(1970, Month.AUGUST, 7, 10, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    LogRecordData log =
+        TestLogRecordData.builder()
+            .setResource(Resource.empty())
+            .setInstrumentationScopeInfo(
+                InstrumentationScopeInfo.builder("logTest").setVersion("1.0").build())
+            .setBody("message")
+            .setSeverity(Severity.ERROR3)
+            .setSeverityText("SEVERE")
+            .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
+            .setSpanContext(
+                SpanContext.create(
+                    "00000000000000010000000000000002",
+                    "0000000000000003",
+                    TraceFlags.getDefault(),
+                    TraceState.getDefault()))
+            .build();
+    StringBuilder output = new StringBuilder();
+    SystemOutLogRecordExporter.formatLog(output, log);
+    assertThat(output.toString())
+        .isEqualTo(
+            "1970-08-07T10:00:00Z ERROR3 [severityText: SEVERE] 'message' : "
+                + "00000000000000010000000000000002 0000000000000003 [scopeInfo: logTest:1.0] {}");
+  }
+
+  @Test
   void formatWithEventName() {
     long timestamp =
         LocalDateTime.of(1970, Month.AUGUST, 7, 10, 0).toInstant(ZoneOffset.UTC).toEpochMilli();


### PR DESCRIPTION
Fixes #8712

## Description

- `SystemOutLogRecordExporter.formatLog()` prints the severity number but drops `LogRecordData.getSeverityText()`.
- Appends `[severityText: ...]` after the severity and before `[eventName: ...]`, matching the OTLP field order (`severity_number` → `severity_text` → ... → `event_name`).
- The OTLP marshalers (`LogMarshaler`, `LogStatelessMarshaler`) already serialize both fields, so this aligns the console exporter with them.
- The two fields are independent: custom levels such as log4j's `AUDIT` cannot be recovered from the severity enum alone.
- Nothing is appended when the severity text is null or empty, so existing output is unchanged.
- Same shape as #8609 (event name), which fixed #8608.

## Testing done

- Added `SystemOutLogRecordExporterTest#formatWithSeverityText` asserting `[severityText: SEVERE]` in the formatted line; the existing `format()` test covers the unset case.
- `./gradlew :exporters:logging:check` — 17 tests passed.
- No public API change, so no apidiff update.

