### PR TITLE
Exclude slack links from lychee

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -13,4 +13,5 @@ include_fragments = "full"
 exclude = [
   "^https://github.com/open-telemetry/opentelemetry-java/(issues|pull)/\\d+$",
   "^https://www.javadoc.io/badge/(.*?)/(.*?).svg$", # returns 522
+  "^https://cloud-native.slack.com/", # slack requires auth
 ]


### PR DESCRIPTION
Fixing build error: https://github.com/open-telemetry/opentelemetry-java/actions/runs/32378671723/job/96456178069