### PR TITLE
Fix incorrect javadoc references in ContextStorageProvider and ContextKey

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/ContextKey.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextKey.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.context;
 
 /**
- * Key for indexing values of type {@link T} stored in a {@link Context}. {@link ContextKey} are
+ * Key for indexing values of type {@code T} stored in a {@link Context}. {@link ContextKey} are
  * compared by reference, so it is expected that only one {@link ContextKey} is created for a
  * particular type of context value.
  *

--- a/context/src/main/java/io/opentelemetry/context/ContextStorageProvider.java
+++ b/context/src/main/java/io/opentelemetry/context/ContextStorageProvider.java
@@ -16,8 +16,8 @@ import java.util.concurrent.Executor;
  * <p><a
  * href="https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/common/RequestContext.html">{@code
  * com.linecorp.armeria.common.RequestContext}</a>, <a
- * href="https://grpc.github.io/grpc-java/javadoc/io/grpc/Context.html">{@code
- * io.grpc.context.Context}</a>, or <a
+ * href="https://grpc.github.io/grpc-java/javadoc/io/grpc/Context.html">{@code io.grpc.Context}</a>,
+ * or <a
  * href="https://download.eclipse.org/microprofile/microprofile-context-propagation-1.0.2/apidocs/org/eclipse/microprofile/context/ThreadContext.html">{@code
  * org.eclipse.microprofile.context.ThreadContext}</a>
  *


### PR DESCRIPTION
<!-- No issue: trivial javadoc reference fix; mirrors #8588/#8486 which had no issue -->

## Description

- `ContextStorageProvider`: the gRPC link text said `io.grpc.context.Context`, which does not exist — grpc-java declares the class in `package io.grpc`, and the `href` on the same line already points at `io/grpc/Context.html`. (`grpc-context` is the Maven artifactId, not the package.)
- `ContextKey`: `values of type {@link T}` renders as `values of type ContextKey`, because javadoc resolves the type variable `T` to the type that declares it, so the sentence says something untrue. No `invalid-tag` warning is emitted — the reference resolves, just to the wrong thing. `{@code T}` renders the letter as intended.

## Testing done

- Docs-only, test-exempt: no test added; `./gradlew :context:check` passed.
- Checked the rendered output with `./gradlew :context:javadoc --rerun-tasks`: `ContextKey.html` now reads `values of type <code>T</code>`, and `ContextStorageProvider.html` shows `io.grpc.Context`.
- No public signature change, so `docs/apidiffs/current_vs_latest/` is unchanged.

