### PR TITLE
Require explanations for suppressed warnings in logging OTLP

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OpenTelemetry All"
 otelJava.moduleName.set("io.opentelemetry.all")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 // Skip ossIndexAudit on test module

--- a/animal-sniffer-signature/build.gradle.kts
+++ b/animal-sniffer-signature/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "Build tool to generate the Animal Sniffer Android signature"
 otelJava.moduleName.set("io.opentelemetry.internal.animalsniffer")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 val signatureJar = configurations.create("signatureJar") {

--- a/api/all/build.gradle.kts
+++ b/api/all/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry API"
 otelJava.moduleName.set("io.opentelemetry.api")
+otelJava.requireSuppressWarningsExplanation.set(false)
 base.archivesName.set("opentelemetry-api")
 // These packages cannot be compileOnly dependencies (api:incubator depends on api:all, creating a
 // circular dependency; sdk:autoconfigure is in a different module family). Declare them as optional

--- a/api/incubator/build.gradle.kts
+++ b/api/incubator/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry API Incubator"
 otelJava.moduleName.set("io.opentelemetry.api.incubator")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("com.fasterxml.jackson.databind"))
 
 dependencies {

--- a/api/testing-internal/build.gradle.kts
+++ b/api/testing-internal/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OpenTelemetry API Testing (Internal)"
 otelJava.moduleName.set("io.opentelemetry.api.testing.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {

--- a/buildSrc/src/main/kotlin/io/opentelemetry/gradle/OtelJavaExtension.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/gradle/OtelJavaExtension.kt
@@ -41,6 +41,10 @@ abstract class OtelJavaExtension {
 
     abstract val minJavaVersionSupported: Property<JavaVersion>
 
+    // TODO(#7874): Remove this property and enable the check unconditionally once all modules
+    // migrate.
+    abstract val requireSuppressWarningsExplanation: Property<Boolean>
+
     init {
         minJavaVersionSupported.convention(JavaVersion.VERSION_1_8)
         osgiEnabled.convention(true)
@@ -49,5 +53,6 @@ abstract class OtelJavaExtension {
         osgiServiceLoaderProvides.convention(emptyList())
         osgiServiceLoaderRequires.convention(emptyList())
         osgiServiceLoaderProcessor.convention(false)
+        requireSuppressWarningsExplanation.convention(true)
     }
 }

--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -86,9 +86,6 @@ tasks {
         disable("AddNullMarkedToPackageInfo")
         disable("AddNullMarkedToClass")
 
-        // This check causes too many changes to be introduced at once to be manageable.
-        disable("SuppressWarningsWithoutExplanation")
-
         if ((name.contains("Jmh") || name.contains("Test") || project.name.contains("testing-internal")) && !project.name.equals("custom-checks")) {
           // Allow underscore in test-type method names
           disable("MemberName")

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -1,4 +1,6 @@
 import io.opentelemetry.gradle.OtelJavaExtension
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.JavaVersion
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
@@ -62,6 +64,13 @@ val testJavaVersion = gradle.startParameter.projectProperties.get("testJavaVersi
 tasks {
   withType<JavaCompile>().configureEach {
     with(options) {
+      errorprone.check(
+        "SuppressWarningsWithoutExplanation",
+        otelJava.requireSuppressWarningsExplanation.map {
+          if (it) CheckSeverity.ERROR else CheckSeverity.OFF
+        },
+      )
+
       release.set(otelJava.minJavaVersionSupported.map { it.majorVersion.toInt() })
 
       if (name != "jmhCompileGeneratedClasses") {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry API Common"
 otelJava.moduleName.set("io.opentelemetry.common")
+otelJava.requireSuppressWarningsExplanation.set(false)
 // ServiceLoaderComponentLoader (this bundle) is the ServiceLoader.load() call site for all
 // ComponentLoader.forClassLoader() usage; requires the processor extender to weave it.
 otelJava.osgiServiceLoaderProcessor.set(true)

--- a/context/build.gradle.kts
+++ b/context/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry Context (Incubator)"
 otelJava.moduleName.set("io.opentelemetry.context")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   api(project(":common"))

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 }
 
 otelJava.moduleName.set("io.opentelemetry.gradle.customchecks")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 // We cannot use "--release" javac option here because that will forbid exporting com.sun.tools package.
 // We also can't seem to use the toolchain without the "--release" option. So disable everything.

--- a/exporters/common/build.gradle.kts
+++ b/exporters/common/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry Exporter Common"
 otelJava.moduleName.set("io.opentelemetry.exporter.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("com.google.common.io", "io.opentelemetry.api.incubator.config", "io.opentelemetry.sdk.autoconfigure.spi"))
 // sun.misc, io.grpc, and org.jspecify are not OSGi bundles and have no package versioning; must use unversioned optional.
 otelJava.osgiUnversionedOptionalPackages.set(listOf("sun.misc", "io.grpc", "org.jspecify.annotations"))

--- a/exporters/common/compile-stub/build.gradle.kts
+++ b/exporters/common/compile-stub/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 description = "OpenTelemetry Exporter Compile Stub"
 otelJava.moduleName.set("io.opentelemetry.exporter.internal.compile-stub")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)

--- a/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
+++ b/exporters/logging-otlp/src/test/java/io/opentelemetry/exporter/logging/otlp/AbstractOtlpStdoutExporterTest.java
@@ -302,7 +302,7 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
         .isEqualTo(MemoryMode.REUSABLE_DATA);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked") // Each test subclass selects a provider that creates T.
   protected T exporterFromComponentProvider(DeclarativeConfigProperties properties) {
     return (T)
         StreamSupport.stream(
@@ -317,7 +317,7 @@ abstract class AbstractOtlpStdoutExporterTest<T> {
             .create(properties);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked") // Each test subclass selects a provider that creates T.
   protected T exporterFromProvider(ConfigProperties config) {
     Object provider = loadProvider(config);
 

--- a/exporters/logging/build.gradle.kts
+++ b/exporters/logging/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry - Logging Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.logging")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator", "io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",

--- a/exporters/otlp/all/build.gradle.kts
+++ b/exporters/otlp/all/build.gradle.kts
@@ -9,6 +9,7 @@ apply<io.opentelemetry.gradle.OtelVersionClassPlugin>()
 
 description = "OpenTelemetry Protocol (OTLP) Exporters"
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator.config", "io.opentelemetry.sdk.autoconfigure.spi"))
 // io.grpc and org.jspecify.annotations are not OSGi bundles; must use unversioned optional.
 otelJava.osgiUnversionedOptionalPackages.set(listOf("io.grpc", "org.jspecify.annotations"))

--- a/exporters/otlp/common/build.gradle.kts
+++ b/exporters/otlp/common/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 description = "OpenTelemetry Protocol Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.internal.otlp")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 val versions = project.property("versions") as Map<*, *>

--- a/exporters/otlp/profiles/build.gradle.kts
+++ b/exporters/otlp/profiles/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry - Profiles Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.profiles")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 val versions = project.property("versions") as Map<*, *>
 

--- a/exporters/otlp/testing-internal/build.gradle.kts
+++ b/exporters/otlp/testing-internal/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OpenTelemetry Exporter Testing (Internal)"
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.testing.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   api(project(":exporters:otlp:common"))

--- a/exporters/prometheus/build.gradle.kts
+++ b/exporters/prometheus/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 description = "OpenTelemetry Prometheus Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.prometheus")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator", "io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.internal.ConfigurableMetricReaderProvider",

--- a/exporters/sender/grpc-managed-channel/build.gradle.kts
+++ b/exporters/sender/grpc-managed-channel/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry gRPC Upstream Sender"
 otelJava.moduleName.set("io.opentelemetry.exporter.sender.grpc.managedchannel.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.common.export.GrpcSenderProvider",
 ))

--- a/exporters/sender/jdk/build.gradle.kts
+++ b/exporters/sender/jdk/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry JDK HttpSender"
 otelJava.moduleName.set("io.opentelemetry.exporter.sender.jdk.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.minJavaVersionSupported.set(JavaVersion.VERSION_11)
 otelJava.osgiServiceLoaderProvides.set(listOf("io.opentelemetry.sdk.common.export.HttpSenderProvider"))
 

--- a/exporters/sender/okhttp/build.gradle.kts
+++ b/exporters/sender/okhttp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry OkHttp Senders"
 otelJava.moduleName.set("io.opentelemetry.exporter.sender.okhttp.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.common.export.GrpcSenderProvider",
   "io.opentelemetry.sdk.common.export.HttpSenderProvider"

--- a/extensions/kotlin/build.gradle.kts
+++ b/extensions/kotlin/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 description = "OpenTelemetry Kotlin Extensions"
 otelJava.moduleName.set("io.opentelemetry.extension.kotlin")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))

--- a/extensions/trace-propagators/build.gradle.kts
+++ b/extensions/trace-propagators/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry Extension : Trace Propagators"
 otelJava.moduleName.set("io.opentelemetry.extension.trace.propagation")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator", "io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider",

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OpenTelemetry Integration Tests"
 otelJava.moduleName.set("io.opentelemetry.integration.tests")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {

--- a/integration-tests/graal-incubating/build.gradle.kts
+++ b/integration-tests/graal-incubating/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 description = "OpenTelemetry Graal Integration Tests (Incubating)"
 otelJava.moduleName.set("io.opentelemetry.graal.integration.tests.incubating")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 otelJava.minJavaVersionSupported.set(JavaVersion.VERSION_17)
 

--- a/integration-tests/graal/build.gradle.kts
+++ b/integration-tests/graal/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry Graal Integration Tests"
 otelJava.moduleName.set("io.opentelemetry.graal.integration.tests")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 otelJava.minJavaVersionSupported.set(JavaVersion.VERSION_17)
 

--- a/integration-tests/osgi/build.gradle.kts
+++ b/integration-tests/osgi/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry OSGi Integration Tests"
 otelJava.moduleName.set("io.opentelemetry.integration.tests.osgi")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 // For similar test examples see:
 // https://github.com/micrometer-metrics/micrometer/tree/main/micrometer-osgi-test

--- a/integration-tests/otlp/build.gradle.kts
+++ b/integration-tests/otlp/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OTLP Exporter Integration Tests"
 otelJava.moduleName.set("io.opentelemetry.integration.tests.otlp")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {

--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 description = "OpenTelemetry W3C Context Propagation Integration Tests"
 otelJava.moduleName.set("io.opentelemetry.tracecontext.integration.tests")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   implementation(project(":sdk:all"))

--- a/javadoc-crawler/build.gradle.kts
+++ b/javadoc-crawler/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
 description = "OpenTelemetry Javadoc Crawler"
 otelJava.moduleName.set("io.opentelemetry.javadocs")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 otelJava.minJavaVersionSupported.set(JavaVersion.VERSION_17)
 

--- a/opencensus-shim/build.gradle.kts
+++ b/opencensus-shim/build.gradle.kts
@@ -8,6 +8,7 @@ apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry OpenCensus Shim"
 otelJava.moduleName.set("io.opentelemetry.opencensusshim")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   api(project(":api:all"))

--- a/opentelemetry-jfr-profiles-shim/build.gradle.kts
+++ b/opentelemetry-jfr-profiles-shim/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry - JFR to Profiles data conversion example"
 otelJava.moduleName.set("io.opentelemetry.jfr.profiles.shim")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 tasks {
   // this module uses the jdk.jfr.consumer API, which was backported into 1.8 but is '@since 9'

--- a/opentracing-shim/build.gradle.kts
+++ b/opentracing-shim/build.gradle.kts
@@ -8,6 +8,7 @@ apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry OpenTracing Bridge"
 otelJava.moduleName.set("io.opentelemetry.opentracingshim")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   api(project(":api:all"))

--- a/perf-harness/build.gradle.kts
+++ b/perf-harness/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "Performance Testing Harness"
 otelJava.moduleName.set("io.opentelemetry.perf-harness")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {

--- a/sdk-extensions/autoconfigure-spi/build.gradle.kts
+++ b/sdk-extensions/autoconfigure-spi/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 description = "OpenTelemetry SDK Auto-configuration SPI"
 otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure.spi")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 dependencies {

--- a/sdk-extensions/autoconfigure/build.gradle.kts
+++ b/sdk-extensions/autoconfigure/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 description = "OpenTelemetry SDK Auto-configuration"
 otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf(
   "io.opentelemetry.sdk.extension.incubator",
   "io.opentelemetry.api.incubator",

--- a/sdk-extensions/declarative-config/build.gradle.kts
+++ b/sdk-extensions/declarative-config/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 description = "OpenTelemetry SDK Declarative Config"
 otelJava.moduleName.set("io.opentelemetry.sdk.autoconfigure.declarativeconfig")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider",

--- a/sdk-extensions/incubator/build.gradle.kts
+++ b/sdk-extensions/incubator/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 description = "OpenTelemetry SDK Incubator"
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.incubator")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator", "io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider",

--- a/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
+++ b/sdk-extensions/jaeger-remote-sampler/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 description = "OpenTelemetry - Jaeger Remote sampler"
 otelJava.moduleName.set("io.opentelemetry.sdk.extension.trace.jaeger")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.sdk.autoconfigure.declarativeconfig", "io.opentelemetry.sdk.autoconfigure.spi"))
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider",

--- a/sdk/all/build.gradle.kts
+++ b/sdk/all/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry SDK"
 otelJava.moduleName.set("io.opentelemetry.sdk")
+otelJava.requireSuppressWarningsExplanation.set(false)
 base.archivesName.set("opentelemetry-sdk")
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 

--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -10,6 +10,7 @@ apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry SDK Common"
 otelJava.moduleName.set("io.opentelemetry.sdk.common")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 dependencies {

--- a/sdk/logs/build.gradle.kts
+++ b/sdk/logs/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry Log SDK"
 otelJava.moduleName.set("io.opentelemetry.sdk.logs")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 dependencies {

--- a/sdk/metrics/build.gradle.kts
+++ b/sdk/metrics/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 description = "OpenTelemetry SDK Metrics"
 otelJava.moduleName.set("io.opentelemetry.sdk.metrics")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 dependencies {

--- a/sdk/profiles/build.gradle.kts
+++ b/sdk/profiles/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 description = "OpenTelemetry - Profiles SDK"
 otelJava.moduleName.set("sdk.profiles")
+otelJava.requireSuppressWarningsExplanation.set(false)
 
 dependencies {
   api(project(":sdk:common"))

--- a/sdk/testing/build.gradle.kts
+++ b/sdk/testing/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 description = "OpenTelemetry SDK Testing utilities"
 otelJava.moduleName.set("io.opentelemetry.sdk.testing")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiServiceLoaderProvides.set(listOf(
   "io.opentelemetry.context.ContextStorageProvider",
 ))

--- a/sdk/trace-shaded-deps/build.gradle.kts
+++ b/sdk/trace-shaded-deps/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "Internal use only - shaded dependencies of OpenTelemetry SDK for Tracing"
 otelJava.moduleName.set("io.opentelemetry.sdk.trace.internal")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {

--- a/sdk/trace/build.gradle.kts
+++ b/sdk/trace/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 description = "OpenTelemetry SDK For Tracing"
 otelJava.moduleName.set("io.opentelemetry.sdk.trace")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 sourceSets {

--- a/testing-internal/build.gradle.kts
+++ b/testing-internal/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 description = "OpenTelemetry Testing (Internal)"
 otelJava.moduleName.set("io.opentelemetry.internal.testing")
+otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiEnabled.set(false)
 
 dependencies {


### PR DESCRIPTION
This adds a module setting for `SuppressWarningsWithoutExplanation` and turns it on for the logging OTLP exporter. The setting lets other modules adopt the check once their existing suppressions are explained.

Related to #7874.

Tested with `./gradlew :exporters:logging-otlp:check`.