### PR TITLE
Fix javadoc examples in context propagation interfaces

### DIFF
--- a/context/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/ContextPropagators.java
@@ -30,8 +30,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *     // Inject the span's SpanContext and other available concerns (such as correlations)
  *     // contained in the specified Context.
  *     Map<String, String> map = new HashMap<>();
- *     textMapPropagator.inject(Context.current(), map, new Setter<String, String>() {
- *       public void put(Map<String, String> map, String key, String value) {
+ *     textMapPropagator.inject(Context.current(), map, new TextMapSetter<Map<String, String>>() {
+ *       public void set(Map<String, String> map, String key, String value) {
  *         map.put(key, value);
  *       }
  *     });
@@ -50,10 +50,13 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  *   // Extract and store the propagated span's SpanContext and other available concerns
  *   // in the specified Context.
- *   Context context = textMapPropagator.extract(Context.current(), request,
- *     new Getter<String, String>() {
- *       public String get(Object request, String key) {
- *         // Return the value associated to the key, if available.
+ *   Context context = textMapPropagator.extract(Context.current(), headers,
+ *     new TextMapGetter<Map<String, String>>() {
+ *       public Iterable<String> keys(Map<String, String> carrier) {
+ *         return carrier.keySet();
+ *       }
+ *       public String get(Map<String, String> carrier, String key) {
+ *         return carrier.get(key);
  *       }
  *     }
  *   );
@@ -80,7 +83,7 @@ public interface ContextPropagators {
    * <pre>{@code
    * ContextPropagators propagators = ContextPropagators.create(
    *   TextMapPropagator.composite(
-   *     HttpTraceContext.getInstance(),
+   *     W3CTraceContextPropagator.getInstance(),
    *     W3CBaggagePropagator.getInstance(),
    *     new MyCustomContextPropagator()));
    * }</pre>

--- a/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
+++ b/context/src/main/java/io/opentelemetry/context/propagation/TextMapPropagator.java
@@ -24,18 +24,24 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Specific concern values (traces, correlations, etc) will be read from the specified {@code
  * Context}, and resulting values will be stored in a new {@code Context} upon extraction. It is
- * recommended to use a single {@code Context.Key} to store the entire concern data:
+ * recommended to use a single {@code ContextKey} to store the entire concern data:
  *
  * <pre>{@code
- * public static final Context.Key CONCERN_KEY = Context.key("my-concern-key");
- * public MyConcernPropagator implements TextMapPropagator {
- *   public <C> void inject(Context context, C carrier, Setter<C> setter) {
- *     Object concern = CONCERN_KEY.get(context);
+ * public class MyConcernPropagator implements TextMapPropagator {
+ *   private static final ContextKey<Object> CONCERN_KEY = ContextKey.named("my-concern-key");
+ *
+ *   public Collection<String> fields() {
+ *     return Collections.singletonList("my-concern-header");
+ *   }
+ *
+ *   public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+ *     Object concern = context.get(CONCERN_KEY);
  *     // Use concern in the specified context to propagate data.
  *   }
- *   public <C> Context extract(Context context, C carrier, Getter<C> getter) {
- *     // Use getter to get the data from the carrier.
- *     return context.withValue(CONCERN_KEY, concern);
+ *
+ *   public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+ *     Object concern = getter.get(carrier, "my-concern-header");
+ *     return context.with(CONCERN_KEY, concern);
  *   }
  * }
  * }</pre>


### PR DESCRIPTION
<!-- No issue: javadoc example fix, mirrors #8486 and #8588 which had no issue -->

## Description

- The class javadoc examples on `TextMapPropagator` and `ContextPropagators` use pre-1.0 API names, so copying them does not compile.
- `Setter`/`Getter` no longer exist: the types are `TextMapSetter<C>`/`TextMapGetter<C>`, and the setter method is `set`, not `put`.
- The server example implemented only `get` (with no `return`) and omitted the required `keys`; it now mirrors `ExtendedContextPropagators.TEXT_MAP_GETTER`.
- `Context.Key`, `Context.key(...)`, `ContextKey.get(context)` and `context.withValue(...)` become `ContextKey.named(...)`, `context.get(key)` and `context.with(key, value)`.
- `MyConcernPropagator` was missing the `class` keyword, used an undeclared `concern`, and did not implement the abstract `fields()`.
- `HttpTraceContext` was removed in 1.0; the composite example now uses `W3CTraceContextPropagator.getInstance()`.
- Incomplete fix of #4140, which touched this same `ContextPropagators` block but left `Setter`/`Getter`/`HttpTraceContext` behind.

## Testing done

- Docs-only, test-exempt: `./gradlew :context:check` passed, and `docs/apidiffs/current_vs_latest/*.txt` is unchanged.
- Compiled the corrected examples with `javac` against `:context` and `:api:all` — every type and signature resolves.
- `./gradlew :context:javadoc --rerun-tasks` — BUILD SUCCESSFUL, no `invalid-tag` in the generated HTML.

