### PR TITLE
Remove Prometheus host default migration log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### SDK
+
+#### Exporters
+
+* Prometheus: Remove the log warning about the default host change from `0.0.0.0` to `localhost`
+  ([#8720](https://github.com/open-telemetry/opentelemetry-java/pull/8720))
+
 ## Version 1.65.0 (2026-08-07)
 
 **NOTE:** The `opentelemetry-exporter-zipkin` artifact has stopped being published. It was

--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java
@@ -18,7 +18,6 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /** A builder for {@link PrometheusHttpServer}. */
@@ -27,12 +26,8 @@ public final class PrometheusHttpServerBuilder {
   static final int DEFAULT_PORT = 9464;
   private static final String DEFAULT_HOST = "localhost";
   private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.REUSABLE_DATA;
-  private static final Logger LOGGER =
-      Logger.getLogger(PrometheusHttpServerBuilder.class.getName());
 
-  // Temporarily nullable to detect when it's not set and log warning about 0.0.0.0 -> localhost
-  // change
-  @Nullable private String host;
+  private String host = DEFAULT_HOST;
   private int port = DEFAULT_PORT;
   private PrometheusRegistry prometheusRegistry = new PrometheusRegistry();
   private PrometheusMetricReaderBuilder metricReaderBuilder = PrometheusMetricReader.builder();
@@ -198,17 +193,9 @@ public final class PrometheusHttpServerBuilder {
           "MemoryMode REUSEABLE_DATA cannot be used with custom executor, "
               + "since data may be corrupted if reading metrics concurrently");
     }
-    String resolvedHost = host;
-    if (resolvedHost == null) {
-      // TODO (jack-berg): Remove log after 1.64.0 release
-      LOGGER.info(
-          "PrometheusHttpServer host not set, defaulting to localhost. Previously defaulted to 0.0.0.0. "
-              + "If you depend on the old behavior, set host to 0.0.0.0 explicitly.");
-      resolvedHost = DEFAULT_HOST;
-    }
     return new PrometheusHttpServer(
         new PrometheusHttpServerBuilder(this), // copy to prevent modification
-        resolvedHost,
+        host,
         port,
         executor,
         prometheusRegistry,


### PR DESCRIPTION
Removes the migration log in `PrometheusHttpServerBuilder`, per the TODO left in #8298:

```java
// TODO (jack-berg): Remove log after 1.64.0 release
```

1.64.0 shipped on 2026-07-10 and 1.65.0 on 2026-08-07, so the condition has been met for two releases.

**Scope note:** I also made `host` non-nullable. The field comment said it was "Temporarily nullable to detect when it's not set and log warning about 0.0.0.0 -> localhost change" — the log was the only reason for the nullability, so `host` now initialises to `DEFAULT_HOST` and the `resolvedHost` null check in `build()` is gone. Happy to cut this back to removing only the log if you'd prefer the smaller diff.

I left the `setHost` Javadoc note about the previous `0.0.0.0` default in place, since that's still useful to users and outside what the TODO covered.

`./gradlew :exporters:prometheus:check` passes. No public API change, so no apidiff updates.
