### PR TITLE
Exclude OpenTelemetry updates from the grouped weekly Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,8 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
+      // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -22,6 +23,10 @@
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry**',
+        '!open-telemetry/**',
       ],
     },
     {


### PR DESCRIPTION
OpenTelemetry dependency updates now get their own Renovate pull request instead of being folded into the grouped weekly one. These updates drive dogfooding and cascaded releases across the OpenTelemetry Java repos, so holding them until Tuesday delays the release chain.

This affects `io.opentelemetry.contrib:opentelemetry-aws-xray-propagator`, `io.opentelemetry.proto:opentelemetry-proto`, and `io.opentelemetry.semconv:opentelemetry-semconv-incubating`.

OpenTelemetry-published Docker images such as `otel/opentelemetry-collector-contrib` stay grouped, since they are test infrastructure rather than part of a cascaded release.
