### PR TITLE
Exclude OpenTelemetry updates from the grouped weekly Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,8 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
+      // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -22,6 +23,10 @@
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry**',
+        '!open-telemetry/**',
       ],
     },
     {


### PR DESCRIPTION
OpenTelemetry dependency updates now always get their own Renovate PR instead of being swallowed into the grouped weekly `all patch and minor versions` PR. These updates are used for dogfooding and for cascaded releases across the OpenTelemetry Java repos, so batching them until Tuesday delays the release chain.

The affected artifacts are `io.opentelemetry.contrib:opentelemetry-aws-xray-propagator`, `io.opentelemetry.proto:opentelemetry-proto`, and `io.opentelemetry.semconv:opentelemetry-semconv-incubating`.

The exclusion is written as `!io.opentelemetry**` without a colon, so it covers every OpenTelemetry group id rather than only the bare `io.opentelemetry` group. `!open-telemetry/**` covers dependencies sourced from GitHub.

OpenTelemetry-published Docker images such as `otel/opentelemetry-collector-contrib` are deliberately still grouped, because they are test infrastructure rather than part of a cascaded release.

GitHub Actions and Dockerfile updates are unaffected. The later `weekly update` rule matches by manager and still overrides the grouping for them, including `open-telemetry/shared-workflows` action bumps.

The comment on the rule also said "group all patch updates" even though the rule has covered minor updates too; that is corrected here.