### PR TITLE
Fix signal name in OTLP gRPC logs package javadoc

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/package-info.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/logs/package-info.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** OpenTelemetry exporter which sends span data to OpenTelemetry collector via OTLP gRPC. */
+/** OpenTelemetry exporter which sends log data to OpenTelemetry collector via OTLP gRPC. */
 @ParametersAreNonnullByDefault
 package io.opentelemetry.exporter.otlp.logs;
 


### PR DESCRIPTION
<!-- No issue: trivial javadoc typo, PR-only -->

## Description

- The package javadoc of `io.opentelemetry.exporter.otlp.logs` says "sends span data", but the package exports logs.
- Changes that one word to "log data", matching the sibling `io.opentelemetry.exporter.otlp.http.logs` package.
- The wrong word dates back to #3670, which created the logs package by copying the trace package.
- Related: #8693 fixed the same kind of copy-paste leftover in public API javadoc.

## Testing done

- Javadoc-only, test-exempt: no test added.
- `./gradlew :exporters:otlp:all:check` — BUILD SUCCESSFUL, 1047 tests passed (13 skipped), 0 failures.
- No signature change, so `docs/apidiffs/current_vs_latest/` is unchanged.

