### PR TITLE
feat(trace): support runtime sampler updates

### DIFF
--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -113,6 +113,9 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   /**
    * Updates the sampler used for new spans.
    *
+   * <p>The sampler must be thread-safe and return immediately because it is called on the span
+   * creation hot path.
+   *
    * @param sampler the sampler to use for sampling new spans.
    */
   public void setSampler(Sampler sampler) {

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -113,8 +113,8 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   /**
    * Updates the sampler used for new spans.
    *
-   * <p>The sampler must be thread-safe and return immediately because it is called on the span
-   * creation hot path.
+   * <p>The {@code sampler} must be thread-safe and return immediately (no remote calls, as
+   * contention free as possible).
    *
    * @param sampler the sampler to use for sampling new spans.
    */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.trace.internal.TracerConfig;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.Closeable;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -107,6 +108,15 @@ public final class SdkTracerProvider implements TracerProvider, Closeable {
   /** Returns the {@link SpanLimits} that are currently applied to created spans. */
   public SpanLimits getSpanLimits() {
     return sharedState.getSpanLimits();
+  }
+
+  /**
+   * Updates the sampler used for new spans.
+   *
+   * @param sampler the sampler to use for sampling new spans.
+   */
+  public void setSampler(Sampler sampler) {
+    sharedState.setSampler(Objects.requireNonNull(sampler, "sampler"));
   }
 
   /** Returns the configured {@link Sampler}. */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -26,7 +26,7 @@ final class TracerSharedState {
   private final Resource resource;
 
   private final Supplier<SpanLimits> spanLimitsSupplier;
-  private final Sampler sampler;
+  private volatile Sampler sampler;
   private final SpanProcessor activeSpanProcessor;
   private final ExceptionAttributeResolver exceptionAttributeResolver;
   private final SdkTracerInstrumentation tracerInstrumentation;
@@ -74,9 +74,13 @@ final class TracerSharedState {
     return spanLimitsSupplier.get();
   }
 
-  /** Returns the configured {@link Sampler}. */
+  /** Returns the currently configured {@link Sampler}. */
   Sampler getSampler() {
     return sampler;
+  }
+
+  void setSampler(Sampler sampler) {
+    this.sampler = sampler;
   }
 
   /**

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/TracerSharedState.java
@@ -80,7 +80,16 @@ final class TracerSharedState {
   }
 
   void setSampler(Sampler sampler) {
-    this.sampler = sampler;
+    synchronized (lock) {
+      if (shutdownResult != null) {
+        sampler.shutdown();
+        return;
+      }
+
+      Sampler previousSampler = this.sampler;
+      this.sampler = sampler;
+      previousSampler.shutdown();
+    }
   }
 
   /**

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -124,6 +125,46 @@ class SdkTracerProviderTest {
     Span secondSpan = tracer.spanBuilder("second").startSpan();
     assertThat(secondSpan.getSpanContext().isSampled()).isTrue();
     secondSpan.end();
+  }
+
+  @Test
+  void setSampler_shutsDownPreviousSampler() {
+    Sampler firstSampler = mock(Sampler.class);
+    Sampler secondSampler = mock(Sampler.class);
+
+    when(firstSampler.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    when(secondSampler.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().setSampler(firstSampler).build();
+
+    tracerProvider.setSampler(secondSampler);
+
+    verify(firstSampler).shutdown();
+    verify(secondSampler, never()).shutdown();
+
+    tracerProvider.shutdown();
+
+    verify(secondSampler).shutdown();
+  }
+
+  @Test
+  void setSampler_afterShutdown_shutsDownNewSampler() {
+    Sampler initialSampler = mock(Sampler.class);
+    Sampler newSampler = mock(Sampler.class);
+
+    when(initialSampler.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    when(newSampler.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().setSampler(initialSampler).build();
+
+    tracerProvider.shutdown();
+    verify(initialSampler).shutdown();
+
+    tracerProvider.setSampler(newSampler);
+
+    verify(newSampler).shutdown();
   }
 
   @Test

--- a/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
+++ b/sdk/trace/src/test/java/io/opentelemetry/sdk/trace/SdkTracerProviderTest.java
@@ -88,6 +88,45 @@ class SdkTracerProviderTest {
   }
 
   @Test
+  void setSampler() {
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().setSampler(Sampler.alwaysOn()).build();
+
+    assertThat(tracerProvider.getSampler()).isEqualTo(Sampler.alwaysOn());
+
+    tracerProvider.setSampler(Sampler.alwaysOff());
+
+    assertThat(tracerProvider.getSampler()).isEqualTo(Sampler.alwaysOff());
+  }
+
+  @Test
+  void setSampler_null() {
+    SdkTracerProvider tracerProvider = SdkTracerProvider.builder().build();
+
+    assertThatThrownBy(() -> tracerProvider.setSampler(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("sampler");
+  }
+
+  @Test
+  void setSampler_affectsExistingTracer() {
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().setSampler(Sampler.alwaysOff()).build();
+
+    Tracer tracer = tracerProvider.get("test");
+
+    Span firstSpan = tracer.spanBuilder("first").startSpan();
+    assertThat(firstSpan.getSpanContext().isSampled()).isFalse();
+    firstSpan.end();
+
+    tracerProvider.setSampler(Sampler.alwaysOn());
+
+    Span secondSpan = tracer.spanBuilder("second").startSpan();
+    assertThat(secondSpan.getSpanContext().isSampled()).isTrue();
+    secondSpan.end();
+  }
+
+  @Test
   void builder_serviceNameProvided() {
     Resource resource =
         Resource.create(Attributes.of(stringKey("service.name"), "mySpecialService"));


### PR DESCRIPTION
## Summary
Add runtime sampler updates to `SdkTracerProvider` so a sampler can be changed after the provider is built.

## Changes
- Add `SdkTracerProvider.setSampler(Sampler)`
- Make the shared sampler reference mutable so new spans observe updates
- Add tests for:
  - updating the sampler at runtime
  - null rejection
  - an existing tracer observing the new sampler for new spans

## Verification
- `./gradlew :sdk:trace:test --tests io.opentelemetry.sdk.trace.SdkTracerProviderTest`
- `./gradlew :sdk:trace:test`
- `./gradlew spotlessApply`
- `git diff --check`