### PR TITLE
Add toString to OtlpJsonLogging exporters

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt
@@ -1,2 +1,10 @@
 Comparing source compatibility of opentelemetry-exporter-logging-otlp-1.66.0-SNAPSHOT.jar against opentelemetry-exporter-logging-otlp-1.64.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporter.java
@@ -54,4 +54,9 @@ public final class OtlpJsonLoggingLogRecordExporter implements LogRecordExporter
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpJsonLoggingLogRecordExporter{}";
+  }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporter.java
@@ -84,4 +84,9 @@ public final class OtlpJsonLoggingMetricExporter implements MetricExporter {
   public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
     return aggregationTemporality;
   }
+
+  @Override
+  public String toString() {
+    return "OtlpJsonLoggingMetricExporter{aggregationTemporality=" + aggregationTemporality + "}";
+  }
 }

--- a/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
+++ b/exporters/logging-otlp/src/main/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.java
@@ -52,4 +52,9 @@ public final class OtlpJsonLoggingSpanExporter implements SpanExporter {
   public CompletableResultCode shutdown() {
     return delegate.shutdown();
   }
+
+  @Override
+  public String toString() {
+    return "OtlpJsonLoggingSpanExporter{}";
+  }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingLogRecordExporterTest.java
@@ -53,4 +53,10 @@ class OtlpJsonLoggingLogRecordExporterTest {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
     logs.assertContains("Calling shutdown() multiple times.");
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(OtlpJsonLoggingLogRecordExporter.create().toString())
+        .isEqualTo("OtlpJsonLoggingLogRecordExporter{}");
+  }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingMetricExporterTest.java
@@ -78,4 +78,12 @@ class OtlpJsonLoggingMetricExporterTest {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
     logs.assertContains("Calling shutdown() multiple times.");
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(OtlpJsonLoggingMetricExporter.create().toString())
+        .isEqualTo("OtlpJsonLoggingMetricExporter{aggregationTemporality=CUMULATIVE}");
+    assertThat(OtlpJsonLoggingMetricExporter.create(AggregationTemporality.DELTA).toString())
+        .isEqualTo("OtlpJsonLoggingMetricExporter{aggregationTemporality=DELTA}");
+  }
 }

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporterTest.java
@@ -64,4 +64,10 @@ class OtlpJsonLoggingSpanExporterTest {
     assertThat(exporter.shutdown().isSuccess()).isTrue();
     logs.assertContains("Calling shutdown() multiple times.");
   }
+
+  @Test
+  void stringRepresentation() {
+    assertThat(OtlpJsonLoggingSpanExporter.create().toString())
+        .isEqualTo("OtlpJsonLoggingSpanExporter{}");
+  }
 }


### PR DESCRIPTION
Fixes #8724

## Description

- `OtlpJsonLoggingMetricExporter`, `OtlpJsonLoggingSpanExporter` and `OtlpJsonLoggingLogRecordExporter` had no `toString()`, so they printed an identity hash such as `OtlpJsonLoggingMetricExporter@6d06d69c`.
- These strings are user-visible: `PeriodicMetricReader.toString()` embeds the exporter as `"exporter=" + exporter`.
- For the metric exporter this hid its only user-settable option, the `AggregationTemporality` passed to `create(AggregationTemporality)`.
- Formats match the siblings in `:exporters:logging`: `LoggingMetricExporter{aggregationTemporality=...}`, `LoggingSpanExporter{}`, `SystemOutLogRecordExporter{}`.
- Delegating to the wrapped `OtlpStdout*Exporter` does not work: it is not exposed, and `create(AggregationTemporality)` never forwards the temporality, so the delegate still reports the builder default `alwaysCumulative()`.
- Same shape as #5686 and #8645; the metric format follows #8623.

## Testing done

- Added `stringRepresentation()` to `OtlpJsonLoggingMetricExporterTest` (cumulative and delta), `OtlpJsonLoggingSpanExporterTest` and `OtlpJsonLoggingLogRecordExporterTest`. All three fail on `main` and pass with this change.
- `./gradlew :exporters:logging-otlp:check` — 80 tests passed, 0 failures.
- Committed the updated `docs/apidiffs/current_vs_latest/opentelemetry-exporter-logging-otlp.txt`.

