### PR TITLE
Converge GitHub Actions and Develocity caches

### DIFF
--- a/.github/workflows/benchmark-tags.yml
+++ b/.github/workflows/benchmark-tags.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
       - name: Run jmh
         run: ./gradlew jmhJar
         env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
       - name: Run jmh
         run: ./gradlew jmhJar
         env:

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Publish to Sonatype
         run: ./gradlew assemble publishToSonatype

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,11 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Keep one writer per OS because Gradle User Home caches are platform-specific.
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch || matrix.test-java-version != 25 }}
+          gradle-home-cache-excludes: >-
+            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && matrix.test-java-version == 25 && 'caches/build-cache-1' || '' }}
       - name: Build
         run: >
             ./gradlew build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Set up gradle
         if: matrix.language == 'java'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/javadoc-crawler.yml
+++ b/.github/workflows/javadoc-crawler.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Run crawler
         run: ./gradlew :javadoc-crawler:crawl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build and publish artifacts
         run: ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository
@@ -189,6 +191,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Update apidiff baseline
         env:

--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       # --no-parallel is needed to avoid OverlappingFileLockException on the shared OSS Index cache
       - run: ./gradlew ossIndexAudit --no-configuration-cache --no-parallel --info

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -78,6 +78,10 @@ val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
 val disableRemoteBuildCache = System.getenv("DISABLE_REMOTE_BUILD_CACHE") != null
+val isRemoteBuildCachePushEnabled =
+  isCI && develocityAccessKey.isNotEmpty() && !disableRemoteBuildCache
+val shouldDisableLocalBuildCache =
+  isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 develocity {
   if (develocityAccessKey.isNotEmpty()) {
@@ -111,9 +115,15 @@ develocity {
 }
 
 buildCache {
-  remote(HttpBuildCache::class) {
-    url = uri("$develocityServer/cache/")
+  // Tasks loaded from the local cache are not pushed to the remote cache. Disable the local cache
+  // on default-branch CI builds so executed tasks populate the authenticated Develocity cache.
+  local {
+    isEnabled = !shouldDisableLocalBuildCache
+  }
+
+  remote(develocity.buildCache) {
+    server = develocityServer
     isEnabled = !disableRemoteBuildCache
-    isPush = isCI && develocityAccessKey.isNotEmpty()
+    isPush = isRemoteBuildCachePushEnabled
   }
 }


### PR DESCRIPTION
Applies the cache fixes from [opentelemetry-java-instrumentation#19532](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19532) and [opentelemetry-java-instrumentation#19533](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19533) to reduce GitHub Actions cache pressure and improve Develocity remote cache coverage.