### PR TITLE
Wire otlp common test suites into check

### DIFF
--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -55,6 +55,12 @@ testing {
   }
 }
 
+tasks {
+  check {
+    dependsOn(testing.suites)
+  }
+}
+
 wire {
   root(
     "opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest",


### PR DESCRIPTION
Fixes #8736

## Description

- `exporters/otlp/common/build.gradle.kts` registers the `testIncubating` JvmTestSuite but never wires it into `check`, so its 4 tests have not run in CI since #7123 added the suite (2025-04-11).
- The sources still compile and pass checkstyle, so nothing looks broken.
- Adds the `tasks { check { dependsOn(testing.suites) } }` block that `sdk/trace`, `sdk/logs`, `context` and eight other modules already use.
- The skipped tests guard #7363: the log marshaler must accept a plain `LogRecordData` even when api-incubator is on the classpath.
- Follow-up to #8691, which fixed the same gap in `api/incubator` and named this module as the remaining one.

## Testing done

- Build wiring only: no production code, signature or public API change, so no test was added.
- `./gradlew :exporters:otlp:common:check --dry-run` now lists `:exporters:otlp:common:testIncubating`; it was absent before.
- `./gradlew :exporters:otlp:common:check` — BUILD SUCCESSFUL, 122 tests passed (118 existing plus the 4 from the newly wired suite, all green).
- `docs/apidiffs/` is untouched.

