### PR TITLE
Change declarative config pojos from with<Prop> to set<Prop>

### DIFF
--- a/api/incubator/src/testConvertToModel/java/io/opentelemetry/api/incubator/InstrumentationConfigUtilTest.java
+++ b/api/incubator/src/testConvertToModel/java/io/opentelemetry/api/incubator/InstrumentationConfigUtilTest.java
@@ -90,16 +90,16 @@ class InstrumentationConfigUtilTest {
         withInstrumentationConfig(
             "my_instrumentation_library",
             new ExperimentalLanguageSpecificInstrumentationPropertyModel()
-                .withAdditionalProperty("string_property", "value")
-                .withAdditionalProperty("boolean_property", true)
-                .withAdditionalProperty("long_property", 1L)
-                .withAdditionalProperty("double_property", 1.1d)
-                .withAdditionalProperty("string_list_property", Arrays.asList("val1", "val2"))
-                .withAdditionalProperty("boolean_list_property", Arrays.asList(true, false))
-                .withAdditionalProperty("long_list_property", Arrays.asList(1L, 2L))
-                .withAdditionalProperty("double_list_property", Arrays.asList(1.1d, 2.2d))
-                .withAdditionalProperty("map_property", Collections.singletonMap("childKey", "val"))
-                .withAdditionalProperty(
+                .setAdditionalProperty("string_property", "value")
+                .setAdditionalProperty("boolean_property", true)
+                .setAdditionalProperty("long_property", 1L)
+                .setAdditionalProperty("double_property", 1.1d)
+                .setAdditionalProperty("string_list_property", Arrays.asList("val1", "val2"))
+                .setAdditionalProperty("boolean_list_property", Arrays.asList(true, false))
+                .setAdditionalProperty("long_list_property", Arrays.asList(1L, 2L))
+                .setAdditionalProperty("double_list_property", Arrays.asList(1.1d, 2.2d))
+                .setAdditionalProperty("map_property", Collections.singletonMap("childKey", "val"))
+                .setAdditionalProperty(
                     "structured_list_property",
                     Collections.singletonList(
                         ImmutableMap.of("key", "the_key", "value", "the_value"))));
@@ -130,12 +130,12 @@ class InstrumentationConfigUtilTest {
       ExperimentalLanguageSpecificInstrumentationPropertyModel instrumentationConfig) {
     ExperimentalLanguageSpecificInstrumentationModel javaConfig =
         new ExperimentalLanguageSpecificInstrumentationModel();
-    javaConfig.withAdditionalProperty(instrumentationName, instrumentationConfig);
+    javaConfig.setAdditionalProperty(instrumentationName, instrumentationConfig);
     DeclarativeConfigProperties modelProperties =
         DeclarativeConfiguration.toConfigProperties(
-            OpenTelemetryConfigurationModelAccessor.withInstrumentation(
+            OpenTelemetryConfigurationModelAccessor.setInstrumentation(
                 new OpenTelemetryConfigurationModel(),
-                new ExperimentalInstrumentationModel().withJava(javaConfig)));
+                new ExperimentalInstrumentationModel().setJava(javaConfig)));
 
     return SdkConfigProvider.create(modelProperties);
   }

--- a/buildSrc/src/main/kotlin/io/opentelemetry/gradle/DeclarativeConfigPojoGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/gradle/DeclarativeConfigPojoGenerator.kt
@@ -100,7 +100,7 @@ class DeclarativeConfigPojoGenerator(
 
   /**
    * The base name used to build getter/builder names. Strips the leading underscore from
-   * "_default" so the methods are "getDefault"/"withDefault", not "get_default".
+   * "_default" so the methods are "getDefault"/"setDefault", not "get_default".
    */
   private fun baseNameFor(jsonKey: String): String {
     val field = fieldName(jsonKey)
@@ -111,7 +111,7 @@ class DeclarativeConfigPojoGenerator(
     "get${baseNameFor(jsonKey).replaceFirstChar { it.uppercase() }}"
 
   private fun builderName(jsonKey: String) =
-    "with${baseNameFor(jsonKey).replaceFirstChar { it.uppercase() }}"
+    "set${baseNameFor(jsonKey).replaceFirstChar { it.uppercase() }}"
 
   // ── Type resolution ──────────────────────────────────────────────────────────
 
@@ -465,7 +465,7 @@ class DeclarativeConfigPojoGenerator(
       append("  @JsonAnyGetter\n")
       append("  public $additionalPropsType getAdditionalProperties() {\n    return this.additionalProperties;\n  }\n\n")
       append("  @JsonAnySetter\n")
-      append("  public $className withAdditionalProperty(String name, $apValueType value) {\n")
+      append("  public $className setAdditionalProperty(String name, $apValueType value) {\n")
       append("    this.additionalProperties.put(name, value);\n    return this;\n  }\n\n")
     }
 
@@ -479,7 +479,7 @@ class DeclarativeConfigPojoGenerator(
       }
       append("  }\n\n")
       append("  @JsonAnySetter\n")
-      append("  public $className withExtensionProperty(String name, @Nullable Object value) {\n")
+      append("  public $className setExtensionProperty(String name, @Nullable Object value) {\n")
       append("    ExtensionPropertyUtil.handleAnySetter(\n")
       val experimentalPropsArg = if (expProps.isNotEmpty()) "EXPERIMENTAL_PROPERTIES" else "Collections.emptyMap()"
       val stablePropsArg = if (stableObjectProps.isNotEmpty()) "STABLE_PROPERTIES" else "Collections.emptyMap()"
@@ -591,7 +591,7 @@ class DeclarativeConfigPojoGenerator(
       append("  public static $stableClassName ${p.builder}(\n")
       append("      $stableClassName model, ${p.typeExpr} value) {\n")
       append("    requireNonNull(value, \"value\");\n")
-      append("    model.withExtensionProperty(${p.constName}, value);\n")
+      append("    model.setExtensionProperty(${p.constName}, value);\n")
       append("    return model;\n")
       append("  }\n\n")
     }
@@ -618,7 +618,7 @@ class DeclarativeConfigPojoGenerator(
     append("  @JsonAnyGetter\n")
     append("  public Map<String, Object> getAdditionalProperties() {\n    return this.additionalProperties;\n  }\n\n")
     append("  @JsonAnySetter\n")
-    append("  public $className withAdditionalProperty(String name, Object value) {\n")
+    append("  public $className setAdditionalProperty(String name, Object value) {\n")
     append("    this.additionalProperties.put(name, value);\n    return this;\n  }\n\n")
     appendToString(className, listOf("additionalProperties"))
     append("\n")

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AggregationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AggregationModel.java
@@ -86,7 +86,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(DEFAULT)
-  public AggregationModel withDefault(DefaultAggregationModel _default) {
+  public AggregationModel setDefault(DefaultAggregationModel _default) {
     this._default = _default;
     return this;
   }
@@ -109,7 +109,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(DROP)
-  public AggregationModel withDrop(DropAggregationModel drop) {
+  public AggregationModel setDrop(DropAggregationModel drop) {
     this.drop = drop;
     return this;
   }
@@ -135,7 +135,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(EXPLICIT_BUCKET_HISTOGRAM)
-  public AggregationModel withExplicitBucketHistogram(
+  public AggregationModel setExplicitBucketHistogram(
       ExplicitBucketHistogramAggregationModel explicitBucketHistogram) {
     this.explicitBucketHistogram = explicitBucketHistogram;
     return this;
@@ -163,7 +163,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(BASE_2_EXPONENTIAL_BUCKET_HISTOGRAM)
-  public AggregationModel withBase2ExponentialBucketHistogram(
+  public AggregationModel setBase2ExponentialBucketHistogram(
       Base2ExponentialBucketHistogramAggregationModel base2ExponentialBucketHistogram) {
     this.base2ExponentialBucketHistogram = base2ExponentialBucketHistogram;
     return this;
@@ -187,7 +187,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(LAST_VALUE)
-  public AggregationModel withLastValue(LastValueAggregationModel lastValue) {
+  public AggregationModel setLastValue(LastValueAggregationModel lastValue) {
     this.lastValue = lastValue;
     return this;
   }
@@ -210,7 +210,7 @@ public class AggregationModel {
   }
 
   @JsonProperty(SUM)
-  public AggregationModel withSum(SumAggregationModel sum) {
+  public AggregationModel setSum(SumAggregationModel sum) {
     this.sum = sum;
     return this;
   }
@@ -221,7 +221,7 @@ public class AggregationModel {
   }
 
   @JsonAnySetter
-  public AggregationModel withExtensionProperty(String name, @Nullable Object value) {
+  public AggregationModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeLimitsModel.java
@@ -61,7 +61,7 @@ public class AttributeLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
-  public AttributeLimitsModel withAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
+  public AttributeLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
     return this;
   }
@@ -84,7 +84,7 @@ public class AttributeLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_COUNT_LIMIT)
-  public AttributeLimitsModel withAttributeCountLimit(Integer attributeCountLimit) {
+  public AttributeLimitsModel setAttributeCountLimit(Integer attributeCountLimit) {
     this.attributeCountLimit = attributeCountLimit;
     return this;
   }
@@ -95,7 +95,7 @@ public class AttributeLimitsModel {
   }
 
   @JsonAnySetter
-  public AttributeLimitsModel withExtensionProperty(String name, @Nullable Object value) {
+  public AttributeLimitsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeNameValueModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeNameValueModel.java
@@ -62,7 +62,7 @@ public class AttributeNameValueModel {
   }
 
   @JsonProperty(NAME)
-  public AttributeNameValueModel withName(String name) {
+  public AttributeNameValueModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -84,7 +84,7 @@ public class AttributeNameValueModel {
   }
 
   @JsonProperty(VALUE)
-  public AttributeNameValueModel withValue(Object value) {
+  public AttributeNameValueModel setValue(Object value) {
     this.value = value;
     return this;
   }
@@ -123,7 +123,7 @@ public class AttributeNameValueModel {
   }
 
   @JsonProperty(TYPE)
-  public AttributeNameValueModel withType(AttributeTypeModel type) {
+  public AttributeNameValueModel setType(AttributeTypeModel type) {
     this.type = type;
     return this;
   }
@@ -134,7 +134,7 @@ public class AttributeNameValueModel {
   }
 
   @JsonAnySetter
-  public AttributeNameValueModel withExtensionProperty(String name, @Nullable Object value) {
+  public AttributeNameValueModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/Base2ExponentialBucketHistogramAggregationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/Base2ExponentialBucketHistogramAggregationModel.java
@@ -62,7 +62,7 @@ public class Base2ExponentialBucketHistogramAggregationModel {
   }
 
   @JsonProperty(MAX_SCALE)
-  public Base2ExponentialBucketHistogramAggregationModel withMaxScale(Integer maxScale) {
+  public Base2ExponentialBucketHistogramAggregationModel setMaxScale(Integer maxScale) {
     this.maxScale = maxScale;
     return this;
   }
@@ -83,7 +83,7 @@ public class Base2ExponentialBucketHistogramAggregationModel {
   }
 
   @JsonProperty(MAX_SIZE)
-  public Base2ExponentialBucketHistogramAggregationModel withMaxSize(Integer maxSize) {
+  public Base2ExponentialBucketHistogramAggregationModel setMaxSize(Integer maxSize) {
     this.maxSize = maxSize;
     return this;
   }
@@ -103,7 +103,7 @@ public class Base2ExponentialBucketHistogramAggregationModel {
   }
 
   @JsonProperty(RECORD_MIN_MAX)
-  public Base2ExponentialBucketHistogramAggregationModel withRecordMinMax(Boolean recordMinMax) {
+  public Base2ExponentialBucketHistogramAggregationModel setRecordMinMax(Boolean recordMinMax) {
     this.recordMinMax = recordMinMax;
     return this;
   }
@@ -114,7 +114,7 @@ public class Base2ExponentialBucketHistogramAggregationModel {
   }
 
   @JsonAnySetter
-  public Base2ExponentialBucketHistogramAggregationModel withExtensionProperty(
+  public Base2ExponentialBucketHistogramAggregationModel setExtensionProperty(
       String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/BatchLogRecordProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/BatchLogRecordProcessorModel.java
@@ -78,7 +78,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonProperty(SCHEDULE_DELAY)
-  public BatchLogRecordProcessorModel withScheduleDelay(Integer scheduleDelay) {
+  public BatchLogRecordProcessorModel setScheduleDelay(Integer scheduleDelay) {
     this.scheduleDelay = scheduleDelay;
     return this;
   }
@@ -100,7 +100,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonProperty(EXPORT_TIMEOUT)
-  public BatchLogRecordProcessorModel withExportTimeout(Integer exportTimeout) {
+  public BatchLogRecordProcessorModel setExportTimeout(Integer exportTimeout) {
     this.exportTimeout = exportTimeout;
     return this;
   }
@@ -120,7 +120,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonProperty(MAX_QUEUE_SIZE)
-  public BatchLogRecordProcessorModel withMaxQueueSize(Integer maxQueueSize) {
+  public BatchLogRecordProcessorModel setMaxQueueSize(Integer maxQueueSize) {
     this.maxQueueSize = maxQueueSize;
     return this;
   }
@@ -141,7 +141,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonProperty(MAX_EXPORT_BATCH_SIZE)
-  public BatchLogRecordProcessorModel withMaxExportBatchSize(Integer maxExportBatchSize) {
+  public BatchLogRecordProcessorModel setMaxExportBatchSize(Integer maxExportBatchSize) {
     this.maxExportBatchSize = maxExportBatchSize;
     return this;
   }
@@ -162,7 +162,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonProperty(EXPORTER)
-  public BatchLogRecordProcessorModel withExporter(LogRecordExporterModel exporter) {
+  public BatchLogRecordProcessorModel setExporter(LogRecordExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -173,7 +173,7 @@ public class BatchLogRecordProcessorModel {
   }
 
   @JsonAnySetter
-  public BatchLogRecordProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public BatchLogRecordProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/BatchSpanProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/BatchSpanProcessorModel.java
@@ -78,7 +78,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonProperty(SCHEDULE_DELAY)
-  public BatchSpanProcessorModel withScheduleDelay(Integer scheduleDelay) {
+  public BatchSpanProcessorModel setScheduleDelay(Integer scheduleDelay) {
     this.scheduleDelay = scheduleDelay;
     return this;
   }
@@ -100,7 +100,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonProperty(EXPORT_TIMEOUT)
-  public BatchSpanProcessorModel withExportTimeout(Integer exportTimeout) {
+  public BatchSpanProcessorModel setExportTimeout(Integer exportTimeout) {
     this.exportTimeout = exportTimeout;
     return this;
   }
@@ -120,7 +120,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonProperty(MAX_QUEUE_SIZE)
-  public BatchSpanProcessorModel withMaxQueueSize(Integer maxQueueSize) {
+  public BatchSpanProcessorModel setMaxQueueSize(Integer maxQueueSize) {
     this.maxQueueSize = maxQueueSize;
     return this;
   }
@@ -141,7 +141,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonProperty(MAX_EXPORT_BATCH_SIZE)
-  public BatchSpanProcessorModel withMaxExportBatchSize(Integer maxExportBatchSize) {
+  public BatchSpanProcessorModel setMaxExportBatchSize(Integer maxExportBatchSize) {
     this.maxExportBatchSize = maxExportBatchSize;
     return this;
   }
@@ -162,7 +162,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonProperty(EXPORTER)
-  public BatchSpanProcessorModel withExporter(SpanExporterModel exporter) {
+  public BatchSpanProcessorModel setExporter(SpanExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -173,7 +173,7 @@ public class BatchSpanProcessorModel {
   }
 
   @JsonAnySetter
-  public BatchSpanProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public BatchSpanProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/CardinalityLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/CardinalityLimitsModel.java
@@ -93,7 +93,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(DEFAULT)
-  public CardinalityLimitsModel withDefault(Integer _default) {
+  public CardinalityLimitsModel setDefault(Integer _default) {
     this._default = _default;
     return this;
   }
@@ -113,7 +113,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(COUNTER)
-  public CardinalityLimitsModel withCounter(Integer counter) {
+  public CardinalityLimitsModel setCounter(Integer counter) {
     this.counter = counter;
     return this;
   }
@@ -133,7 +133,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(GAUGE)
-  public CardinalityLimitsModel withGauge(Integer gauge) {
+  public CardinalityLimitsModel setGauge(Integer gauge) {
     this.gauge = gauge;
     return this;
   }
@@ -153,7 +153,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(HISTOGRAM)
-  public CardinalityLimitsModel withHistogram(Integer histogram) {
+  public CardinalityLimitsModel setHistogram(Integer histogram) {
     this.histogram = histogram;
     return this;
   }
@@ -174,7 +174,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(OBSERVABLE_COUNTER)
-  public CardinalityLimitsModel withObservableCounter(Integer observableCounter) {
+  public CardinalityLimitsModel setObservableCounter(Integer observableCounter) {
     this.observableCounter = observableCounter;
     return this;
   }
@@ -195,7 +195,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(OBSERVABLE_GAUGE)
-  public CardinalityLimitsModel withObservableGauge(Integer observableGauge) {
+  public CardinalityLimitsModel setObservableGauge(Integer observableGauge) {
     this.observableGauge = observableGauge;
     return this;
   }
@@ -216,7 +216,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(OBSERVABLE_UP_DOWN_COUNTER)
-  public CardinalityLimitsModel withObservableUpDownCounter(Integer observableUpDownCounter) {
+  public CardinalityLimitsModel setObservableUpDownCounter(Integer observableUpDownCounter) {
     this.observableUpDownCounter = observableUpDownCounter;
     return this;
   }
@@ -237,7 +237,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonProperty(UP_DOWN_COUNTER)
-  public CardinalityLimitsModel withUpDownCounter(Integer upDownCounter) {
+  public CardinalityLimitsModel setUpDownCounter(Integer upDownCounter) {
     this.upDownCounter = upDownCounter;
     return this;
   }
@@ -248,7 +248,7 @@ public class CardinalityLimitsModel {
   }
 
   @JsonAnySetter
-  public CardinalityLimitsModel withExtensionProperty(String name, @Nullable Object value) {
+  public CardinalityLimitsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ConsoleMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ConsoleMetricExporterModel.java
@@ -70,7 +70,7 @@ public class ConsoleMetricExporterModel {
   }
 
   @JsonProperty(TEMPORALITY_PREFERENCE)
-  public ConsoleMetricExporterModel withTemporalityPreference(
+  public ConsoleMetricExporterModel setTemporalityPreference(
       ExporterTemporalityPreferenceModel temporalityPreference) {
     this.temporalityPreference = temporalityPreference;
     return this;
@@ -102,7 +102,7 @@ public class ConsoleMetricExporterModel {
   }
 
   @JsonProperty(DEFAULT_HISTOGRAM_AGGREGATION)
-  public ConsoleMetricExporterModel withDefaultHistogramAggregation(
+  public ConsoleMetricExporterModel setDefaultHistogramAggregation(
       ExporterDefaultHistogramAggregationModel defaultHistogramAggregation) {
     this.defaultHistogramAggregation = defaultHistogramAggregation;
     return this;
@@ -114,7 +114,7 @@ public class ConsoleMetricExporterModel {
   }
 
   @JsonAnySetter
-  public ConsoleMetricExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public ConsoleMetricExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/DistributionModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/DistributionModel.java
@@ -31,7 +31,7 @@ public class DistributionModel {
   }
 
   @JsonAnySetter
-  public DistributionModel withExtensionProperty(String name, @Nullable Object value) {
+  public DistributionModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ExplicitBucketHistogramAggregationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ExplicitBucketHistogramAggregationModel.java
@@ -56,7 +56,7 @@ public class ExplicitBucketHistogramAggregationModel {
   }
 
   @JsonProperty(BOUNDARIES)
-  public ExplicitBucketHistogramAggregationModel withBoundaries(List<Double> boundaries) {
+  public ExplicitBucketHistogramAggregationModel setBoundaries(List<Double> boundaries) {
     this.boundaries = boundaries;
     return this;
   }
@@ -76,7 +76,7 @@ public class ExplicitBucketHistogramAggregationModel {
   }
 
   @JsonProperty(RECORD_MIN_MAX)
-  public ExplicitBucketHistogramAggregationModel withRecordMinMax(Boolean recordMinMax) {
+  public ExplicitBucketHistogramAggregationModel setRecordMinMax(Boolean recordMinMax) {
     this.recordMinMax = recordMinMax;
     return this;
   }
@@ -87,7 +87,7 @@ public class ExplicitBucketHistogramAggregationModel {
   }
 
   @JsonAnySetter
-  public ExplicitBucketHistogramAggregationModel withExtensionProperty(
+  public ExplicitBucketHistogramAggregationModel setExtensionProperty(
       String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/GrpcTlsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/GrpcTlsModel.java
@@ -68,7 +68,7 @@ public class GrpcTlsModel {
   }
 
   @JsonProperty(CA_FILE)
-  public GrpcTlsModel withCaFile(String caFile) {
+  public GrpcTlsModel setCaFile(String caFile) {
     this.caFile = caFile;
     return this;
   }
@@ -91,7 +91,7 @@ public class GrpcTlsModel {
   }
 
   @JsonProperty(KEY_FILE)
-  public GrpcTlsModel withKeyFile(String keyFile) {
+  public GrpcTlsModel setKeyFile(String keyFile) {
     this.keyFile = keyFile;
     return this;
   }
@@ -114,7 +114,7 @@ public class GrpcTlsModel {
   }
 
   @JsonProperty(CERT_FILE)
-  public GrpcTlsModel withCertFile(String certFile) {
+  public GrpcTlsModel setCertFile(String certFile) {
     this.certFile = certFile;
     return this;
   }
@@ -137,7 +137,7 @@ public class GrpcTlsModel {
   }
 
   @JsonProperty(INSECURE)
-  public GrpcTlsModel withInsecure(Boolean insecure) {
+  public GrpcTlsModel setInsecure(Boolean insecure) {
     this.insecure = insecure;
     return this;
   }
@@ -148,7 +148,7 @@ public class GrpcTlsModel {
   }
 
   @JsonAnySetter
-  public GrpcTlsModel withExtensionProperty(String name, @Nullable Object value) {
+  public GrpcTlsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/HttpTlsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/HttpTlsModel.java
@@ -64,7 +64,7 @@ public class HttpTlsModel {
   }
 
   @JsonProperty(CA_FILE)
-  public HttpTlsModel withCaFile(String caFile) {
+  public HttpTlsModel setCaFile(String caFile) {
     this.caFile = caFile;
     return this;
   }
@@ -87,7 +87,7 @@ public class HttpTlsModel {
   }
 
   @JsonProperty(KEY_FILE)
-  public HttpTlsModel withKeyFile(String keyFile) {
+  public HttpTlsModel setKeyFile(String keyFile) {
     this.keyFile = keyFile;
     return this;
   }
@@ -110,7 +110,7 @@ public class HttpTlsModel {
   }
 
   @JsonProperty(CERT_FILE)
-  public HttpTlsModel withCertFile(String certFile) {
+  public HttpTlsModel setCertFile(String certFile) {
     this.certFile = certFile;
     return this;
   }
@@ -121,7 +121,7 @@ public class HttpTlsModel {
   }
 
   @JsonAnySetter
-  public HttpTlsModel withExtensionProperty(String name, @Nullable Object value) {
+  public HttpTlsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/IdGeneratorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/IdGeneratorModel.java
@@ -55,7 +55,7 @@ public class IdGeneratorModel {
   }
 
   @JsonProperty(RANDOM)
-  public IdGeneratorModel withRandom(RandomIdGeneratorModel random) {
+  public IdGeneratorModel setRandom(RandomIdGeneratorModel random) {
     this.random = random;
     return this;
   }
@@ -66,7 +66,7 @@ public class IdGeneratorModel {
   }
 
   @JsonAnySetter
-  public IdGeneratorModel withExtensionProperty(String name, @Nullable Object value) {
+  public IdGeneratorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/IncludeExcludeModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/IncludeExcludeModel.java
@@ -45,7 +45,7 @@ public class IncludeExcludeModel {
   }
 
   @JsonProperty(INCLUDED)
-  public IncludeExcludeModel withIncluded(List<String> included) {
+  public IncludeExcludeModel setIncluded(List<String> included) {
     this.included = included;
     return this;
   }
@@ -70,7 +70,7 @@ public class IncludeExcludeModel {
   }
 
   @JsonProperty(EXCLUDED)
-  public IncludeExcludeModel withExcluded(List<String> excluded) {
+  public IncludeExcludeModel setExcluded(List<String> excluded) {
     this.excluded = excluded;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordExporterModel.java
@@ -63,7 +63,7 @@ public class LogRecordExporterModel {
   }
 
   @JsonProperty(OTLP_HTTP)
-  public LogRecordExporterModel withOtlpHttp(OtlpHttpExporterModel otlpHttp) {
+  public LogRecordExporterModel setOtlpHttp(OtlpHttpExporterModel otlpHttp) {
     this.otlpHttp = otlpHttp;
     return this;
   }
@@ -84,7 +84,7 @@ public class LogRecordExporterModel {
   }
 
   @JsonProperty(OTLP_GRPC)
-  public LogRecordExporterModel withOtlpGrpc(OtlpGrpcExporterModel otlpGrpc) {
+  public LogRecordExporterModel setOtlpGrpc(OtlpGrpcExporterModel otlpGrpc) {
     this.otlpGrpc = otlpGrpc;
     return this;
   }
@@ -105,7 +105,7 @@ public class LogRecordExporterModel {
   }
 
   @JsonProperty(CONSOLE)
-  public LogRecordExporterModel withConsole(ConsoleExporterModel console) {
+  public LogRecordExporterModel setConsole(ConsoleExporterModel console) {
     this.console = console;
     return this;
   }
@@ -116,7 +116,7 @@ public class LogRecordExporterModel {
   }
 
   @JsonAnySetter
-  public LogRecordExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public LogRecordExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordLimitsModel.java
@@ -61,7 +61,7 @@ public class LogRecordLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
-  public LogRecordLimitsModel withAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
+  public LogRecordLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
     return this;
   }
@@ -84,7 +84,7 @@ public class LogRecordLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_COUNT_LIMIT)
-  public LogRecordLimitsModel withAttributeCountLimit(Integer attributeCountLimit) {
+  public LogRecordLimitsModel setAttributeCountLimit(Integer attributeCountLimit) {
     this.attributeCountLimit = attributeCountLimit;
     return this;
   }
@@ -95,7 +95,7 @@ public class LogRecordLimitsModel {
   }
 
   @JsonAnySetter
-  public LogRecordLimitsModel withExtensionProperty(String name, @Nullable Object value) {
+  public LogRecordLimitsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordProcessorModel.java
@@ -59,7 +59,7 @@ public class LogRecordProcessorModel {
   }
 
   @JsonProperty(BATCH)
-  public LogRecordProcessorModel withBatch(BatchLogRecordProcessorModel batch) {
+  public LogRecordProcessorModel setBatch(BatchLogRecordProcessorModel batch) {
     this.batch = batch;
     return this;
   }
@@ -80,7 +80,7 @@ public class LogRecordProcessorModel {
   }
 
   @JsonProperty(SIMPLE)
-  public LogRecordProcessorModel withSimple(SimpleLogRecordProcessorModel simple) {
+  public LogRecordProcessorModel setSimple(SimpleLogRecordProcessorModel simple) {
     this.simple = simple;
     return this;
   }
@@ -91,7 +91,7 @@ public class LogRecordProcessorModel {
   }
 
   @JsonAnySetter
-  public LogRecordProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public LogRecordProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LoggerProviderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LoggerProviderModel.java
@@ -55,7 +55,7 @@ public class LoggerProviderModel {
   }
 
   @JsonProperty(PROCESSORS)
-  public LoggerProviderModel withProcessors(List<LogRecordProcessorModel> processors) {
+  public LoggerProviderModel setProcessors(List<LogRecordProcessorModel> processors) {
     this.processors = processors;
     return this;
   }
@@ -76,7 +76,7 @@ public class LoggerProviderModel {
   }
 
   @JsonProperty(LIMITS)
-  public LoggerProviderModel withLimits(LogRecordLimitsModel limits) {
+  public LoggerProviderModel setLimits(LogRecordLimitsModel limits) {
     this.limits = limits;
     return this;
   }
@@ -87,7 +87,7 @@ public class LoggerProviderModel {
   }
 
   @JsonAnySetter
-  public LoggerProviderModel withExtensionProperty(String name, @Nullable Object value) {
+  public LoggerProviderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MeterProviderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MeterProviderModel.java
@@ -58,7 +58,7 @@ public class MeterProviderModel {
   }
 
   @JsonProperty(READERS)
-  public MeterProviderModel withReaders(List<MetricReaderModel> readers) {
+  public MeterProviderModel setReaders(List<MetricReaderModel> readers) {
     this.readers = readers;
     return this;
   }
@@ -78,7 +78,7 @@ public class MeterProviderModel {
   }
 
   @JsonProperty(VIEWS)
-  public MeterProviderModel withViews(List<ViewModel> views) {
+  public MeterProviderModel setViews(List<ViewModel> views) {
     this.views = views;
     return this;
   }
@@ -108,7 +108,7 @@ public class MeterProviderModel {
   }
 
   @JsonProperty(EXEMPLAR_FILTER)
-  public MeterProviderModel withExemplarFilter(ExemplarFilterModel exemplarFilter) {
+  public MeterProviderModel setExemplarFilter(ExemplarFilterModel exemplarFilter) {
     this.exemplarFilter = exemplarFilter;
     return this;
   }
@@ -119,7 +119,7 @@ public class MeterProviderModel {
   }
 
   @JsonAnySetter
-  public MeterProviderModel withExtensionProperty(String name, @Nullable Object value) {
+  public MeterProviderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MetricProducerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MetricProducerModel.java
@@ -55,7 +55,7 @@ public class MetricProducerModel {
   }
 
   @JsonProperty(OPENCENSUS)
-  public MetricProducerModel withOpencensus(OpenCensusMetricProducerModel opencensus) {
+  public MetricProducerModel setOpencensus(OpenCensusMetricProducerModel opencensus) {
     this.opencensus = opencensus;
     return this;
   }
@@ -66,7 +66,7 @@ public class MetricProducerModel {
   }
 
   @JsonAnySetter
-  public MetricProducerModel withExtensionProperty(String name, @Nullable Object value) {
+  public MetricProducerModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MetricReaderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/MetricReaderModel.java
@@ -59,7 +59,7 @@ public class MetricReaderModel {
   }
 
   @JsonProperty(PERIODIC)
-  public MetricReaderModel withPeriodic(PeriodicMetricReaderModel periodic) {
+  public MetricReaderModel setPeriodic(PeriodicMetricReaderModel periodic) {
     this.periodic = periodic;
     return this;
   }
@@ -80,7 +80,7 @@ public class MetricReaderModel {
   }
 
   @JsonProperty(PULL)
-  public MetricReaderModel withPull(PullMetricReaderModel pull) {
+  public MetricReaderModel setPull(PullMetricReaderModel pull) {
     this.pull = pull;
     return this;
   }
@@ -91,7 +91,7 @@ public class MetricReaderModel {
   }
 
   @JsonAnySetter
-  public MetricReaderModel withExtensionProperty(String name, @Nullable Object value) {
+  public MetricReaderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/NameStringValuePairModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/NameStringValuePairModel.java
@@ -58,7 +58,7 @@ public class NameStringValuePairModel {
   }
 
   @JsonProperty(NAME)
-  public NameStringValuePairModel withName(String name) {
+  public NameStringValuePairModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -78,7 +78,7 @@ public class NameStringValuePairModel {
   }
 
   @JsonProperty(VALUE)
-  public NameStringValuePairModel withValue(String value) {
+  public NameStringValuePairModel setValue(String value) {
     this.value = value;
     return this;
   }
@@ -89,7 +89,7 @@ public class NameStringValuePairModel {
   }
 
   @JsonAnySetter
-  public NameStringValuePairModel withExtensionProperty(String name, @Nullable Object value) {
+  public NameStringValuePairModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OpenTelemetryConfigurationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OpenTelemetryConfigurationModel.java
@@ -110,7 +110,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(FILE_FORMAT)
-  public OpenTelemetryConfigurationModel withFileFormat(String fileFormat) {
+  public OpenTelemetryConfigurationModel setFileFormat(String fileFormat) {
     this.fileFormat = fileFormat;
     return this;
   }
@@ -130,7 +130,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(DISABLED)
-  public OpenTelemetryConfigurationModel withDisabled(Boolean disabled) {
+  public OpenTelemetryConfigurationModel setDisabled(Boolean disabled) {
     this.disabled = disabled;
     return this;
   }
@@ -201,7 +201,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(LOG_LEVEL)
-  public OpenTelemetryConfigurationModel withLogLevel(SeverityNumberModel logLevel) {
+  public OpenTelemetryConfigurationModel setLogLevel(SeverityNumberModel logLevel) {
     this.logLevel = logLevel;
     return this;
   }
@@ -222,7 +222,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(ATTRIBUTE_LIMITS)
-  public OpenTelemetryConfigurationModel withAttributeLimits(AttributeLimitsModel attributeLimits) {
+  public OpenTelemetryConfigurationModel setAttributeLimits(AttributeLimitsModel attributeLimits) {
     this.attributeLimits = attributeLimits;
     return this;
   }
@@ -243,7 +243,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(LOGGER_PROVIDER)
-  public OpenTelemetryConfigurationModel withLoggerProvider(LoggerProviderModel loggerProvider) {
+  public OpenTelemetryConfigurationModel setLoggerProvider(LoggerProviderModel loggerProvider) {
     this.loggerProvider = loggerProvider;
     return this;
   }
@@ -264,7 +264,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(METER_PROVIDER)
-  public OpenTelemetryConfigurationModel withMeterProvider(MeterProviderModel meterProvider) {
+  public OpenTelemetryConfigurationModel setMeterProvider(MeterProviderModel meterProvider) {
     this.meterProvider = meterProvider;
     return this;
   }
@@ -285,7 +285,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(PROPAGATOR)
-  public OpenTelemetryConfigurationModel withPropagator(PropagatorModel propagator) {
+  public OpenTelemetryConfigurationModel setPropagator(PropagatorModel propagator) {
     this.propagator = propagator;
     return this;
   }
@@ -306,7 +306,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(TRACER_PROVIDER)
-  public OpenTelemetryConfigurationModel withTracerProvider(TracerProviderModel tracerProvider) {
+  public OpenTelemetryConfigurationModel setTracerProvider(TracerProviderModel tracerProvider) {
     this.tracerProvider = tracerProvider;
     return this;
   }
@@ -326,7 +326,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(RESOURCE)
-  public OpenTelemetryConfigurationModel withResource(ResourceModel resource) {
+  public OpenTelemetryConfigurationModel setResource(ResourceModel resource) {
     this.resource = resource;
     return this;
   }
@@ -353,7 +353,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonProperty(DISTRIBUTION)
-  public OpenTelemetryConfigurationModel withDistribution(DistributionModel distribution) {
+  public OpenTelemetryConfigurationModel setDistribution(DistributionModel distribution) {
     this.distribution = distribution;
     return this;
   }
@@ -364,8 +364,7 @@ public class OpenTelemetryConfigurationModel {
   }
 
   @JsonAnySetter
-  public OpenTelemetryConfigurationModel withExtensionProperty(
-      String name, @Nullable Object value) {
+  public OpenTelemetryConfigurationModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcExporterModel.java
@@ -74,7 +74,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(ENDPOINT)
-  public OtlpGrpcExporterModel withEndpoint(String endpoint) {
+  public OtlpGrpcExporterModel setEndpoint(String endpoint) {
     this.endpoint = endpoint;
     return this;
   }
@@ -94,7 +94,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(TLS)
-  public OtlpGrpcExporterModel withTls(GrpcTlsModel tls) {
+  public OtlpGrpcExporterModel setTls(GrpcTlsModel tls) {
     this.tls = tls;
     return this;
   }
@@ -113,7 +113,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(HEADERS)
-  public OtlpGrpcExporterModel withHeaders(List<NameStringValuePairModel> headers) {
+  public OtlpGrpcExporterModel setHeaders(List<NameStringValuePairModel> headers) {
     this.headers = headers;
     return this;
   }
@@ -138,7 +138,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(HEADERS_LIST)
-  public OtlpGrpcExporterModel withHeadersList(String headersList) {
+  public OtlpGrpcExporterModel setHeadersList(String headersList) {
     this.headersList = headersList;
     return this;
   }
@@ -160,7 +160,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(COMPRESSION)
-  public OtlpGrpcExporterModel withCompression(String compression) {
+  public OtlpGrpcExporterModel setCompression(String compression) {
     this.compression = compression;
     return this;
   }
@@ -182,7 +182,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonProperty(TIMEOUT)
-  public OtlpGrpcExporterModel withTimeout(Integer timeout) {
+  public OtlpGrpcExporterModel setTimeout(Integer timeout) {
     this.timeout = timeout;
     return this;
   }
@@ -193,7 +193,7 @@ public class OtlpGrpcExporterModel {
   }
 
   @JsonAnySetter
-  public OtlpGrpcExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public OtlpGrpcExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcMetricExporterModel.java
@@ -92,7 +92,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(ENDPOINT)
-  public OtlpGrpcMetricExporterModel withEndpoint(String endpoint) {
+  public OtlpGrpcMetricExporterModel setEndpoint(String endpoint) {
     this.endpoint = endpoint;
     return this;
   }
@@ -112,7 +112,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(TLS)
-  public OtlpGrpcMetricExporterModel withTls(GrpcTlsModel tls) {
+  public OtlpGrpcMetricExporterModel setTls(GrpcTlsModel tls) {
     this.tls = tls;
     return this;
   }
@@ -131,7 +131,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(HEADERS)
-  public OtlpGrpcMetricExporterModel withHeaders(List<NameStringValuePairModel> headers) {
+  public OtlpGrpcMetricExporterModel setHeaders(List<NameStringValuePairModel> headers) {
     this.headers = headers;
     return this;
   }
@@ -156,7 +156,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(HEADERS_LIST)
-  public OtlpGrpcMetricExporterModel withHeadersList(String headersList) {
+  public OtlpGrpcMetricExporterModel setHeadersList(String headersList) {
     this.headersList = headersList;
     return this;
   }
@@ -178,7 +178,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(COMPRESSION)
-  public OtlpGrpcMetricExporterModel withCompression(String compression) {
+  public OtlpGrpcMetricExporterModel setCompression(String compression) {
     this.compression = compression;
     return this;
   }
@@ -200,7 +200,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(TIMEOUT)
-  public OtlpGrpcMetricExporterModel withTimeout(Integer timeout) {
+  public OtlpGrpcMetricExporterModel setTimeout(Integer timeout) {
     this.timeout = timeout;
     return this;
   }
@@ -231,7 +231,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(TEMPORALITY_PREFERENCE)
-  public OtlpGrpcMetricExporterModel withTemporalityPreference(
+  public OtlpGrpcMetricExporterModel setTemporalityPreference(
       ExporterTemporalityPreferenceModel temporalityPreference) {
     this.temporalityPreference = temporalityPreference;
     return this;
@@ -263,7 +263,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonProperty(DEFAULT_HISTOGRAM_AGGREGATION)
-  public OtlpGrpcMetricExporterModel withDefaultHistogramAggregation(
+  public OtlpGrpcMetricExporterModel setDefaultHistogramAggregation(
       ExporterDefaultHistogramAggregationModel defaultHistogramAggregation) {
     this.defaultHistogramAggregation = defaultHistogramAggregation;
     return this;
@@ -275,7 +275,7 @@ public class OtlpGrpcMetricExporterModel {
   }
 
   @JsonAnySetter
-  public OtlpGrpcMetricExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public OtlpGrpcMetricExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpExporterModel.java
@@ -79,7 +79,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(ENDPOINT)
-  public OtlpHttpExporterModel withEndpoint(String endpoint) {
+  public OtlpHttpExporterModel setEndpoint(String endpoint) {
     this.endpoint = endpoint;
     return this;
   }
@@ -99,7 +99,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(TLS)
-  public OtlpHttpExporterModel withTls(HttpTlsModel tls) {
+  public OtlpHttpExporterModel setTls(HttpTlsModel tls) {
     this.tls = tls;
     return this;
   }
@@ -118,7 +118,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(HEADERS)
-  public OtlpHttpExporterModel withHeaders(List<NameStringValuePairModel> headers) {
+  public OtlpHttpExporterModel setHeaders(List<NameStringValuePairModel> headers) {
     this.headers = headers;
     return this;
   }
@@ -143,7 +143,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(HEADERS_LIST)
-  public OtlpHttpExporterModel withHeadersList(String headersList) {
+  public OtlpHttpExporterModel setHeadersList(String headersList) {
     this.headersList = headersList;
     return this;
   }
@@ -165,7 +165,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(COMPRESSION)
-  public OtlpHttpExporterModel withCompression(String compression) {
+  public OtlpHttpExporterModel setCompression(String compression) {
     this.compression = compression;
     return this;
   }
@@ -187,7 +187,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(TIMEOUT)
-  public OtlpHttpExporterModel withTimeout(Integer timeout) {
+  public OtlpHttpExporterModel setTimeout(Integer timeout) {
     this.timeout = timeout;
     return this;
   }
@@ -216,7 +216,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonProperty(ENCODING)
-  public OtlpHttpExporterModel withEncoding(OtlpHttpEncodingModel encoding) {
+  public OtlpHttpExporterModel setEncoding(OtlpHttpEncodingModel encoding) {
     this.encoding = encoding;
     return this;
   }
@@ -227,7 +227,7 @@ public class OtlpHttpExporterModel {
   }
 
   @JsonAnySetter
-  public OtlpHttpExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public OtlpHttpExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpMetricExporterModel.java
@@ -97,7 +97,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(ENDPOINT)
-  public OtlpHttpMetricExporterModel withEndpoint(String endpoint) {
+  public OtlpHttpMetricExporterModel setEndpoint(String endpoint) {
     this.endpoint = endpoint;
     return this;
   }
@@ -117,7 +117,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(TLS)
-  public OtlpHttpMetricExporterModel withTls(HttpTlsModel tls) {
+  public OtlpHttpMetricExporterModel setTls(HttpTlsModel tls) {
     this.tls = tls;
     return this;
   }
@@ -136,7 +136,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(HEADERS)
-  public OtlpHttpMetricExporterModel withHeaders(List<NameStringValuePairModel> headers) {
+  public OtlpHttpMetricExporterModel setHeaders(List<NameStringValuePairModel> headers) {
     this.headers = headers;
     return this;
   }
@@ -161,7 +161,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(HEADERS_LIST)
-  public OtlpHttpMetricExporterModel withHeadersList(String headersList) {
+  public OtlpHttpMetricExporterModel setHeadersList(String headersList) {
     this.headersList = headersList;
     return this;
   }
@@ -183,7 +183,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(COMPRESSION)
-  public OtlpHttpMetricExporterModel withCompression(String compression) {
+  public OtlpHttpMetricExporterModel setCompression(String compression) {
     this.compression = compression;
     return this;
   }
@@ -205,7 +205,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(TIMEOUT)
-  public OtlpHttpMetricExporterModel withTimeout(Integer timeout) {
+  public OtlpHttpMetricExporterModel setTimeout(Integer timeout) {
     this.timeout = timeout;
     return this;
   }
@@ -234,7 +234,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(ENCODING)
-  public OtlpHttpMetricExporterModel withEncoding(OtlpHttpEncodingModel encoding) {
+  public OtlpHttpMetricExporterModel setEncoding(OtlpHttpEncodingModel encoding) {
     this.encoding = encoding;
     return this;
   }
@@ -265,7 +265,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(TEMPORALITY_PREFERENCE)
-  public OtlpHttpMetricExporterModel withTemporalityPreference(
+  public OtlpHttpMetricExporterModel setTemporalityPreference(
       ExporterTemporalityPreferenceModel temporalityPreference) {
     this.temporalityPreference = temporalityPreference;
     return this;
@@ -297,7 +297,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonProperty(DEFAULT_HISTOGRAM_AGGREGATION)
-  public OtlpHttpMetricExporterModel withDefaultHistogramAggregation(
+  public OtlpHttpMetricExporterModel setDefaultHistogramAggregation(
       ExporterDefaultHistogramAggregationModel defaultHistogramAggregation) {
     this.defaultHistogramAggregation = defaultHistogramAggregation;
     return this;
@@ -309,7 +309,7 @@ public class OtlpHttpMetricExporterModel {
   }
 
   @JsonAnySetter
-  public OtlpHttpMetricExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public OtlpHttpMetricExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ParentBasedSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ParentBasedSamplerModel.java
@@ -76,7 +76,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonProperty(ROOT)
-  public ParentBasedSamplerModel withRoot(SamplerModel root) {
+  public ParentBasedSamplerModel setRoot(SamplerModel root) {
     this.root = root;
     return this;
   }
@@ -97,7 +97,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonProperty(REMOTE_PARENT_SAMPLED)
-  public ParentBasedSamplerModel withRemoteParentSampled(SamplerModel remoteParentSampled) {
+  public ParentBasedSamplerModel setRemoteParentSampled(SamplerModel remoteParentSampled) {
     this.remoteParentSampled = remoteParentSampled;
     return this;
   }
@@ -118,7 +118,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonProperty(REMOTE_PARENT_NOT_SAMPLED)
-  public ParentBasedSamplerModel withRemoteParentNotSampled(SamplerModel remoteParentNotSampled) {
+  public ParentBasedSamplerModel setRemoteParentNotSampled(SamplerModel remoteParentNotSampled) {
     this.remoteParentNotSampled = remoteParentNotSampled;
     return this;
   }
@@ -139,7 +139,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonProperty(LOCAL_PARENT_SAMPLED)
-  public ParentBasedSamplerModel withLocalParentSampled(SamplerModel localParentSampled) {
+  public ParentBasedSamplerModel setLocalParentSampled(SamplerModel localParentSampled) {
     this.localParentSampled = localParentSampled;
     return this;
   }
@@ -160,7 +160,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonProperty(LOCAL_PARENT_NOT_SAMPLED)
-  public ParentBasedSamplerModel withLocalParentNotSampled(SamplerModel localParentNotSampled) {
+  public ParentBasedSamplerModel setLocalParentNotSampled(SamplerModel localParentNotSampled) {
     this.localParentNotSampled = localParentNotSampled;
     return this;
   }
@@ -171,7 +171,7 @@ public class ParentBasedSamplerModel {
   }
 
   @JsonAnySetter
-  public ParentBasedSamplerModel withExtensionProperty(String name, @Nullable Object value) {
+  public ParentBasedSamplerModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PeriodicMetricReaderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PeriodicMetricReaderModel.java
@@ -72,7 +72,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonProperty(INTERVAL)
-  public PeriodicMetricReaderModel withInterval(Integer interval) {
+  public PeriodicMetricReaderModel setInterval(Integer interval) {
     this.interval = interval;
     return this;
   }
@@ -94,7 +94,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonProperty(TIMEOUT)
-  public PeriodicMetricReaderModel withTimeout(Integer timeout) {
+  public PeriodicMetricReaderModel setTimeout(Integer timeout) {
     this.timeout = timeout;
     return this;
   }
@@ -115,7 +115,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonProperty(EXPORTER)
-  public PeriodicMetricReaderModel withExporter(PushMetricExporterModel exporter) {
+  public PeriodicMetricReaderModel setExporter(PushMetricExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -132,7 +132,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonProperty(PRODUCERS)
-  public PeriodicMetricReaderModel withProducers(List<MetricProducerModel> producers) {
+  public PeriodicMetricReaderModel setProducers(List<MetricProducerModel> producers) {
     this.producers = producers;
     return this;
   }
@@ -153,7 +153,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonProperty(CARDINALITY_LIMITS)
-  public PeriodicMetricReaderModel withCardinalityLimits(CardinalityLimitsModel cardinalityLimits) {
+  public PeriodicMetricReaderModel setCardinalityLimits(CardinalityLimitsModel cardinalityLimits) {
     this.cardinalityLimits = cardinalityLimits;
     return this;
   }
@@ -164,7 +164,7 @@ public class PeriodicMetricReaderModel {
   }
 
   @JsonAnySetter
-  public PeriodicMetricReaderModel withExtensionProperty(String name, @Nullable Object value) {
+  public PeriodicMetricReaderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PropagatorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PropagatorModel.java
@@ -59,7 +59,7 @@ public class PropagatorModel {
   }
 
   @JsonProperty(COMPOSITE)
-  public PropagatorModel withComposite(List<TextMapPropagatorModel> composite) {
+  public PropagatorModel setComposite(List<TextMapPropagatorModel> composite) {
     this.composite = composite;
     return this;
   }
@@ -88,7 +88,7 @@ public class PropagatorModel {
   }
 
   @JsonProperty(COMPOSITE_LIST)
-  public PropagatorModel withCompositeList(String compositeList) {
+  public PropagatorModel setCompositeList(String compositeList) {
     this.compositeList = compositeList;
     return this;
   }
@@ -99,7 +99,7 @@ public class PropagatorModel {
   }
 
   @JsonAnySetter
-  public PropagatorModel withExtensionProperty(String name, @Nullable Object value) {
+  public PropagatorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PullMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PullMetricExporterModel.java
@@ -33,7 +33,7 @@ public class PullMetricExporterModel {
   }
 
   @JsonAnySetter
-  public PullMetricExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public PullMetricExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PullMetricReaderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PullMetricReaderModel.java
@@ -63,7 +63,7 @@ public class PullMetricReaderModel {
   }
 
   @JsonProperty(EXPORTER)
-  public PullMetricReaderModel withExporter(PullMetricExporterModel exporter) {
+  public PullMetricReaderModel setExporter(PullMetricExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -80,7 +80,7 @@ public class PullMetricReaderModel {
   }
 
   @JsonProperty(PRODUCERS)
-  public PullMetricReaderModel withProducers(List<MetricProducerModel> producers) {
+  public PullMetricReaderModel setProducers(List<MetricProducerModel> producers) {
     this.producers = producers;
     return this;
   }
@@ -101,7 +101,7 @@ public class PullMetricReaderModel {
   }
 
   @JsonProperty(CARDINALITY_LIMITS)
-  public PullMetricReaderModel withCardinalityLimits(CardinalityLimitsModel cardinalityLimits) {
+  public PullMetricReaderModel setCardinalityLimits(CardinalityLimitsModel cardinalityLimits) {
     this.cardinalityLimits = cardinalityLimits;
     return this;
   }
@@ -112,7 +112,7 @@ public class PullMetricReaderModel {
   }
 
   @JsonAnySetter
-  public PullMetricReaderModel withExtensionProperty(String name, @Nullable Object value) {
+  public PullMetricReaderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PushMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/PushMetricExporterModel.java
@@ -63,7 +63,7 @@ public class PushMetricExporterModel {
   }
 
   @JsonProperty(OTLP_HTTP)
-  public PushMetricExporterModel withOtlpHttp(OtlpHttpMetricExporterModel otlpHttp) {
+  public PushMetricExporterModel setOtlpHttp(OtlpHttpMetricExporterModel otlpHttp) {
     this.otlpHttp = otlpHttp;
     return this;
   }
@@ -84,7 +84,7 @@ public class PushMetricExporterModel {
   }
 
   @JsonProperty(OTLP_GRPC)
-  public PushMetricExporterModel withOtlpGrpc(OtlpGrpcMetricExporterModel otlpGrpc) {
+  public PushMetricExporterModel setOtlpGrpc(OtlpGrpcMetricExporterModel otlpGrpc) {
     this.otlpGrpc = otlpGrpc;
     return this;
   }
@@ -105,7 +105,7 @@ public class PushMetricExporterModel {
   }
 
   @JsonProperty(CONSOLE)
-  public PushMetricExporterModel withConsole(ConsoleMetricExporterModel console) {
+  public PushMetricExporterModel setConsole(ConsoleMetricExporterModel console) {
     this.console = console;
     return this;
   }
@@ -116,7 +116,7 @@ public class PushMetricExporterModel {
   }
 
   @JsonAnySetter
-  public PushMetricExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public PushMetricExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ResourceModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ResourceModel.java
@@ -60,7 +60,7 @@ public class ResourceModel {
   }
 
   @JsonProperty(ATTRIBUTES)
-  public ResourceModel withAttributes(List<AttributeNameValueModel> attributes) {
+  public ResourceModel setAttributes(List<AttributeNameValueModel> attributes) {
     this.attributes = attributes;
     return this;
   }
@@ -80,7 +80,7 @@ public class ResourceModel {
   }
 
   @JsonProperty(SCHEMA_URL)
-  public ResourceModel withSchemaUrl(String schemaUrl) {
+  public ResourceModel setSchemaUrl(String schemaUrl) {
     this.schemaUrl = schemaUrl;
     return this;
   }
@@ -106,7 +106,7 @@ public class ResourceModel {
   }
 
   @JsonProperty(ATTRIBUTES_LIST)
-  public ResourceModel withAttributesList(String attributesList) {
+  public ResourceModel setAttributesList(String attributesList) {
     this.attributesList = attributesList;
     return this;
   }
@@ -117,7 +117,7 @@ public class ResourceModel {
   }
 
   @JsonAnySetter
-  public ResourceModel withExtensionProperty(String name, @Nullable Object value) {
+  public ResourceModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SamplerModel.java
@@ -67,7 +67,7 @@ public class SamplerModel {
   }
 
   @JsonProperty(ALWAYS_OFF)
-  public SamplerModel withAlwaysOff(AlwaysOffSamplerModel alwaysOff) {
+  public SamplerModel setAlwaysOff(AlwaysOffSamplerModel alwaysOff) {
     this.alwaysOff = alwaysOff;
     return this;
   }
@@ -88,7 +88,7 @@ public class SamplerModel {
   }
 
   @JsonProperty(ALWAYS_ON)
-  public SamplerModel withAlwaysOn(AlwaysOnSamplerModel alwaysOn) {
+  public SamplerModel setAlwaysOn(AlwaysOnSamplerModel alwaysOn) {
     this.alwaysOn = alwaysOn;
     return this;
   }
@@ -109,7 +109,7 @@ public class SamplerModel {
   }
 
   @JsonProperty(PARENT_BASED)
-  public SamplerModel withParentBased(ParentBasedSamplerModel parentBased) {
+  public SamplerModel setParentBased(ParentBasedSamplerModel parentBased) {
     this.parentBased = parentBased;
     return this;
   }
@@ -130,7 +130,7 @@ public class SamplerModel {
   }
 
   @JsonProperty(TRACE_ID_RATIO_BASED)
-  public SamplerModel withTraceIdRatioBased(TraceIdRatioBasedSamplerModel traceIdRatioBased) {
+  public SamplerModel setTraceIdRatioBased(TraceIdRatioBasedSamplerModel traceIdRatioBased) {
     this.traceIdRatioBased = traceIdRatioBased;
     return this;
   }
@@ -141,7 +141,7 @@ public class SamplerModel {
   }
 
   @JsonAnySetter
-  public SamplerModel withExtensionProperty(String name, @Nullable Object value) {
+  public SamplerModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SimpleLogRecordProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SimpleLogRecordProcessorModel.java
@@ -55,7 +55,7 @@ public class SimpleLogRecordProcessorModel {
   }
 
   @JsonProperty(EXPORTER)
-  public SimpleLogRecordProcessorModel withExporter(LogRecordExporterModel exporter) {
+  public SimpleLogRecordProcessorModel setExporter(LogRecordExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -66,7 +66,7 @@ public class SimpleLogRecordProcessorModel {
   }
 
   @JsonAnySetter
-  public SimpleLogRecordProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public SimpleLogRecordProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SimpleSpanProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SimpleSpanProcessorModel.java
@@ -55,7 +55,7 @@ public class SimpleSpanProcessorModel {
   }
 
   @JsonProperty(EXPORTER)
-  public SimpleSpanProcessorModel withExporter(SpanExporterModel exporter) {
+  public SimpleSpanProcessorModel setExporter(SpanExporterModel exporter) {
     this.exporter = exporter;
     return this;
   }
@@ -66,7 +66,7 @@ public class SimpleSpanProcessorModel {
   }
 
   @JsonAnySetter
-  public SimpleSpanProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public SimpleSpanProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanExporterModel.java
@@ -63,7 +63,7 @@ public class SpanExporterModel {
   }
 
   @JsonProperty(OTLP_HTTP)
-  public SpanExporterModel withOtlpHttp(OtlpHttpExporterModel otlpHttp) {
+  public SpanExporterModel setOtlpHttp(OtlpHttpExporterModel otlpHttp) {
     this.otlpHttp = otlpHttp;
     return this;
   }
@@ -84,7 +84,7 @@ public class SpanExporterModel {
   }
 
   @JsonProperty(OTLP_GRPC)
-  public SpanExporterModel withOtlpGrpc(OtlpGrpcExporterModel otlpGrpc) {
+  public SpanExporterModel setOtlpGrpc(OtlpGrpcExporterModel otlpGrpc) {
     this.otlpGrpc = otlpGrpc;
     return this;
   }
@@ -105,7 +105,7 @@ public class SpanExporterModel {
   }
 
   @JsonProperty(CONSOLE)
-  public SpanExporterModel withConsole(ConsoleExporterModel console) {
+  public SpanExporterModel setConsole(ConsoleExporterModel console) {
     this.console = console;
     return this;
   }
@@ -116,7 +116,7 @@ public class SpanExporterModel {
   }
 
   @JsonAnySetter
-  public SpanExporterModel withExtensionProperty(String name, @Nullable Object value) {
+  public SpanExporterModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanLimitsModel.java
@@ -84,7 +84,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
-  public SpanLimitsModel withAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
+  public SpanLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
     return this;
   }
@@ -107,7 +107,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(ATTRIBUTE_COUNT_LIMIT)
-  public SpanLimitsModel withAttributeCountLimit(Integer attributeCountLimit) {
+  public SpanLimitsModel setAttributeCountLimit(Integer attributeCountLimit) {
     this.attributeCountLimit = attributeCountLimit;
     return this;
   }
@@ -130,7 +130,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(EVENT_COUNT_LIMIT)
-  public SpanLimitsModel withEventCountLimit(Integer eventCountLimit) {
+  public SpanLimitsModel setEventCountLimit(Integer eventCountLimit) {
     this.eventCountLimit = eventCountLimit;
     return this;
   }
@@ -153,7 +153,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(LINK_COUNT_LIMIT)
-  public SpanLimitsModel withLinkCountLimit(Integer linkCountLimit) {
+  public SpanLimitsModel setLinkCountLimit(Integer linkCountLimit) {
     this.linkCountLimit = linkCountLimit;
     return this;
   }
@@ -176,7 +176,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(EVENT_ATTRIBUTE_COUNT_LIMIT)
-  public SpanLimitsModel withEventAttributeCountLimit(Integer eventAttributeCountLimit) {
+  public SpanLimitsModel setEventAttributeCountLimit(Integer eventAttributeCountLimit) {
     this.eventAttributeCountLimit = eventAttributeCountLimit;
     return this;
   }
@@ -199,7 +199,7 @@ public class SpanLimitsModel {
   }
 
   @JsonProperty(LINK_ATTRIBUTE_COUNT_LIMIT)
-  public SpanLimitsModel withLinkAttributeCountLimit(Integer linkAttributeCountLimit) {
+  public SpanLimitsModel setLinkAttributeCountLimit(Integer linkAttributeCountLimit) {
     this.linkAttributeCountLimit = linkAttributeCountLimit;
     return this;
   }
@@ -210,7 +210,7 @@ public class SpanLimitsModel {
   }
 
   @JsonAnySetter
-  public SpanLimitsModel withExtensionProperty(String name, @Nullable Object value) {
+  public SpanLimitsModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanProcessorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanProcessorModel.java
@@ -59,7 +59,7 @@ public class SpanProcessorModel {
   }
 
   @JsonProperty(BATCH)
-  public SpanProcessorModel withBatch(BatchSpanProcessorModel batch) {
+  public SpanProcessorModel setBatch(BatchSpanProcessorModel batch) {
     this.batch = batch;
     return this;
   }
@@ -80,7 +80,7 @@ public class SpanProcessorModel {
   }
 
   @JsonProperty(SIMPLE)
-  public SpanProcessorModel withSimple(SimpleSpanProcessorModel simple) {
+  public SpanProcessorModel setSimple(SimpleSpanProcessorModel simple) {
     this.simple = simple;
     return this;
   }
@@ -91,7 +91,7 @@ public class SpanProcessorModel {
   }
 
   @JsonAnySetter
-  public SpanProcessorModel withExtensionProperty(String name, @Nullable Object value) {
+  public SpanProcessorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TextMapPropagatorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TextMapPropagatorModel.java
@@ -67,7 +67,7 @@ public class TextMapPropagatorModel {
   }
 
   @JsonProperty(TRACECONTEXT)
-  public TextMapPropagatorModel withTracecontext(TraceContextPropagatorModel tracecontext) {
+  public TextMapPropagatorModel setTracecontext(TraceContextPropagatorModel tracecontext) {
     this.tracecontext = tracecontext;
     return this;
   }
@@ -88,7 +88,7 @@ public class TextMapPropagatorModel {
   }
 
   @JsonProperty(BAGGAGE)
-  public TextMapPropagatorModel withBaggage(BaggagePropagatorModel baggage) {
+  public TextMapPropagatorModel setBaggage(BaggagePropagatorModel baggage) {
     this.baggage = baggage;
     return this;
   }
@@ -108,7 +108,7 @@ public class TextMapPropagatorModel {
   }
 
   @JsonProperty(B_3)
-  public TextMapPropagatorModel withB3(B3PropagatorModel b3) {
+  public TextMapPropagatorModel setB3(B3PropagatorModel b3) {
     this.b3 = b3;
     return this;
   }
@@ -129,7 +129,7 @@ public class TextMapPropagatorModel {
   }
 
   @JsonProperty(B_3_MULTI)
-  public TextMapPropagatorModel withB3multi(B3MultiPropagatorModel b3multi) {
+  public TextMapPropagatorModel setB3multi(B3MultiPropagatorModel b3multi) {
     this.b3multi = b3multi;
     return this;
   }
@@ -140,7 +140,7 @@ public class TextMapPropagatorModel {
   }
 
   @JsonAnySetter
-  public TextMapPropagatorModel withExtensionProperty(String name, @Nullable Object value) {
+  public TextMapPropagatorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TraceIdRatioBasedSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TraceIdRatioBasedSamplerModel.java
@@ -54,7 +54,7 @@ public class TraceIdRatioBasedSamplerModel {
   }
 
   @JsonProperty(RATIO)
-  public TraceIdRatioBasedSamplerModel withRatio(Double ratio) {
+  public TraceIdRatioBasedSamplerModel setRatio(Double ratio) {
     this.ratio = ratio;
     return this;
   }
@@ -65,7 +65,7 @@ public class TraceIdRatioBasedSamplerModel {
   }
 
   @JsonAnySetter
-  public TraceIdRatioBasedSamplerModel withExtensionProperty(String name, @Nullable Object value) {
+  public TraceIdRatioBasedSamplerModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TracerProviderModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/TracerProviderModel.java
@@ -63,7 +63,7 @@ public class TracerProviderModel {
   }
 
   @JsonProperty(PROCESSORS)
-  public TracerProviderModel withProcessors(List<SpanProcessorModel> processors) {
+  public TracerProviderModel setProcessors(List<SpanProcessorModel> processors) {
     this.processors = processors;
     return this;
   }
@@ -83,7 +83,7 @@ public class TracerProviderModel {
   }
 
   @JsonProperty(LIMITS)
-  public TracerProviderModel withLimits(SpanLimitsModel limits) {
+  public TracerProviderModel setLimits(SpanLimitsModel limits) {
     this.limits = limits;
     return this;
   }
@@ -103,7 +103,7 @@ public class TracerProviderModel {
   }
 
   @JsonProperty(SAMPLER)
-  public TracerProviderModel withSampler(SamplerModel sampler) {
+  public TracerProviderModel setSampler(SamplerModel sampler) {
     this.sampler = sampler;
     return this;
   }
@@ -124,7 +124,7 @@ public class TracerProviderModel {
   }
 
   @JsonProperty(ID_GENERATOR)
-  public TracerProviderModel withIdGenerator(IdGeneratorModel idGenerator) {
+  public TracerProviderModel setIdGenerator(IdGeneratorModel idGenerator) {
     this.idGenerator = idGenerator;
     return this;
   }
@@ -135,7 +135,7 @@ public class TracerProviderModel {
   }
 
   @JsonAnySetter
-  public TracerProviderModel withExtensionProperty(String name, @Nullable Object value) {
+  public TracerProviderModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewModel.java
@@ -62,7 +62,7 @@ public class ViewModel {
   }
 
   @JsonProperty(SELECTOR)
-  public ViewModel withSelector(ViewSelectorModel selector) {
+  public ViewModel setSelector(ViewSelectorModel selector) {
     this.selector = selector;
     return this;
   }
@@ -82,7 +82,7 @@ public class ViewModel {
   }
 
   @JsonProperty(STREAM)
-  public ViewModel withStream(ViewStreamModel stream) {
+  public ViewModel setStream(ViewStreamModel stream) {
     this.stream = stream;
     return this;
   }
@@ -93,7 +93,7 @@ public class ViewModel {
   }
 
   @JsonAnySetter
-  public ViewModel withExtensionProperty(String name, @Nullable Object value) {
+  public ViewModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewSelectorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewSelectorModel.java
@@ -81,7 +81,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(INSTRUMENT_NAME)
-  public ViewSelectorModel withInstrumentName(String instrumentName) {
+  public ViewSelectorModel setInstrumentName(String instrumentName) {
     this.instrumentName = instrumentName;
     return this;
   }
@@ -118,7 +118,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(INSTRUMENT_TYPE)
-  public ViewSelectorModel withInstrumentType(InstrumentTypeModel instrumentType) {
+  public ViewSelectorModel setInstrumentType(InstrumentTypeModel instrumentType) {
     this.instrumentType = instrumentType;
     return this;
   }
@@ -138,7 +138,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(UNIT)
-  public ViewSelectorModel withUnit(String unit) {
+  public ViewSelectorModel setUnit(String unit) {
     this.unit = unit;
     return this;
   }
@@ -158,7 +158,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(METER_NAME)
-  public ViewSelectorModel withMeterName(String meterName) {
+  public ViewSelectorModel setMeterName(String meterName) {
     this.meterName = meterName;
     return this;
   }
@@ -178,7 +178,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(METER_VERSION)
-  public ViewSelectorModel withMeterVersion(String meterVersion) {
+  public ViewSelectorModel setMeterVersion(String meterVersion) {
     this.meterVersion = meterVersion;
     return this;
   }
@@ -199,7 +199,7 @@ public class ViewSelectorModel {
   }
 
   @JsonProperty(METER_SCHEMA_URL)
-  public ViewSelectorModel withMeterSchemaUrl(String meterSchemaUrl) {
+  public ViewSelectorModel setMeterSchemaUrl(String meterSchemaUrl) {
     this.meterSchemaUrl = meterSchemaUrl;
     return this;
   }
@@ -210,7 +210,7 @@ public class ViewSelectorModel {
   }
 
   @JsonAnySetter
-  public ViewSelectorModel withExtensionProperty(String name, @Nullable Object value) {
+  public ViewSelectorModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewStreamModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ViewStreamModel.java
@@ -70,7 +70,7 @@ public class ViewStreamModel {
   }
 
   @JsonProperty(NAME)
-  public ViewStreamModel withName(String name) {
+  public ViewStreamModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -90,7 +90,7 @@ public class ViewStreamModel {
   }
 
   @JsonProperty(DESCRIPTION)
-  public ViewStreamModel withDescription(String description) {
+  public ViewStreamModel setDescription(String description) {
     this.description = description;
     return this;
   }
@@ -111,7 +111,7 @@ public class ViewStreamModel {
   }
 
   @JsonProperty(AGGREGATION)
-  public ViewStreamModel withAggregation(AggregationModel aggregation) {
+  public ViewStreamModel setAggregation(AggregationModel aggregation) {
     this.aggregation = aggregation;
     return this;
   }
@@ -132,7 +132,7 @@ public class ViewStreamModel {
   }
 
   @JsonProperty(AGGREGATION_CARDINALITY_LIMIT)
-  public ViewStreamModel withAggregationCardinalityLimit(Integer aggregationCardinalityLimit) {
+  public ViewStreamModel setAggregationCardinalityLimit(Integer aggregationCardinalityLimit) {
     this.aggregationCardinalityLimit = aggregationCardinalityLimit;
     return this;
   }
@@ -153,7 +153,7 @@ public class ViewStreamModel {
   }
 
   @JsonProperty(ATTRIBUTE_KEYS)
-  public ViewStreamModel withAttributeKeys(IncludeExcludeModel attributeKeys) {
+  public ViewStreamModel setAttributeKeys(IncludeExcludeModel attributeKeys) {
     this.attributeKeys = attributeKeys;
     return this;
   }
@@ -164,7 +164,7 @@ public class ViewStreamModel {
   }
 
   @JsonAnySetter
-  public ViewStreamModel withExtensionProperty(String name, @Nullable Object value) {
+  public ViewStreamModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalCodeInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalCodeInstrumentationModel.java
@@ -37,7 +37,7 @@ public class ExperimentalCodeInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalCodeInstrumentationModel withSemconv(ExperimentalSemconvConfigModel semconv) {
+  public ExperimentalCodeInstrumentationModel setSemconv(ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableParentThresholdSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableParentThresholdSamplerModel.java
@@ -30,7 +30,7 @@ public class ExperimentalComposableParentThresholdSamplerModel {
   }
 
   @JsonProperty("root")
-  public ExperimentalComposableParentThresholdSamplerModel withRoot(
+  public ExperimentalComposableParentThresholdSamplerModel setRoot(
       ExperimentalComposableSamplerModel root) {
     this.root = root;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableProbabilitySamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableProbabilitySamplerModel.java
@@ -30,7 +30,7 @@ public class ExperimentalComposableProbabilitySamplerModel {
   }
 
   @JsonProperty("ratio")
-  public ExperimentalComposableProbabilitySamplerModel withRatio(Double ratio) {
+  public ExperimentalComposableProbabilitySamplerModel setRatio(Double ratio) {
     this.ratio = ratio;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerModel.java
@@ -38,7 +38,7 @@ public class ExperimentalComposableRuleBasedSamplerModel {
   }
 
   @JsonProperty("rules")
-  public ExperimentalComposableRuleBasedSamplerModel withRules(
+  public ExperimentalComposableRuleBasedSamplerModel setRules(
       List<ExperimentalComposableRuleBasedSamplerRuleModel> rules) {
     this.rules = rules;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel.java
@@ -33,7 +33,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel {
   }
 
   @JsonProperty("key")
-  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel withKey(String key) {
+  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel setKey(String key) {
     this.key = key;
     return this;
   }
@@ -57,7 +57,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel {
   }
 
   @JsonProperty("included")
-  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel withIncluded(
+  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel setIncluded(
       List<String> included) {
     this.included = included;
     return this;
@@ -83,7 +83,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel {
   }
 
   @JsonProperty("excluded")
-  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel withExcluded(
+  public ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel setExcluded(
       List<String> excluded) {
     this.excluded = excluded;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel.java
@@ -32,7 +32,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel {
   }
 
   @JsonProperty("key")
-  public ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel withKey(String key) {
+  public ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel setKey(String key) {
     this.key = key;
     return this;
   }
@@ -50,7 +50,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel {
   }
 
   @JsonProperty("values")
-  public ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel withValues(
+  public ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel setValues(
       List<String> values) {
     this.values = values;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableRuleBasedSamplerRuleModel.java
@@ -45,7 +45,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleModel {
   }
 
   @JsonProperty("attribute_values")
-  public ExperimentalComposableRuleBasedSamplerRuleModel withAttributeValues(
+  public ExperimentalComposableRuleBasedSamplerRuleModel setAttributeValues(
       ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel attributeValues) {
     this.attributeValues = attributeValues;
     return this;
@@ -69,7 +69,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleModel {
   }
 
   @JsonProperty("attribute_patterns")
-  public ExperimentalComposableRuleBasedSamplerRuleModel withAttributePatterns(
+  public ExperimentalComposableRuleBasedSamplerRuleModel setAttributePatterns(
       ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel attributePatterns) {
     this.attributePatterns = attributePatterns;
     return this;
@@ -99,7 +99,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleModel {
   }
 
   @JsonProperty("span_kinds")
-  public ExperimentalComposableRuleBasedSamplerRuleModel withSpanKinds(
+  public ExperimentalComposableRuleBasedSamplerRuleModel setSpanKinds(
       List<SpanKindModel> spanKinds) {
     this.spanKinds = spanKinds;
     return this;
@@ -125,7 +125,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleModel {
   }
 
   @JsonProperty("parent")
-  public ExperimentalComposableRuleBasedSamplerRuleModel withParent(
+  public ExperimentalComposableRuleBasedSamplerRuleModel setParent(
       List<ExperimentalSpanParentModel> parent) {
     this.parent = parent;
     return this;
@@ -143,7 +143,7 @@ public class ExperimentalComposableRuleBasedSamplerRuleModel {
   }
 
   @JsonProperty("sampler")
-  public ExperimentalComposableRuleBasedSamplerRuleModel withSampler(
+  public ExperimentalComposableRuleBasedSamplerRuleModel setSampler(
       ExperimentalComposableSamplerModel sampler) {
     this.sampler = sampler;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableSamplerModel.java
@@ -40,7 +40,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonProperty("always_off")
-  public ExperimentalComposableSamplerModel withAlwaysOff(
+  public ExperimentalComposableSamplerModel setAlwaysOff(
       ExperimentalComposableAlwaysOffSamplerModel alwaysOff) {
     this.alwaysOff = alwaysOff;
     return this;
@@ -58,7 +58,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonProperty("always_on")
-  public ExperimentalComposableSamplerModel withAlwaysOn(
+  public ExperimentalComposableSamplerModel setAlwaysOn(
       ExperimentalComposableAlwaysOnSamplerModel alwaysOn) {
     this.alwaysOn = alwaysOn;
     return this;
@@ -76,7 +76,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonProperty("parent_threshold")
-  public ExperimentalComposableSamplerModel withParentThreshold(
+  public ExperimentalComposableSamplerModel setParentThreshold(
       ExperimentalComposableParentThresholdSamplerModel parentThreshold) {
     this.parentThreshold = parentThreshold;
     return this;
@@ -94,7 +94,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonProperty("probability")
-  public ExperimentalComposableSamplerModel withProbability(
+  public ExperimentalComposableSamplerModel setProbability(
       ExperimentalComposableProbabilitySamplerModel probability) {
     this.probability = probability;
     return this;
@@ -112,7 +112,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonProperty("rule_based")
-  public ExperimentalComposableSamplerModel withRuleBased(
+  public ExperimentalComposableSamplerModel setRuleBased(
       ExperimentalComposableRuleBasedSamplerModel ruleBased) {
     this.ruleBased = ruleBased;
     return this;
@@ -124,7 +124,7 @@ public class ExperimentalComposableSamplerModel {
   }
 
   @JsonAnySetter
-  public ExperimentalComposableSamplerModel withAdditionalProperty(
+  public ExperimentalComposableSamplerModel setAdditionalProperty(
       String name, ExperimentalComposableSamplerPropertyModel value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableSamplerPropertyModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalComposableSamplerPropertyModel.java
@@ -27,7 +27,7 @@ public class ExperimentalComposableSamplerPropertyModel {
   }
 
   @JsonAnySetter
-  public ExperimentalComposableSamplerPropertyModel withAdditionalProperty(
+  public ExperimentalComposableSamplerPropertyModel setAdditionalProperty(
       String name, Object value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalDbInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalDbInstrumentationModel.java
@@ -36,7 +36,7 @@ public class ExperimentalDbInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalDbInstrumentationModel withSemconv(ExperimentalSemconvConfigModel semconv) {
+  public ExperimentalDbInstrumentationModel setSemconv(ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalGenAiInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalGenAiInstrumentationModel.java
@@ -36,7 +36,7 @@ public class ExperimentalGenAiInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalGenAiInstrumentationModel withSemconv(ExperimentalSemconvConfigModel semconv) {
+  public ExperimentalGenAiInstrumentationModel setSemconv(ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalGeneralInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalGeneralInstrumentationModel.java
@@ -48,7 +48,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("http")
-  public ExperimentalGeneralInstrumentationModel withHttp(
+  public ExperimentalGeneralInstrumentationModel setHttp(
       ExperimentalHttpInstrumentationModel http) {
     this.http = http;
     return this;
@@ -69,7 +69,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("code")
-  public ExperimentalGeneralInstrumentationModel withCode(
+  public ExperimentalGeneralInstrumentationModel setCode(
       ExperimentalCodeInstrumentationModel code) {
     this.code = code;
     return this;
@@ -89,7 +89,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("db")
-  public ExperimentalGeneralInstrumentationModel withDb(ExperimentalDbInstrumentationModel db) {
+  public ExperimentalGeneralInstrumentationModel setDb(ExperimentalDbInstrumentationModel db) {
     this.db = db;
     return this;
   }
@@ -108,7 +108,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("gen_ai")
-  public ExperimentalGeneralInstrumentationModel withGenAi(
+  public ExperimentalGeneralInstrumentationModel setGenAi(
       ExperimentalGenAiInstrumentationModel genAi) {
     this.genAi = genAi;
     return this;
@@ -128,7 +128,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("messaging")
-  public ExperimentalGeneralInstrumentationModel withMessaging(
+  public ExperimentalGeneralInstrumentationModel setMessaging(
       ExperimentalMessagingInstrumentationModel messaging) {
     this.messaging = messaging;
     return this;
@@ -148,7 +148,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("rpc")
-  public ExperimentalGeneralInstrumentationModel withRpc(ExperimentalRpcInstrumentationModel rpc) {
+  public ExperimentalGeneralInstrumentationModel setRpc(ExperimentalRpcInstrumentationModel rpc) {
     this.rpc = rpc;
     return this;
   }
@@ -165,7 +165,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("sanitization")
-  public ExperimentalGeneralInstrumentationModel withSanitization(
+  public ExperimentalGeneralInstrumentationModel setSanitization(
       ExperimentalSanitizationModel sanitization) {
     this.sanitization = sanitization;
     return this;
@@ -231,7 +231,7 @@ public class ExperimentalGeneralInstrumentationModel {
   }
 
   @JsonProperty("stability_opt_in_list")
-  public ExperimentalGeneralInstrumentationModel withStabilityOptInList(String stabilityOptInList) {
+  public ExperimentalGeneralInstrumentationModel setStabilityOptInList(String stabilityOptInList) {
     this.stabilityOptInList = stabilityOptInList;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpClientInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpClientInstrumentationModel.java
@@ -33,7 +33,7 @@ public class ExperimentalHttpClientInstrumentationModel {
   }
 
   @JsonProperty("request_captured_headers")
-  public ExperimentalHttpClientInstrumentationModel withRequestCapturedHeaders(
+  public ExperimentalHttpClientInstrumentationModel setRequestCapturedHeaders(
       List<String> requestCapturedHeaders) {
     this.requestCapturedHeaders = requestCapturedHeaders;
     return this;
@@ -51,7 +51,7 @@ public class ExperimentalHttpClientInstrumentationModel {
   }
 
   @JsonProperty("response_captured_headers")
-  public ExperimentalHttpClientInstrumentationModel withResponseCapturedHeaders(
+  public ExperimentalHttpClientInstrumentationModel setResponseCapturedHeaders(
       List<String> responseCapturedHeaders) {
     this.responseCapturedHeaders = responseCapturedHeaders;
     return this;
@@ -75,7 +75,7 @@ public class ExperimentalHttpClientInstrumentationModel {
   }
 
   @JsonProperty("known_methods")
-  public ExperimentalHttpClientInstrumentationModel withKnownMethods(List<String> knownMethods) {
+  public ExperimentalHttpClientInstrumentationModel setKnownMethods(List<String> knownMethods) {
     this.knownMethods = knownMethods;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpInstrumentationModel.java
@@ -39,7 +39,7 @@ public class ExperimentalHttpInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalHttpInstrumentationModel withSemconv(ExperimentalSemconvConfigModel semconv) {
+  public ExperimentalHttpInstrumentationModel setSemconv(ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;
   }
@@ -56,7 +56,7 @@ public class ExperimentalHttpInstrumentationModel {
   }
 
   @JsonProperty("client")
-  public ExperimentalHttpInstrumentationModel withClient(
+  public ExperimentalHttpInstrumentationModel setClient(
       ExperimentalHttpClientInstrumentationModel client) {
     this.client = client;
     return this;
@@ -74,7 +74,7 @@ public class ExperimentalHttpInstrumentationModel {
   }
 
   @JsonProperty("server")
-  public ExperimentalHttpInstrumentationModel withServer(
+  public ExperimentalHttpInstrumentationModel setServer(
       ExperimentalHttpServerInstrumentationModel server) {
     this.server = server;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpServerInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalHttpServerInstrumentationModel.java
@@ -33,7 +33,7 @@ public class ExperimentalHttpServerInstrumentationModel {
   }
 
   @JsonProperty("request_captured_headers")
-  public ExperimentalHttpServerInstrumentationModel withRequestCapturedHeaders(
+  public ExperimentalHttpServerInstrumentationModel setRequestCapturedHeaders(
       List<String> requestCapturedHeaders) {
     this.requestCapturedHeaders = requestCapturedHeaders;
     return this;
@@ -51,7 +51,7 @@ public class ExperimentalHttpServerInstrumentationModel {
   }
 
   @JsonProperty("response_captured_headers")
-  public ExperimentalHttpServerInstrumentationModel withResponseCapturedHeaders(
+  public ExperimentalHttpServerInstrumentationModel setResponseCapturedHeaders(
       List<String> responseCapturedHeaders) {
     this.responseCapturedHeaders = responseCapturedHeaders;
     return this;
@@ -75,7 +75,7 @@ public class ExperimentalHttpServerInstrumentationModel {
   }
 
   @JsonProperty("known_methods")
-  public ExperimentalHttpServerInstrumentationModel withKnownMethods(List<String> knownMethods) {
+  public ExperimentalHttpServerInstrumentationModel setKnownMethods(List<String> knownMethods) {
     this.knownMethods = knownMethods;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalInstrumentationModel.java
@@ -46,7 +46,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("general")
-  public ExperimentalInstrumentationModel withGeneral(
+  public ExperimentalInstrumentationModel setGeneral(
       ExperimentalGeneralInstrumentationModel general) {
     this.general = general;
     return this;
@@ -64,7 +64,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("cpp")
-  public ExperimentalInstrumentationModel withCpp(
+  public ExperimentalInstrumentationModel setCpp(
       ExperimentalLanguageSpecificInstrumentationModel cpp) {
     this.cpp = cpp;
     return this;
@@ -85,7 +85,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("dotnet")
-  public ExperimentalInstrumentationModel withDotnet(
+  public ExperimentalInstrumentationModel setDotnet(
       ExperimentalLanguageSpecificInstrumentationModel dotnet) {
     this.dotnet = dotnet;
     return this;
@@ -106,7 +106,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("erlang")
-  public ExperimentalInstrumentationModel withErlang(
+  public ExperimentalInstrumentationModel setErlang(
       ExperimentalLanguageSpecificInstrumentationModel erlang) {
     this.erlang = erlang;
     return this;
@@ -127,7 +127,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("go")
-  public ExperimentalInstrumentationModel withGo(
+  public ExperimentalInstrumentationModel setGo(
       ExperimentalLanguageSpecificInstrumentationModel go) {
     this.go = go;
     return this;
@@ -148,7 +148,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("java")
-  public ExperimentalInstrumentationModel withJava(
+  public ExperimentalInstrumentationModel setJava(
       ExperimentalLanguageSpecificInstrumentationModel java) {
     this.java = java;
     return this;
@@ -169,7 +169,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("js")
-  public ExperimentalInstrumentationModel withJs(
+  public ExperimentalInstrumentationModel setJs(
       ExperimentalLanguageSpecificInstrumentationModel js) {
     this.js = js;
     return this;
@@ -190,7 +190,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("php")
-  public ExperimentalInstrumentationModel withPhp(
+  public ExperimentalInstrumentationModel setPhp(
       ExperimentalLanguageSpecificInstrumentationModel php) {
     this.php = php;
     return this;
@@ -211,7 +211,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("python")
-  public ExperimentalInstrumentationModel withPython(
+  public ExperimentalInstrumentationModel setPython(
       ExperimentalLanguageSpecificInstrumentationModel python) {
     this.python = python;
     return this;
@@ -232,7 +232,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("ruby")
-  public ExperimentalInstrumentationModel withRuby(
+  public ExperimentalInstrumentationModel setRuby(
       ExperimentalLanguageSpecificInstrumentationModel ruby) {
     this.ruby = ruby;
     return this;
@@ -253,7 +253,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("rust")
-  public ExperimentalInstrumentationModel withRust(
+  public ExperimentalInstrumentationModel setRust(
       ExperimentalLanguageSpecificInstrumentationModel rust) {
     this.rust = rust;
     return this;
@@ -274,7 +274,7 @@ public class ExperimentalInstrumentationModel {
   }
 
   @JsonProperty("swift")
-  public ExperimentalInstrumentationModel withSwift(
+  public ExperimentalInstrumentationModel setSwift(
       ExperimentalLanguageSpecificInstrumentationModel swift) {
     this.swift = swift;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalJaegerRemoteSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalJaegerRemoteSamplerModel.java
@@ -33,7 +33,7 @@ public class ExperimentalJaegerRemoteSamplerModel {
   }
 
   @JsonProperty("endpoint")
-  public ExperimentalJaegerRemoteSamplerModel withEndpoint(String endpoint) {
+  public ExperimentalJaegerRemoteSamplerModel setEndpoint(String endpoint) {
     this.endpoint = endpoint;
     return this;
   }
@@ -50,7 +50,7 @@ public class ExperimentalJaegerRemoteSamplerModel {
   }
 
   @JsonProperty("interval")
-  public ExperimentalJaegerRemoteSamplerModel withInterval(Integer interval) {
+  public ExperimentalJaegerRemoteSamplerModel setInterval(Integer interval) {
     this.interval = interval;
     return this;
   }
@@ -67,7 +67,7 @@ public class ExperimentalJaegerRemoteSamplerModel {
   }
 
   @JsonProperty("initial_sampler")
-  public ExperimentalJaegerRemoteSamplerModel withInitialSampler(SamplerModel initialSampler) {
+  public ExperimentalJaegerRemoteSamplerModel setInitialSampler(SamplerModel initialSampler) {
     this.initialSampler = initialSampler;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLanguageSpecificInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLanguageSpecificInstrumentationModel.java
@@ -30,7 +30,7 @@ public class ExperimentalLanguageSpecificInstrumentationModel {
   }
 
   @JsonAnySetter
-  public ExperimentalLanguageSpecificInstrumentationModel withAdditionalProperty(
+  public ExperimentalLanguageSpecificInstrumentationModel setAdditionalProperty(
       String name, ExperimentalLanguageSpecificInstrumentationPropertyModel value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLanguageSpecificInstrumentationPropertyModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLanguageSpecificInstrumentationPropertyModel.java
@@ -27,7 +27,7 @@ public class ExperimentalLanguageSpecificInstrumentationPropertyModel {
   }
 
   @JsonAnySetter
-  public ExperimentalLanguageSpecificInstrumentationPropertyModel withAdditionalProperty(
+  public ExperimentalLanguageSpecificInstrumentationPropertyModel setAdditionalProperty(
       String name, Object value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerConfigModel.java
@@ -33,7 +33,7 @@ public class ExperimentalLoggerConfigModel {
   }
 
   @JsonProperty("enabled")
-  public ExperimentalLoggerConfigModel withEnabled(Boolean enabled) {
+  public ExperimentalLoggerConfigModel setEnabled(Boolean enabled) {
     this.enabled = enabled;
     return this;
   }
@@ -103,7 +103,7 @@ public class ExperimentalLoggerConfigModel {
   }
 
   @JsonProperty("minimum_severity")
-  public ExperimentalLoggerConfigModel withMinimumSeverity(SeverityNumberModel minimumSeverity) {
+  public ExperimentalLoggerConfigModel setMinimumSeverity(SeverityNumberModel minimumSeverity) {
     this.minimumSeverity = minimumSeverity;
     return this;
   }
@@ -124,7 +124,7 @@ public class ExperimentalLoggerConfigModel {
   }
 
   @JsonProperty("trace_based")
-  public ExperimentalLoggerConfigModel withTraceBased(Boolean traceBased) {
+  public ExperimentalLoggerConfigModel setTraceBased(Boolean traceBased) {
     this.traceBased = traceBased;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerConfiguratorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerConfiguratorModel.java
@@ -33,7 +33,7 @@ public class ExperimentalLoggerConfiguratorModel {
   }
 
   @JsonProperty("default_config")
-  public ExperimentalLoggerConfiguratorModel withDefaultConfig(
+  public ExperimentalLoggerConfiguratorModel setDefaultConfig(
       ExperimentalLoggerConfigModel defaultConfig) {
     this.defaultConfig = defaultConfig;
     return this;
@@ -51,7 +51,7 @@ public class ExperimentalLoggerConfiguratorModel {
   }
 
   @JsonProperty("loggers")
-  public ExperimentalLoggerConfiguratorModel withLoggers(
+  public ExperimentalLoggerConfiguratorModel setLoggers(
       List<ExperimentalLoggerMatcherAndConfigModel> loggers) {
     this.loggers = loggers;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerMatcherAndConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalLoggerMatcherAndConfigModel.java
@@ -36,7 +36,7 @@ public class ExperimentalLoggerMatcherAndConfigModel {
   }
 
   @JsonProperty("name")
-  public ExperimentalLoggerMatcherAndConfigModel withName(String name) {
+  public ExperimentalLoggerMatcherAndConfigModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -53,7 +53,7 @@ public class ExperimentalLoggerMatcherAndConfigModel {
   }
 
   @JsonProperty("config")
-  public ExperimentalLoggerMatcherAndConfigModel withConfig(ExperimentalLoggerConfigModel config) {
+  public ExperimentalLoggerMatcherAndConfigModel setConfig(ExperimentalLoggerConfigModel config) {
     this.config = config;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMessagingInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMessagingInstrumentationModel.java
@@ -36,7 +36,7 @@ public class ExperimentalMessagingInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalMessagingInstrumentationModel withSemconv(
+  public ExperimentalMessagingInstrumentationModel setSemconv(
       ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterConfigModel.java
@@ -30,7 +30,7 @@ public class ExperimentalMeterConfigModel {
   }
 
   @JsonProperty("enabled")
-  public ExperimentalMeterConfigModel withEnabled(Boolean enabled) {
+  public ExperimentalMeterConfigModel setEnabled(Boolean enabled) {
     this.enabled = enabled;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterConfiguratorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterConfiguratorModel.java
@@ -33,7 +33,7 @@ public class ExperimentalMeterConfiguratorModel {
   }
 
   @JsonProperty("default_config")
-  public ExperimentalMeterConfiguratorModel withDefaultConfig(
+  public ExperimentalMeterConfiguratorModel setDefaultConfig(
       ExperimentalMeterConfigModel defaultConfig) {
     this.defaultConfig = defaultConfig;
     return this;
@@ -51,7 +51,7 @@ public class ExperimentalMeterConfiguratorModel {
   }
 
   @JsonProperty("meters")
-  public ExperimentalMeterConfiguratorModel withMeters(
+  public ExperimentalMeterConfiguratorModel setMeters(
       List<ExperimentalMeterMatcherAndConfigModel> meters) {
     this.meters = meters;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterMatcherAndConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalMeterMatcherAndConfigModel.java
@@ -36,7 +36,7 @@ public class ExperimentalMeterMatcherAndConfigModel {
   }
 
   @JsonProperty("name")
-  public ExperimentalMeterMatcherAndConfigModel withName(String name) {
+  public ExperimentalMeterMatcherAndConfigModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -53,7 +53,7 @@ public class ExperimentalMeterMatcherAndConfigModel {
   }
 
   @JsonProperty("config")
-  public ExperimentalMeterMatcherAndConfigModel withConfig(ExperimentalMeterConfigModel config) {
+  public ExperimentalMeterMatcherAndConfigModel setConfig(ExperimentalMeterConfigModel config) {
     this.config = config;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalOtlpFileExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalOtlpFileExporterModel.java
@@ -32,7 +32,7 @@ public class ExperimentalOtlpFileExporterModel {
   }
 
   @JsonProperty("output_stream")
-  public ExperimentalOtlpFileExporterModel withOutputStream(String outputStream) {
+  public ExperimentalOtlpFileExporterModel setOutputStream(String outputStream) {
     this.outputStream = outputStream;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalOtlpFileMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalOtlpFileMetricExporterModel.java
@@ -36,7 +36,7 @@ public class ExperimentalOtlpFileMetricExporterModel {
   }
 
   @JsonProperty("output_stream")
-  public ExperimentalOtlpFileMetricExporterModel withOutputStream(String outputStream) {
+  public ExperimentalOtlpFileMetricExporterModel setOutputStream(String outputStream) {
     this.outputStream = outputStream;
     return this;
   }
@@ -63,7 +63,7 @@ public class ExperimentalOtlpFileMetricExporterModel {
   }
 
   @JsonProperty("temporality_preference")
-  public ExperimentalOtlpFileMetricExporterModel withTemporalityPreference(
+  public ExperimentalOtlpFileMetricExporterModel setTemporalityPreference(
       ExporterTemporalityPreferenceModel temporalityPreference) {
     this.temporalityPreference = temporalityPreference;
     return this;
@@ -89,7 +89,7 @@ public class ExperimentalOtlpFileMetricExporterModel {
   }
 
   @JsonProperty("default_histogram_aggregation")
-  public ExperimentalOtlpFileMetricExporterModel withDefaultHistogramAggregation(
+  public ExperimentalOtlpFileMetricExporterModel setDefaultHistogramAggregation(
       ExporterDefaultHistogramAggregationModel defaultHistogramAggregation) {
     this.defaultHistogramAggregation = defaultHistogramAggregation;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalProbabilitySamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalProbabilitySamplerModel.java
@@ -30,7 +30,7 @@ public class ExperimentalProbabilitySamplerModel {
   }
 
   @JsonProperty("ratio")
-  public ExperimentalProbabilitySamplerModel withRatio(Double ratio) {
+  public ExperimentalProbabilitySamplerModel setRatio(Double ratio) {
     this.ratio = ratio;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalPrometheusMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalPrometheusMetricExporterModel.java
@@ -43,7 +43,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("host")
-  public ExperimentalPrometheusMetricExporterModel withHost(String host) {
+  public ExperimentalPrometheusMetricExporterModel setHost(String host) {
     this.host = host;
     return this;
   }
@@ -60,7 +60,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("port")
-  public ExperimentalPrometheusMetricExporterModel withPort(Integer port) {
+  public ExperimentalPrometheusMetricExporterModel setPort(Integer port) {
     this.port = port;
     return this;
   }
@@ -77,7 +77,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("scope_info_enabled")
-  public ExperimentalPrometheusMetricExporterModel withScopeInfoEnabled(Boolean scopeInfoEnabled) {
+  public ExperimentalPrometheusMetricExporterModel setScopeInfoEnabled(Boolean scopeInfoEnabled) {
     this.scopeInfoEnabled = scopeInfoEnabled;
     return this;
   }
@@ -94,7 +94,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("target_info_enabled/development")
-  public ExperimentalPrometheusMetricExporterModel withTargetInfoEnabledDevelopment(
+  public ExperimentalPrometheusMetricExporterModel setTargetInfoEnabledDevelopment(
       Boolean targetInfoEnabledDevelopment) {
     this.targetInfoEnabledDevelopment = targetInfoEnabledDevelopment;
     return this;
@@ -113,7 +113,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("resource_constant_labels")
-  public ExperimentalPrometheusMetricExporterModel withResourceConstantLabels(
+  public ExperimentalPrometheusMetricExporterModel setResourceConstantLabels(
       IncludeExcludeModel resourceConstantLabels) {
     this.resourceConstantLabels = resourceConstantLabels;
     return this;
@@ -146,7 +146,7 @@ public class ExperimentalPrometheusMetricExporterModel {
   }
 
   @JsonProperty("translation_strategy")
-  public ExperimentalPrometheusMetricExporterModel withTranslationStrategy(
+  public ExperimentalPrometheusMetricExporterModel setTranslationStrategy(
       ExperimentalPrometheusTranslationStrategyModel translationStrategy) {
     this.translationStrategy = translationStrategy;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectionModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectionModel.java
@@ -33,7 +33,7 @@ public class ExperimentalResourceDetectionModel {
   }
 
   @JsonProperty("attributes")
-  public ExperimentalResourceDetectionModel withAttributes(IncludeExcludeModel attributes) {
+  public ExperimentalResourceDetectionModel setAttributes(IncludeExcludeModel attributes) {
     this.attributes = attributes;
     return this;
   }
@@ -53,7 +53,7 @@ public class ExperimentalResourceDetectionModel {
   }
 
   @JsonProperty("detectors")
-  public ExperimentalResourceDetectionModel withDetectors(
+  public ExperimentalResourceDetectionModel setDetectors(
       List<ExperimentalResourceDetectorModel> detectors) {
     this.detectors = detectors;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectorModel.java
@@ -39,7 +39,7 @@ public class ExperimentalResourceDetectorModel {
   }
 
   @JsonProperty("container")
-  public ExperimentalResourceDetectorModel withContainer(
+  public ExperimentalResourceDetectorModel setContainer(
       ExperimentalContainerResourceDetectorModel container) {
     this.container = container;
     return this;
@@ -57,7 +57,7 @@ public class ExperimentalResourceDetectorModel {
   }
 
   @JsonProperty("host")
-  public ExperimentalResourceDetectorModel withHost(ExperimentalHostResourceDetectorModel host) {
+  public ExperimentalResourceDetectorModel setHost(ExperimentalHostResourceDetectorModel host) {
     this.host = host;
     return this;
   }
@@ -74,7 +74,7 @@ public class ExperimentalResourceDetectorModel {
   }
 
   @JsonProperty("process")
-  public ExperimentalResourceDetectorModel withProcess(
+  public ExperimentalResourceDetectorModel setProcess(
       ExperimentalProcessResourceDetectorModel process) {
     this.process = process;
     return this;
@@ -93,7 +93,7 @@ public class ExperimentalResourceDetectorModel {
   }
 
   @JsonProperty("service")
-  public ExperimentalResourceDetectorModel withService(
+  public ExperimentalResourceDetectorModel setService(
       ExperimentalServiceResourceDetectorModel service) {
     this.service = service;
     return this;
@@ -105,7 +105,7 @@ public class ExperimentalResourceDetectorModel {
   }
 
   @JsonAnySetter
-  public ExperimentalResourceDetectorModel withAdditionalProperty(
+  public ExperimentalResourceDetectorModel setAdditionalProperty(
       String name, ExperimentalResourceDetectorPropertyModel value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectorPropertyModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalResourceDetectorPropertyModel.java
@@ -27,7 +27,7 @@ public class ExperimentalResourceDetectorPropertyModel {
   }
 
   @JsonAnySetter
-  public ExperimentalResourceDetectorPropertyModel withAdditionalProperty(
+  public ExperimentalResourceDetectorPropertyModel setAdditionalProperty(
       String name, Object value) {
     this.additionalProperties.put(name, value);
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalRpcInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalRpcInstrumentationModel.java
@@ -36,7 +36,7 @@ public class ExperimentalRpcInstrumentationModel {
   }
 
   @JsonProperty("semconv")
-  public ExperimentalRpcInstrumentationModel withSemconv(ExperimentalSemconvConfigModel semconv) {
+  public ExperimentalRpcInstrumentationModel setSemconv(ExperimentalSemconvConfigModel semconv) {
     this.semconv = semconv;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalSanitizationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalSanitizationModel.java
@@ -30,7 +30,7 @@ public class ExperimentalSanitizationModel {
   }
 
   @JsonProperty("url")
-  public ExperimentalSanitizationModel withUrl(ExperimentalUrlSanitizationModel url) {
+  public ExperimentalSanitizationModel setUrl(ExperimentalUrlSanitizationModel url) {
     this.url = url;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalSemconvConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalSemconvConfigModel.java
@@ -33,7 +33,7 @@ public class ExperimentalSemconvConfigModel {
   }
 
   @JsonProperty("version")
-  public ExperimentalSemconvConfigModel withVersion(Integer version) {
+  public ExperimentalSemconvConfigModel setVersion(Integer version) {
     this.version = version;
     return this;
   }
@@ -51,7 +51,7 @@ public class ExperimentalSemconvConfigModel {
   }
 
   @JsonProperty("experimental")
-  public ExperimentalSemconvConfigModel withExperimental(Boolean experimental) {
+  public ExperimentalSemconvConfigModel setExperimental(Boolean experimental) {
     this.experimental = experimental;
     return this;
   }
@@ -76,7 +76,7 @@ public class ExperimentalSemconvConfigModel {
   }
 
   @JsonProperty("dual_emit")
-  public ExperimentalSemconvConfigModel withDualEmit(Boolean dualEmit) {
+  public ExperimentalSemconvConfigModel setDualEmit(Boolean dualEmit) {
     this.dualEmit = dualEmit;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerConfigModel.java
@@ -30,7 +30,7 @@ public class ExperimentalTracerConfigModel {
   }
 
   @JsonProperty("enabled")
-  public ExperimentalTracerConfigModel withEnabled(Boolean enabled) {
+  public ExperimentalTracerConfigModel setEnabled(Boolean enabled) {
     this.enabled = enabled;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerConfiguratorModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerConfiguratorModel.java
@@ -33,7 +33,7 @@ public class ExperimentalTracerConfiguratorModel {
   }
 
   @JsonProperty("default_config")
-  public ExperimentalTracerConfiguratorModel withDefaultConfig(
+  public ExperimentalTracerConfiguratorModel setDefaultConfig(
       ExperimentalTracerConfigModel defaultConfig) {
     this.defaultConfig = defaultConfig;
     return this;
@@ -51,7 +51,7 @@ public class ExperimentalTracerConfiguratorModel {
   }
 
   @JsonProperty("tracers")
-  public ExperimentalTracerConfiguratorModel withTracers(
+  public ExperimentalTracerConfiguratorModel setTracers(
       List<ExperimentalTracerMatcherAndConfigModel> tracers) {
     this.tracers = tracers;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerMatcherAndConfigModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalTracerMatcherAndConfigModel.java
@@ -36,7 +36,7 @@ public class ExperimentalTracerMatcherAndConfigModel {
   }
 
   @JsonProperty("name")
-  public ExperimentalTracerMatcherAndConfigModel withName(String name) {
+  public ExperimentalTracerMatcherAndConfigModel setName(String name) {
     this.name = name;
     return this;
   }
@@ -53,7 +53,7 @@ public class ExperimentalTracerMatcherAndConfigModel {
   }
 
   @JsonProperty("config")
-  public ExperimentalTracerMatcherAndConfigModel withConfig(ExperimentalTracerConfigModel config) {
+  public ExperimentalTracerMatcherAndConfigModel setConfig(ExperimentalTracerConfigModel config) {
     this.config = config;
     return this;
   }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalUrlSanitizationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalUrlSanitizationModel.java
@@ -41,7 +41,7 @@ public class ExperimentalUrlSanitizationModel {
   }
 
   @JsonProperty("sensitive_query_parameters")
-  public ExperimentalUrlSanitizationModel withSensitiveQueryParameters(
+  public ExperimentalUrlSanitizationModel setSensitiveQueryParameters(
       List<String> sensitiveQueryParameters) {
     this.sensitiveQueryParameters = sensitiveQueryParameters;
     return this;

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LogRecordExporterModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LogRecordExporterModelAccessor.java
@@ -38,10 +38,10 @@ public final class LogRecordExporterModelAccessor {
         OTLP_FILE, model.getExtensionProperties(), ExperimentalOtlpFileExporterModel.class);
   }
 
-  public static LogRecordExporterModel withOtlpFile(
+  public static LogRecordExporterModel setOtlpFile(
       LogRecordExporterModel model, ExperimentalOtlpFileExporterModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(OTLP_FILE, value);
+    model.setExtensionProperty(OTLP_FILE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LogRecordProcessorModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LogRecordProcessorModelAccessor.java
@@ -43,11 +43,11 @@ public final class LogRecordProcessorModelAccessor {
         ExperimentalEventToSpanEventBridgeLogRecordProcessorModel.class);
   }
 
-  public static LogRecordProcessorModel withEventToSpanEventBridge(
+  public static LogRecordProcessorModel setEventToSpanEventBridge(
       LogRecordProcessorModel model,
       ExperimentalEventToSpanEventBridgeLogRecordProcessorModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(EVENT_TO_SPAN_EVENT_BRIDGE, value);
+    model.setExtensionProperty(EVENT_TO_SPAN_EVENT_BRIDGE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LoggerProviderModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/LoggerProviderModelAccessor.java
@@ -41,10 +41,10 @@ public final class LoggerProviderModelAccessor {
         ExperimentalLoggerConfiguratorModel.class);
   }
 
-  public static LoggerProviderModel withLoggerConfigurator(
+  public static LoggerProviderModel setLoggerConfigurator(
       LoggerProviderModel model, ExperimentalLoggerConfiguratorModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(LOGGER_CONFIGURATOR, value);
+    model.setExtensionProperty(LOGGER_CONFIGURATOR, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/MeterProviderModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/MeterProviderModelAccessor.java
@@ -40,10 +40,10 @@ public final class MeterProviderModelAccessor {
         ExperimentalMeterConfiguratorModel.class);
   }
 
-  public static MeterProviderModel withMeterConfigurator(
+  public static MeterProviderModel setMeterConfigurator(
       MeterProviderModel model, ExperimentalMeterConfiguratorModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(METER_CONFIGURATOR, value);
+    model.setExtensionProperty(METER_CONFIGURATOR, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/OpenTelemetryConfigurationModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/OpenTelemetryConfigurationModelAccessor.java
@@ -39,10 +39,10 @@ public final class OpenTelemetryConfigurationModelAccessor {
         INSTRUMENTATION, model.getExtensionProperties(), ExperimentalInstrumentationModel.class);
   }
 
-  public static OpenTelemetryConfigurationModel withInstrumentation(
+  public static OpenTelemetryConfigurationModel setInstrumentation(
       OpenTelemetryConfigurationModel model, ExperimentalInstrumentationModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(INSTRUMENTATION, value);
+    model.setExtensionProperty(INSTRUMENTATION, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PeriodicMetricReaderModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PeriodicMetricReaderModelAccessor.java
@@ -38,10 +38,10 @@ public final class PeriodicMetricReaderModelAccessor {
         MAX_EXPORT_BATCH_SIZE, model.getExtensionProperties(), Integer.class);
   }
 
-  public static PeriodicMetricReaderModel withMaxExportBatchSize(
+  public static PeriodicMetricReaderModel setMaxExportBatchSize(
       PeriodicMetricReaderModel model, Integer value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(MAX_EXPORT_BATCH_SIZE, value);
+    model.setExtensionProperty(MAX_EXPORT_BATCH_SIZE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PullMetricExporterModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PullMetricExporterModelAccessor.java
@@ -41,10 +41,10 @@ public final class PullMetricExporterModelAccessor {
         ExperimentalPrometheusMetricExporterModel.class);
   }
 
-  public static PullMetricExporterModel withPrometheus(
+  public static PullMetricExporterModel setPrometheus(
       PullMetricExporterModel model, ExperimentalPrometheusMetricExporterModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(PROMETHEUS, value);
+    model.setExtensionProperty(PROMETHEUS, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PushMetricExporterModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/PushMetricExporterModelAccessor.java
@@ -38,10 +38,10 @@ public final class PushMetricExporterModelAccessor {
         OTLP_FILE, model.getExtensionProperties(), ExperimentalOtlpFileMetricExporterModel.class);
   }
 
-  public static PushMetricExporterModel withOtlpFile(
+  public static PushMetricExporterModel setOtlpFile(
       PushMetricExporterModel model, ExperimentalOtlpFileMetricExporterModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(OTLP_FILE, value);
+    model.setExtensionProperty(OTLP_FILE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ResourceModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ResourceModelAccessor.java
@@ -38,10 +38,10 @@ public final class ResourceModelAccessor {
         DETECTION, model.getExtensionProperties(), ExperimentalResourceDetectionModel.class);
   }
 
-  public static ResourceModel withDetection(
+  public static ResourceModel setDetection(
       ResourceModel model, ExperimentalResourceDetectionModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(DETECTION, value);
+    model.setExtensionProperty(DETECTION, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/SamplerModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/SamplerModelAccessor.java
@@ -42,10 +42,10 @@ public final class SamplerModelAccessor {
         COMPOSITE, model.getExtensionProperties(), ExperimentalComposableSamplerModel.class);
   }
 
-  public static SamplerModel withComposite(
+  public static SamplerModel setComposite(
       SamplerModel model, ExperimentalComposableSamplerModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(COMPOSITE, value);
+    model.setExtensionProperty(COMPOSITE, value);
     return model;
   }
 
@@ -55,10 +55,10 @@ public final class SamplerModelAccessor {
         JAEGER_REMOTE, model.getExtensionProperties(), ExperimentalJaegerRemoteSamplerModel.class);
   }
 
-  public static SamplerModel withJaegerRemote(
+  public static SamplerModel setJaegerRemote(
       SamplerModel model, ExperimentalJaegerRemoteSamplerModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(JAEGER_REMOTE, value);
+    model.setExtensionProperty(JAEGER_REMOTE, value);
     return model;
   }
 
@@ -68,10 +68,10 @@ public final class SamplerModelAccessor {
         PROBABILITY, model.getExtensionProperties(), ExperimentalProbabilitySamplerModel.class);
   }
 
-  public static SamplerModel withProbability(
+  public static SamplerModel setProbability(
       SamplerModel model, ExperimentalProbabilitySamplerModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(PROBABILITY, value);
+    model.setExtensionProperty(PROBABILITY, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/SpanExporterModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/SpanExporterModelAccessor.java
@@ -38,10 +38,10 @@ public final class SpanExporterModelAccessor {
         OTLP_FILE, model.getExtensionProperties(), ExperimentalOtlpFileExporterModel.class);
   }
 
-  public static SpanExporterModel withOtlpFile(
+  public static SpanExporterModel setOtlpFile(
       SpanExporterModel model, ExperimentalOtlpFileExporterModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(OTLP_FILE, value);
+    model.setExtensionProperty(OTLP_FILE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/TracerProviderModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/TracerProviderModelAccessor.java
@@ -41,10 +41,10 @@ public final class TracerProviderModelAccessor {
         ExperimentalTracerConfiguratorModel.class);
   }
 
-  public static TracerProviderModel withTracerConfigurator(
+  public static TracerProviderModel setTracerConfigurator(
       TracerProviderModel model, ExperimentalTracerConfiguratorModel value) {
     requireNonNull(value, "value");
-    model.withExtensionProperty(TRACER_CONFIGURATOR, value);
+    model.setExtensionProperty(TRACER_CONFIGURATOR, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/AggregationFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/AggregationFactoryTest.java
@@ -37,28 +37,26 @@ class AggregationFactoryTest {
     return Stream.of(
         Arguments.argumentSet("default", new AggregationModel(), Aggregation.defaultAggregation()),
         Arguments.argumentSet(
-            "drop",
-            new AggregationModel().withDrop(new DropAggregationModel()),
-            Aggregation.drop()),
+            "drop", new AggregationModel().setDrop(new DropAggregationModel()), Aggregation.drop()),
         Arguments.argumentSet(
-            "sum", new AggregationModel().withSum(new SumAggregationModel()), Aggregation.sum()),
+            "sum", new AggregationModel().setSum(new SumAggregationModel()), Aggregation.sum()),
         Arguments.argumentSet(
             "last_Value",
-            new AggregationModel().withLastValue(new LastValueAggregationModel()),
+            new AggregationModel().setLastValue(new LastValueAggregationModel()),
             Aggregation.lastValue()),
         Arguments.argumentSet(
             "base2_exponential_bucket_histogram defaults",
             new AggregationModel()
-                .withBase2ExponentialBucketHistogram(
+                .setBase2ExponentialBucketHistogram(
                     new Base2ExponentialBucketHistogramAggregationModel()),
             Aggregation.base2ExponentialBucketHistogram()),
         Arguments.argumentSet(
             "base2_exponential_bucket_histogram with options",
             new AggregationModel()
-                .withBase2ExponentialBucketHistogram(
+                .setBase2ExponentialBucketHistogram(
                     new Base2ExponentialBucketHistogramAggregationModel()
-                        .withMaxSize(2)
-                        .withMaxScale(2)),
+                        .setMaxSize(2)
+                        .setMaxScale(2)),
             Aggregation.base2ExponentialBucketHistogram(
                 Base2ExponentialHistogramOptions.builder()
                     .setMaxBuckets(2)
@@ -67,15 +65,15 @@ class AggregationFactoryTest {
         Arguments.argumentSet(
             "explicit_bucket_histogram null boundaries",
             new AggregationModel()
-                .withExplicitBucketHistogram(
-                    new ExplicitBucketHistogramAggregationModel().withBoundaries(null)),
+                .setExplicitBucketHistogram(
+                    new ExplicitBucketHistogramAggregationModel().setBoundaries(null)),
             Aggregation.explicitBucketHistogram()),
         Arguments.argumentSet(
             "explicit_bucket_histogram with boundaries",
             new AggregationModel()
-                .withExplicitBucketHistogram(
+                .setExplicitBucketHistogram(
                     new ExplicitBucketHistogramAggregationModel()
-                        .withBoundaries(Arrays.asList(1.0, 2.0))),
+                        .setBoundaries(Arrays.asList(1.0, 2.0))),
             Aggregation.explicitBucketHistogram(
                 ExplicitBucketHistogramOptions.builder()
                     .setBucketBoundaries(Arrays.asList(1.0, 2.0))
@@ -83,10 +81,10 @@ class AggregationFactoryTest {
         Arguments.argumentSet(
             "explicit_bucket_histogram record_min_max true",
             new AggregationModel()
-                .withExplicitBucketHistogram(
+                .setExplicitBucketHistogram(
                     new ExplicitBucketHistogramAggregationModel()
-                        .withBoundaries(Arrays.asList(1.0, 2.0))
-                        .withRecordMinMax(true)),
+                        .setBoundaries(Arrays.asList(1.0, 2.0))
+                        .setRecordMinMax(true)),
             Aggregation.explicitBucketHistogram(
                 ExplicitBucketHistogramOptions.builder()
                     .setBucketBoundaries(Arrays.asList(1.0, 2.0))
@@ -95,10 +93,10 @@ class AggregationFactoryTest {
         Arguments.argumentSet(
             "explicit_bucket_histogram record_min_max false",
             new AggregationModel()
-                .withExplicitBucketHistogram(
+                .setExplicitBucketHistogram(
                     new ExplicitBucketHistogramAggregationModel()
-                        .withBoundaries(Arrays.asList(1.0, 2.0))
-                        .withRecordMinMax(false)),
+                        .setBoundaries(Arrays.asList(1.0, 2.0))
+                        .setRecordMinMax(false)),
             Aggregation.explicitBucketHistogram(
                 ExplicitBucketHistogramOptions.builder()
                     .setBucketBoundaries(Arrays.asList(1.0, 2.0))
@@ -107,20 +105,20 @@ class AggregationFactoryTest {
         Arguments.argumentSet(
             "explicit_bucket_histogram null boundaries record_min_max false",
             new AggregationModel()
-                .withExplicitBucketHistogram(
+                .setExplicitBucketHistogram(
                     new ExplicitBucketHistogramAggregationModel()
-                        .withBoundaries(null)
-                        .withRecordMinMax(false)),
+                        .setBoundaries(null)
+                        .setRecordMinMax(false)),
             Aggregation.explicitBucketHistogram(
                 ExplicitBucketHistogramOptions.builder().setRecordMinMax(false).build())),
         Arguments.argumentSet(
             "base2_exponential_bucket_histogram record_min_max true",
             new AggregationModel()
-                .withBase2ExponentialBucketHistogram(
+                .setBase2ExponentialBucketHistogram(
                     new Base2ExponentialBucketHistogramAggregationModel()
-                        .withMaxSize(2)
-                        .withMaxScale(2)
-                        .withRecordMinMax(true)),
+                        .setMaxSize(2)
+                        .setMaxScale(2)
+                        .setRecordMinMax(true)),
             Aggregation.base2ExponentialBucketHistogram(
                 Base2ExponentialHistogramOptions.builder()
                     .setMaxBuckets(2)
@@ -130,11 +128,11 @@ class AggregationFactoryTest {
         Arguments.argumentSet(
             "base2_exponential_bucket_histogram record_min_max false",
             new AggregationModel()
-                .withBase2ExponentialBucketHistogram(
+                .setBase2ExponentialBucketHistogram(
                     new Base2ExponentialBucketHistogramAggregationModel()
-                        .withMaxSize(2)
-                        .withMaxScale(2)
-                        .withRecordMinMax(false)),
+                        .setMaxSize(2)
+                        .setMaxScale(2)
+                        .setRecordMinMax(false)),
             Aggregation.base2ExponentialBucketHistogram(
                 Base2ExponentialHistogramOptions.builder()
                     .setMaxBuckets(2)

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/AttributeListFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/AttributeListFactoryTest.java
@@ -39,28 +39,28 @@ class AttributeListFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "null value",
-            Collections.singletonList(new AttributeNameValueModel().withName("key")),
+            Collections.singletonList(new AttributeNameValueModel().setName("key")),
             "attribute value is required but is null"),
         Arguments.argumentSet(
             "wrong type string",
             Collections.singletonList(
-                new AttributeNameValueModel().withName("key").withValue(new Object())),
+                new AttributeNameValueModel().setName("key").setValue(new Object())),
             "Error processing attribute with name \"key\": value did not match type STRING"),
         Arguments.argumentSet(
             "wrong type int list",
             Collections.singletonList(
                 new AttributeNameValueModel()
-                    .withName("key")
-                    .withType(AttributeTypeModel.INT)
-                    .withValue(Arrays.asList(1L, 1))),
+                    .setName("key")
+                    .setType(AttributeTypeModel.INT)
+                    .setValue(Arrays.asList(1L, 1))),
             "Error processing attribute with name \"key\": value did not match type INT"),
         Arguments.argumentSet(
             "wrong type int boolean",
             Collections.singletonList(
                 new AttributeNameValueModel()
-                    .withName("key")
-                    .withType(AttributeTypeModel.INT)
-                    .withValue(true)),
+                    .setName("key")
+                    .setType(AttributeTypeModel.INT)
+                    .setValue(true)),
             "Error processing attribute with name \"key\": value did not match type INT"));
   }
 
@@ -87,56 +87,56 @@ class AttributeListFactoryTest {
                 .create(
                     Arrays.asList(
                         new AttributeNameValueModel()
-                            .withName("service.name")
-                            .withValue("my-service"),
+                            .setName("service.name")
+                            .setValue("my-service"),
                         new AttributeNameValueModel()
-                            .withName("strKey")
-                            .withValue("val")
-                            .withType(AttributeTypeModel.STRING),
+                            .setName("strKey")
+                            .setValue("val")
+                            .setType(AttributeTypeModel.STRING),
                         new AttributeNameValueModel()
-                            .withName("longKey")
-                            .withValue(1L)
-                            .withType(AttributeTypeModel.INT),
+                            .setName("longKey")
+                            .setValue(1L)
+                            .setType(AttributeTypeModel.INT),
                         new AttributeNameValueModel()
-                            .withName("intKey")
-                            .withValue(2)
-                            .withType(AttributeTypeModel.INT),
+                            .setName("intKey")
+                            .setValue(2)
+                            .setType(AttributeTypeModel.INT),
                         new AttributeNameValueModel()
-                            .withName("doubleKey")
-                            .withValue(1.0d)
-                            .withType(AttributeTypeModel.DOUBLE),
+                            .setName("doubleKey")
+                            .setValue(1.0d)
+                            .setType(AttributeTypeModel.DOUBLE),
                         new AttributeNameValueModel()
-                            .withName("floatKey")
-                            .withValue(2.0f)
-                            .withType(AttributeTypeModel.DOUBLE),
+                            .setName("floatKey")
+                            .setValue(2.0f)
+                            .setType(AttributeTypeModel.DOUBLE),
                         new AttributeNameValueModel()
-                            .withName("boolKey")
-                            .withValue(true)
-                            .withType(AttributeTypeModel.BOOL),
+                            .setName("boolKey")
+                            .setValue(true)
+                            .setType(AttributeTypeModel.BOOL),
                         new AttributeNameValueModel()
-                            .withName("strArrKey")
-                            .withValue(Arrays.asList("val1", "val2"))
-                            .withType(AttributeTypeModel.STRING_ARRAY),
+                            .setName("strArrKey")
+                            .setValue(Arrays.asList("val1", "val2"))
+                            .setType(AttributeTypeModel.STRING_ARRAY),
                         new AttributeNameValueModel()
-                            .withName("longArrKey")
-                            .withValue(Arrays.asList(1L, 2L))
-                            .withType(AttributeTypeModel.INT_ARRAY),
+                            .setName("longArrKey")
+                            .setValue(Arrays.asList(1L, 2L))
+                            .setType(AttributeTypeModel.INT_ARRAY),
                         new AttributeNameValueModel()
-                            .withName("intArrKey")
-                            .withValue(Arrays.asList(1, 2))
-                            .withType(AttributeTypeModel.INT_ARRAY),
+                            .setName("intArrKey")
+                            .setValue(Arrays.asList(1, 2))
+                            .setType(AttributeTypeModel.INT_ARRAY),
                         new AttributeNameValueModel()
-                            .withName("doubleArrKey")
-                            .withValue(Arrays.asList(1.0d, 2.0d))
-                            .withType(AttributeTypeModel.DOUBLE_ARRAY),
+                            .setName("doubleArrKey")
+                            .setValue(Arrays.asList(1.0d, 2.0d))
+                            .setType(AttributeTypeModel.DOUBLE_ARRAY),
                         new AttributeNameValueModel()
-                            .withName("floatArrKey")
-                            .withValue(Arrays.asList(1.0f, 2.0f))
-                            .withType(AttributeTypeModel.DOUBLE_ARRAY),
+                            .setName("floatArrKey")
+                            .setValue(Arrays.asList(1.0f, 2.0f))
+                            .setType(AttributeTypeModel.DOUBLE_ARRAY),
                         new AttributeNameValueModel()
-                            .withName("boolArrKey")
-                            .withValue(Arrays.asList(true, false))
-                            .withType(AttributeTypeModel.BOOL_ARRAY)),
+                            .setName("boolArrKey")
+                            .setValue(Arrays.asList(true, false))
+                            .setType(AttributeTypeModel.BOOL_ARRAY)),
                     mock(DeclarativeConfigContext.class)))
         .isEqualTo(expectedAttributes);
   }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/CardinalityLimitsFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/CardinalityLimitsFactoryTest.java
@@ -39,7 +39,7 @@ class CardinalityLimitsFactoryTest {
             CardinalityLimitSelector.defaultCardinalityLimitSelector()),
         Arguments.argumentSet(
             "default and counter",
-            new CardinalityLimitsModel().withDefault(10).withCounter(1),
+            new CardinalityLimitsModel().setDefault(10).setCounter(1),
             (CardinalityLimitSelector)
                 instrumentType -> {
                   if (instrumentType == InstrumentType.COUNTER) {
@@ -50,13 +50,13 @@ class CardinalityLimitsFactoryTest {
         Arguments.argumentSet(
             "all instrument types",
             new CardinalityLimitsModel()
-                .withCounter(1)
-                .withUpDownCounter(2)
-                .withHistogram(3)
-                .withObservableCounter(4)
-                .withObservableUpDownCounter(5)
-                .withObservableGauge(6)
-                .withGauge(7),
+                .setCounter(1)
+                .setUpDownCounter(2)
+                .setHistogram(3)
+                .setObservableCounter(4)
+                .setObservableUpDownCounter(5)
+                .setObservableGauge(6)
+                .setGauge(7),
             (CardinalityLimitSelector)
                 instrumentType -> {
                   switch (instrumentType) {

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ComposableRuleBasedSamplerFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ComposableRuleBasedSamplerFactoryTest.java
@@ -74,63 +74,63 @@ class ComposableRuleBasedSamplerFactoryTest {
         Arguments.argumentSet(
             "attribute_patterns included empty",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Collections.singletonList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributePatterns(
+                            .setAttributePatterns(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel()
-                                    .withKey("http.path")
-                                    .withIncluded(Collections.emptyList())
-                                    .withExcluded(null))
-                            .withSampler(
+                                    .setKey("http.path")
+                                    .setIncluded(Collections.emptyList())
+                                    .setExcluded(null))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             "included must not be empty"),
         Arguments.argumentSet(
             "attribute_patterns excluded empty",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Collections.singletonList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributePatterns(
+                            .setAttributePatterns(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel()
-                                    .withKey("http.path")
-                                    .withIncluded(null)
-                                    .withExcluded(Collections.emptyList()))
-                            .withSampler(
+                                    .setKey("http.path")
+                                    .setIncluded(null)
+                                    .setExcluded(Collections.emptyList()))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             "excluded must not be empty"),
         Arguments.argumentSet(
             "attribute_values null values",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Collections.singletonList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributeValues(
+                            .setAttributeValues(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel()
-                                    .withKey("http.route")
-                                    .withValues(null))
-                            .withSampler(
+                                    .setKey("http.route")
+                                    .setValues(null))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             ".values is required and must be non-empty"),
         Arguments.argumentSet(
             "attribute_values empty values",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Collections.singletonList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributeValues(
+                            .setAttributeValues(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel()
-                                    .withKey("http.route")
-                                    .withValues(Collections.emptyList()))
-                            .withSampler(
+                                    .setKey("http.route")
+                                    .setValues(Collections.emptyList()))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             ".values is required and must be non-empty"));
   }
@@ -145,16 +145,16 @@ class ComposableRuleBasedSamplerFactoryTest {
         Arguments.argumentSet(
             "attribute_patterns included only",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Collections.singletonList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributePatterns(
+                            .setAttributePatterns(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel()
-                                    .withKey("http.path")
-                                    .withIncluded(Collections.singletonList("/internal/*")))
-                            .withSampler(
+                                    .setKey("http.path")
+                                    .setIncluded(Collections.singletonList("/internal/*")))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             ComposableSampler.ruleBasedBuilder()
                 .add(
@@ -171,41 +171,40 @@ class ComposableRuleBasedSamplerFactoryTest {
         Arguments.argumentSet(
             "full example",
             new ExperimentalComposableRuleBasedSamplerModel()
-                .withRules(
+                .setRules(
                     Arrays.asList(
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributeValues(
+                            .setAttributeValues(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributeValuesModel()
-                                    .withKey("http.route")
-                                    .withValues(Arrays.asList("/healthz", "/livez")))
-                            .withSampler(
+                                    .setKey("http.route")
+                                    .setValues(Arrays.asList("/healthz", "/livez")))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOff(
+                                    .setAlwaysOff(
                                         new ExperimentalComposableAlwaysOffSamplerModel())),
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withAttributePatterns(
+                            .setAttributePatterns(
                                 new ExperimentalComposableRuleBasedSamplerRuleAttributePatternsModel()
-                                    .withKey("http.path")
-                                    .withIncluded(Collections.singletonList("/internal/*"))
-                                    .withExcluded(Collections.singletonList("/internal/special/*")))
-                            .withSampler(
+                                    .setKey("http.path")
+                                    .setIncluded(Collections.singletonList("/internal/*"))
+                                    .setExcluded(Collections.singletonList("/internal/special/*")))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
-                                        new ExperimentalComposableAlwaysOnSamplerModel())),
+                                    .setAlwaysOn(new ExperimentalComposableAlwaysOnSamplerModel())),
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withParent(Collections.singletonList(ExperimentalSpanParentModel.NONE))
-                            .withSpanKinds(Collections.singletonList(SpanKindModel.CLIENT))
-                            .withSampler(
+                            .setParent(Collections.singletonList(ExperimentalSpanParentModel.NONE))
+                            .setSpanKinds(Collections.singletonList(SpanKindModel.CLIENT))
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withProbability(
+                                    .setProbability(
                                         new ExperimentalComposableProbabilitySamplerModel()
-                                            .withRatio(0.05))),
+                                            .setRatio(0.05))),
                         new ExperimentalComposableRuleBasedSamplerRuleModel()
-                            .withSampler(
+                            .setSampler(
                                 new ExperimentalComposableSamplerModel()
-                                    .withProbability(
+                                    .setProbability(
                                         new ExperimentalComposableProbabilitySamplerModel()
-                                            .withRatio(0.05))))),
+                                            .setRatio(0.05))))),
             ComposableSampler.ruleBasedBuilder()
                 .add(
                     new DeclarativeConfigSamplingPredicate(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
@@ -170,12 +170,12 @@ class DeclarativeConfigurationCreateTest {
   @Test
   void create_ModelCustomizer() {
     OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
-    model.withFileFormat("1.1");
-    model.withTracerProvider(
+    model.setFileFormat("1.1");
+    model.setTracerProvider(
         new TracerProviderModel()
-            .withProcessors(
+            .setProcessors(
                 Collections.singletonList(
-                    new SpanProcessorModel().withExtensionProperty("test", null))));
+                    new SpanProcessorModel().setExtensionProperty("test", null))));
     ExtendedOpenTelemetrySdk sdk =
         DeclarativeConfiguration.create(
                 model,

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationParseTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationParseTest.java
@@ -128,12 +128,12 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .withAttributeLimits(new AttributeLimitsModel())
-                .withTracerProvider(
+                .setAttributeLimits(new AttributeLimitsModel())
+                .setTracerProvider(
                     new TracerProviderModel()
-                        .withSampler(
+                        .setSampler(
                             new SamplerModel()
-                                .withTraceIdRatioBased(new TraceIdRatioBasedSamplerModel()))));
+                                .setTraceIdRatioBased(new TraceIdRatioBasedSamplerModel()))));
   }
 
   @Test
@@ -153,8 +153,8 @@ class DeclarativeConfigurationParseTest {
     Assertions.assertNotNull(model.getResource());
     assertThat(model.getResource().getAttributes())
         .containsExactly(
-            new AttributeNameValueModel().withName("single_quote").withValue("\"single\""),
-            new AttributeNameValueModel().withName("double_quote").withValue("\"double\""));
+            new AttributeNameValueModel().setName("single_quote").setValue("\"single\""),
+            new AttributeNameValueModel().setName("double_quote").setValue("\"double\""));
   }
 
   @ParameterizedTest
@@ -472,27 +472,26 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .withFileFormat("1.0")
-                .withTracerProvider(
+                .setFileFormat("1.0")
+                .setTracerProvider(
                     new TracerProviderModel()
-                        .withProcessors(
+                        .setProcessors(
                             Arrays.asList(
                                 new SpanProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchSpanProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new SpanExporterModel()
-                                                    .withOtlpHttp(
+                                                    .setOtlpHttp(
                                                         new OtlpHttpExporterModel()
-                                                            .withEndpoint(
+                                                            .setEndpoint(
                                                                 "http://collector:4317")))),
                                 new SpanProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchSpanProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new SpanExporterModel()
-                                                    .withOtlpHttp(
-                                                        new OtlpHttpExporterModel())))))));
+                                                    .setOtlpHttp(new OtlpHttpExporterModel())))))));
   }
 
   @Test
@@ -519,27 +518,26 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .withFileFormat("1.0")
-                .withTracerProvider(
+                .setFileFormat("1.0")
+                .setTracerProvider(
                     new TracerProviderModel()
-                        .withProcessors(
+                        .setProcessors(
                             Arrays.asList(
                                 new SpanProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchSpanProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new SpanExporterModel()
-                                                    .withOtlpHttp(
+                                                    .setOtlpHttp(
                                                         new OtlpHttpExporterModel()
-                                                            .withEndpoint(
+                                                            .setEndpoint(
                                                                 "http://collector:4318")))),
                                 new SpanProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchSpanProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new SpanExporterModel()
-                                                    .withOtlpHttp(
-                                                        new OtlpHttpExporterModel())))))));
+                                                    .setOtlpHttp(new OtlpHttpExporterModel())))))));
   }
 
   @Test
@@ -564,19 +562,19 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .withFileFormat("1.0")
-                .withResource(
+                .setFileFormat("1.0")
+                .setResource(
                     new ResourceModel()
-                        .withAttributes(
+                        .setAttributes(
                             Arrays.asList(
                                 new AttributeNameValueModel()
-                                    .withName("service.name")
-                                    .withValue("my-service"),
+                                    .setName("service.name")
+                                    .setValue("my-service"),
                                 new AttributeNameValueModel()
-                                    .withName("service.version")
-                                    .withValue("1.2.3"),
+                                    .setName("service.version")
+                                    .setValue("1.2.3"),
                                 new AttributeNameValueModel()
-                                    .withName("deployment.environment")
-                                    .withValue("production")))));
+                                    .setName("deployment.environment")
+                                    .setValue("production")))));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ExtensionPropertyUtilTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ExtensionPropertyUtilTest.java
@@ -123,7 +123,7 @@ class ExtensionPropertyUtilTest {
   @Test
   void stableGetter_returnsGraduatedValue_fromExtensionPropertiesFallback() {
     LoggerProviderModel model = new LoggerProviderModel();
-    model.withExtensionProperty("limits/development", new LinkedHashMap<>());
+    model.setExtensionProperty("limits/development", new LinkedHashMap<>());
 
     assertThat(model.getLimits()).isNotNull().isInstanceOf(LogRecordLimitsModel.class);
   }
@@ -132,9 +132,9 @@ class ExtensionPropertyUtilTest {
   void graduatedValue_isEqualToDirectlySetValue() {
     LogRecordLimitsModel limits = new LogRecordLimitsModel();
 
-    LoggerProviderModel viaStableSetter = new LoggerProviderModel().withLimits(limits);
+    LoggerProviderModel viaStableSetter = new LoggerProviderModel().setLimits(limits);
     LoggerProviderModel viaGraduatedKey = new LoggerProviderModel();
-    viaGraduatedKey.withExtensionProperty("limits/development", limits);
+    viaGraduatedKey.setExtensionProperty("limits/development", limits);
 
     assertThat(viaStableSetter.getLimits()).isEqualTo(viaGraduatedKey.getLimits());
     assertThat(viaStableSetter).isEqualTo(viaGraduatedKey);

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/IdGeneratorFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/IdGeneratorFactoryTest.java
@@ -47,11 +47,11 @@ class IdGeneratorFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "random id generator",
-            new IdGeneratorModel().withRandom(new RandomIdGeneratorModel()),
+            new IdGeneratorModel().setRandom(new RandomIdGeneratorModel()),
             IdGenerator.random()),
         Arguments.argumentSet(
             "SPI id generator",
-            new IdGeneratorModel().withExtensionProperty("test", null),
+            new IdGeneratorModel().setExtensionProperty("test", null),
             IdGeneratorComponentProvider.TestIdGenerator.create()));
   }
 
@@ -68,7 +68,7 @@ class IdGeneratorFactoryTest {
         Arguments.argumentSet(
             "unknown SPI id generator",
             new IdGeneratorModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value")),
             "No component provider detected for io.opentelemetry.sdk.trace.IdGenerator with name \"unknown_key\"."));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/IncludeExcludeFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/IncludeExcludeFactoryTest.java
@@ -36,23 +36,23 @@ class IncludeExcludeFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "both null",
-            new IncludeExcludeModel().withIncluded(null).withExcluded(null),
+            new IncludeExcludeModel().setIncluded(null).setExcluded(null),
             IncludeExcludePredicate.createPatternMatching(null, null)),
         Arguments.argumentSet(
             "included present excluded null",
-            new IncludeExcludeModel().withIncluded(Arrays.asList("foo", "bar")).withExcluded(null),
+            new IncludeExcludeModel().setIncluded(Arrays.asList("foo", "bar")).setExcluded(null),
             IncludeExcludePredicate.createPatternMatching(Arrays.asList("foo", "bar"), null)),
         Arguments.argumentSet(
             "included null excluded present",
             new IncludeExcludeModel()
-                .withIncluded(null)
-                .withExcluded(Collections.singletonList("baz")),
+                .setIncluded(null)
+                .setExcluded(Collections.singletonList("baz")),
             IncludeExcludePredicate.createPatternMatching(null, Collections.singletonList("baz"))),
         Arguments.argumentSet(
             "both present",
             new IncludeExcludeModel()
-                .withIncluded(Arrays.asList("foo", "bar"))
-                .withExcluded(Collections.singletonList("baz")),
+                .setIncluded(Arrays.asList("foo", "bar"))
+                .setExcluded(Collections.singletonList("baz")),
             IncludeExcludePredicate.createPatternMatching(
                 Arrays.asList("foo", "bar"), Collections.singletonList("baz"))));
   }
@@ -69,11 +69,11 @@ class IncludeExcludeFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "included empty",
-            new IncludeExcludeModel().withIncluded(Collections.emptyList()).withExcluded(null),
+            new IncludeExcludeModel().setIncluded(Collections.emptyList()).setExcluded(null),
             "included must not be empty"),
         Arguments.argumentSet(
             "excluded empty",
-            new IncludeExcludeModel().withIncluded(null).withExcluded(Collections.emptyList()),
+            new IncludeExcludeModel().setIncluded(null).setExcluded(Collections.emptyList()),
             "excluded must not be empty"));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/InstrumentSelectorFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/InstrumentSelectorFactoryTest.java
@@ -34,12 +34,12 @@ class InstrumentSelectorFactoryTest {
             InstrumentSelectorFactory.getInstance()
                 .create(
                     new ViewSelectorModel()
-                        .withInstrumentName("instrument-name")
-                        .withInstrumentType(InstrumentTypeModel.COUNTER)
-                        .withUnit("ms")
-                        .withMeterName("meter-name")
-                        .withMeterSchemaUrl("https://opentelemetry.io/schemas/1.16.0")
-                        .withMeterVersion("1.0.0"),
+                        .setInstrumentName("instrument-name")
+                        .setInstrumentType(InstrumentTypeModel.COUNTER)
+                        .setUnit("ms")
+                        .setMeterName("meter-name")
+                        .setMeterSchemaUrl("https://opentelemetry.io/schemas/1.16.0")
+                        .setMeterVersion("1.0.0"),
                     mock(DeclarativeConfigContext.class)))
         .isEqualTo(
             InstrumentSelector.builder()

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogLimitsFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogLimitsFactoryTest.java
@@ -40,19 +40,19 @@ class LogLimitsFactoryTest {
             "attribute limits only",
             LogRecordLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
-                    .withAttributeValueLengthLimit(1)
-                    .withAttributeCountLimit(2),
+                    .setAttributeValueLengthLimit(1)
+                    .setAttributeCountLimit(2),
                 new LogRecordLimitsModel()),
             LogLimits.builder().setMaxAttributeValueLength(1).setMaxNumberOfAttributes(2).build()),
         Arguments.argumentSet(
             "log record limits override attribute limits",
             LogRecordLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
-                    .withAttributeValueLengthLimit(1)
-                    .withAttributeCountLimit(2),
+                    .setAttributeValueLengthLimit(1)
+                    .setAttributeCountLimit(2),
                 new LogRecordLimitsModel()
-                    .withAttributeValueLengthLimit(3)
-                    .withAttributeCountLimit(4)),
+                    .setAttributeValueLengthLimit(3)
+                    .setAttributeCountLimit(4)),
             LogLimits.builder().setMaxAttributeValueLength(3).setMaxNumberOfAttributes(4).build()));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogRecordExporterFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogRecordExporterFactoryTest.java
@@ -95,27 +95,25 @@ class LogRecordExporterFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "otlp_http default",
-            new LogRecordExporterModel().withOtlpHttp(new OtlpHttpExporterModel()),
+            new LogRecordExporterModel().setOtlpHttp(new OtlpHttpExporterModel()),
             OtlpHttpLogRecordExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_http with options",
             new LogRecordExporterModel()
-                .withOtlpHttp(
+                .setOtlpHttp(
                     new OtlpHttpExporterModel()
-                        .withEndpoint("http://example:4318/v1/logs")
-                        .withHeaders(
+                        .setEndpoint("http://example:4318/v1/logs")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new HttpTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))),
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))),
             OtlpHttpLogRecordExporter.builder()
                 .setEndpoint("http://example:4318/v1/logs")
                 .addHeader("key1", "value1")
@@ -126,27 +124,25 @@ class LogRecordExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "otlp_grpc default",
-            new LogRecordExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()),
+            new LogRecordExporterModel().setOtlpGrpc(new OtlpGrpcExporterModel()),
             OtlpGrpcLogRecordExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_grpc with options",
             new LogRecordExporterModel()
-                .withOtlpGrpc(
+                .setOtlpGrpc(
                     new OtlpGrpcExporterModel()
-                        .withEndpoint("http://example:4317")
-                        .withHeaders(
+                        .setEndpoint("http://example:4317")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new GrpcTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))),
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))),
             OtlpGrpcLogRecordExporter.builder()
                 .setEndpoint("http://example:4317")
                 .addHeader("key1", "value1")
@@ -157,7 +153,7 @@ class LogRecordExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "otlp_file/development",
-            LogRecordExporterModelAccessor.withOtlpFile(
+            LogRecordExporterModelAccessor.setOtlpFile(
                 new LogRecordExporterModel(), new ExperimentalOtlpFileExporterModel()),
             OtlpStdoutLogRecordExporter.builder().build()));
   }
@@ -175,7 +171,7 @@ class LogRecordExporterFactoryTest {
         Arguments.argumentSet(
             "unknown component provider",
             new LogRecordExporterModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.logs.export.LogRecordExporter with name \"unknown_key\"."));
   }
 
@@ -185,7 +181,7 @@ class LogRecordExporterFactoryTest {
         LogRecordExporterFactory.getInstance()
             .create(
                 new LogRecordExporterModel()
-                    .withExtensionProperty("test", Collections.singletonMap("key1", "value1")),
+                    .setExtensionProperty("test", Collections.singletonMap("key1", "value1")),
                 context);
     assertThat(logRecordExporter)
         .isInstanceOf(LogRecordExporterComponentProvider.TestLogRecordExporter.class);
@@ -205,7 +201,7 @@ class LogRecordExporterFactoryTest {
 
     LogRecordExporter result =
         LogRecordExporterFactory.getInstance()
-            .create(new LogRecordExporterModel().withConsole(new ConsoleExporterModel()), context);
+            .create(new LogRecordExporterModel().setConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(result).isInstanceOf(SystemOutLogRecordExporter.class);
@@ -223,8 +219,7 @@ class LogRecordExporterFactoryTest {
 
     LogRecordExporter result =
         LogRecordExporterFactory.getInstance()
-            .create(
-                new LogRecordExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()), context);
+            .create(new LogRecordExporterModel().setOtlpGrpc(new OtlpGrpcExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(result).isInstanceOf(OtlpGrpcLogRecordExporter.class);
@@ -246,7 +241,7 @@ class LogRecordExporterFactoryTest {
 
     LogRecordExporter result =
         LogRecordExporterFactory.getInstance()
-            .create(new LogRecordExporterModel().withConsole(new ConsoleExporterModel()), context);
+            .create(new LogRecordExporterModel().setConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(callCount.get()).isEqualTo(0);
@@ -263,7 +258,7 @@ class LogRecordExporterFactoryTest {
             () ->
                 LogRecordExporterFactory.getInstance()
                     .create(
-                        new LogRecordExporterModel().withConsole(new ConsoleExporterModel()),
+                        new LogRecordExporterModel().setConsole(new ConsoleExporterModel()),
                         context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessageContaining("Customizer returned null for LogRecordExporter: console");

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogRecordProcessorFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LogRecordProcessorFactoryTest.java
@@ -60,24 +60,23 @@ class LogRecordProcessorFactoryTest {
         Arguments.argumentSet(
             "batch otlp_http defaults",
             new LogRecordProcessorModel()
-                .withBatch(
+                .setBatch(
                     new BatchLogRecordProcessorModel()
-                        .withExporter(
-                            new LogRecordExporterModel()
-                                .withOtlpHttp(new OtlpHttpExporterModel()))),
+                        .setExporter(
+                            new LogRecordExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))),
             BatchLogRecordProcessor.builder(
                     OtlpHttpLogRecordExporter.builder().setComponentLoader(context).build())
                 .build()),
         Arguments.argumentSet(
             "batch otlp_http with options",
             new LogRecordProcessorModel()
-                .withBatch(
+                .setBatch(
                     new BatchLogRecordProcessorModel()
-                        .withExporter(
-                            new LogRecordExporterModel().withOtlpHttp(new OtlpHttpExporterModel()))
-                        .withScheduleDelay(1)
-                        .withMaxExportBatchSize(2)
-                        .withExportTimeout(3)),
+                        .setExporter(
+                            new LogRecordExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))
+                        .setScheduleDelay(1)
+                        .setMaxExportBatchSize(2)
+                        .setExportTimeout(3)),
             BatchLogRecordProcessor.builder(
                     OtlpHttpLogRecordExporter.builder().setComponentLoader(context).build())
                 .setScheduleDelay(Duration.ofMillis(1))
@@ -87,22 +86,21 @@ class LogRecordProcessorFactoryTest {
         Arguments.argumentSet(
             "simple otlp_http",
             new LogRecordProcessorModel()
-                .withSimple(
+                .setSimple(
                     new SimpleLogRecordProcessorModel()
-                        .withExporter(
-                            new LogRecordExporterModel()
-                                .withOtlpHttp(new OtlpHttpExporterModel()))),
+                        .setExporter(
+                            new LogRecordExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))),
             SimpleLogRecordProcessor.create(
                 OtlpHttpLogRecordExporter.builder().setComponentLoader(context).build())),
         Arguments.argumentSet(
             "event_to_span_event_bridge/development",
-            LogRecordProcessorModelAccessor.withEventToSpanEventBridge(
+            LogRecordProcessorModelAccessor.setEventToSpanEventBridge(
                 new LogRecordProcessorModel(),
                 new ExperimentalEventToSpanEventBridgeLogRecordProcessorModel()),
             EventToSpanEventBridge.create()),
         Arguments.argumentSet(
             "spi test processor",
-            new LogRecordProcessorModel().withExtensionProperty("test", null),
+            new LogRecordProcessorModel().setExtensionProperty("test", null),
             LogRecordProcessorComponentProvider.TestLogRecordProcessor.create()));
   }
 
@@ -118,16 +116,16 @@ class LogRecordProcessorFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "batch missing exporter",
-            new LogRecordProcessorModel().withBatch(new BatchLogRecordProcessorModel()),
+            new LogRecordProcessorModel().setBatch(new BatchLogRecordProcessorModel()),
             "batch log record processor exporter is required but is null"),
         Arguments.argumentSet(
             "simple missing exporter",
-            new LogRecordProcessorModel().withSimple(new SimpleLogRecordProcessorModel()),
+            new LogRecordProcessorModel().setSimple(new SimpleLogRecordProcessorModel()),
             "simple log record processor exporter is required but is null"),
         Arguments.argumentSet(
             "unknown component provider",
             new LogRecordProcessorModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.logs.LogRecordProcessor with name \"unknown_key\"."));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LoggerProviderFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/LoggerProviderFactoryTest.java
@@ -82,31 +82,31 @@ class LoggerProviderFactoryTest {
             "full configuration",
             LoggerProviderAndAttributeLimits.create(
                 new AttributeLimitsModel(),
-                LoggerProviderModelAccessor.withLoggerConfigurator(
+                LoggerProviderModelAccessor.setLoggerConfigurator(
                     new LoggerProviderModel()
-                        .withLimits(
+                        .setLimits(
                             new LogRecordLimitsModel()
-                                .withAttributeCountLimit(1)
-                                .withAttributeValueLengthLimit(2))
-                        .withProcessors(
+                                .setAttributeCountLimit(1)
+                                .setAttributeValueLengthLimit(2))
+                        .setProcessors(
                             Collections.singletonList(
                                 new LogRecordProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchLogRecordProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new LogRecordExporterModel()
-                                                    .withOtlpHttp(new OtlpHttpExporterModel()))))),
+                                                    .setOtlpHttp(new OtlpHttpExporterModel()))))),
                     new ExperimentalLoggerConfiguratorModel()
-                        .withDefaultConfig(new ExperimentalLoggerConfigModel().withEnabled(false))
-                        .withLoggers(
+                        .setDefaultConfig(new ExperimentalLoggerConfigModel().setEnabled(false))
+                        .setLoggers(
                             Collections.singletonList(
                                 new ExperimentalLoggerMatcherAndConfigModel()
-                                    .withName("foo")
-                                    .withConfig(
+                                    .setName("foo")
+                                    .setConfig(
                                         new ExperimentalLoggerConfigModel()
-                                            .withEnabled(true)
-                                            .withTraceBased(true)
-                                            .withMinimumSeverity(SeverityNumberModel.INFO)))))),
+                                            .setEnabled(true)
+                                            .setTraceBased(true)
+                                            .setMinimumSeverity(SeverityNumberModel.INFO)))))),
             setLoggerConfigurator(
                     SdkLoggerProvider.builder(),
                     ScopeConfigurator.<LoggerConfig>builder()

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MeterProviderFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MeterProviderFactoryTest.java
@@ -75,36 +75,36 @@ class MeterProviderFactoryTest {
             "defaults", new MeterProviderModel(), SdkMeterProvider.builder().build()),
         Arguments.argumentSet(
             "with reader view and meter configurator",
-            MeterProviderModelAccessor.withMeterConfigurator(
+            MeterProviderModelAccessor.setMeterConfigurator(
                     new MeterProviderModel()
-                        .withReaders(
+                        .setReaders(
                             Collections.singletonList(
                                 new MetricReaderModel()
-                                    .withPeriodic(
+                                    .setPeriodic(
                                         new PeriodicMetricReaderModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new PushMetricExporterModel()
-                                                    .withOtlpHttp(
+                                                    .setOtlpHttp(
                                                         new OtlpHttpMetricExporterModel())))))
-                        .withViews(
+                        .setViews(
                             Collections.singletonList(
                                 new ViewModel()
-                                    .withSelector(
+                                    .setSelector(
                                         new ViewSelectorModel()
-                                            .withInstrumentName("instrument-name"))
-                                    .withStream(
+                                            .setInstrumentName("instrument-name"))
+                                    .setStream(
                                         new ViewStreamModel()
-                                            .withName("stream-name")
-                                            .withAttributeKeys(null)))),
+                                            .setName("stream-name")
+                                            .setAttributeKeys(null)))),
                     new ExperimentalMeterConfiguratorModel()
-                        .withDefaultConfig(new ExperimentalMeterConfigModel().withEnabled(false))
-                        .withMeters(
+                        .setDefaultConfig(new ExperimentalMeterConfigModel().setEnabled(false))
+                        .setMeters(
                             Collections.singletonList(
                                 new ExperimentalMeterMatcherAndConfigModel()
-                                    .withName("foo")
-                                    .withConfig(
-                                        new ExperimentalMeterConfigModel().withEnabled(true)))))
-                .withExemplarFilter(ExemplarFilterModel.ALWAYS_ON),
+                                    .setName("foo")
+                                    .setConfig(
+                                        new ExperimentalMeterConfigModel().setEnabled(true)))))
+                .setExemplarFilter(ExemplarFilterModel.ALWAYS_ON),
             setMeterConfigurator(
                     SdkMeterProvider.builder(),
                     ScopeConfigurator.<MeterConfig>builder()

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricExporterFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricExporterFactoryTest.java
@@ -101,29 +101,27 @@ class MetricExporterFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "otlp_http default",
-            new PushMetricExporterModel().withOtlpHttp(new OtlpHttpMetricExporterModel()),
+            new PushMetricExporterModel().setOtlpHttp(new OtlpHttpMetricExporterModel()),
             OtlpHttpMetricExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_http with options",
             new PushMetricExporterModel()
-                .withOtlpHttp(
+                .setOtlpHttp(
                     new OtlpHttpMetricExporterModel()
-                        .withEndpoint("http://example:4318/v1/metrics")
-                        .withHeaders(
+                        .setEndpoint("http://example:4318/v1/metrics")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new HttpTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))
-                        .withTemporalityPreference(ExporterTemporalityPreferenceModel.DELTA)
-                        .withDefaultHistogramAggregation(
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))
+                        .setTemporalityPreference(ExporterTemporalityPreferenceModel.DELTA)
+                        .setDefaultHistogramAggregation(
                             ExporterDefaultHistogramAggregationModel
                                 .BASE_2_EXPONENTIAL_BUCKET_HISTOGRAM)),
             OtlpHttpMetricExporter.builder()
@@ -142,29 +140,27 @@ class MetricExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "otlp_grpc default",
-            new PushMetricExporterModel().withOtlpGrpc(new OtlpGrpcMetricExporterModel()),
+            new PushMetricExporterModel().setOtlpGrpc(new OtlpGrpcMetricExporterModel()),
             OtlpGrpcMetricExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_grpc with options",
             new PushMetricExporterModel()
-                .withOtlpGrpc(
+                .setOtlpGrpc(
                     new OtlpGrpcMetricExporterModel()
-                        .withEndpoint("http://example:4317")
-                        .withHeaders(
+                        .setEndpoint("http://example:4317")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new GrpcTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))
-                        .withTemporalityPreference(ExporterTemporalityPreferenceModel.DELTA)
-                        .withDefaultHistogramAggregation(
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))
+                        .setTemporalityPreference(ExporterTemporalityPreferenceModel.DELTA)
+                        .setDefaultHistogramAggregation(
                             ExporterDefaultHistogramAggregationModel
                                 .BASE_2_EXPONENTIAL_BUCKET_HISTOGRAM)),
             OtlpGrpcMetricExporter.builder()
@@ -183,11 +179,11 @@ class MetricExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "console",
-            new PushMetricExporterModel().withConsole(new ConsoleMetricExporterModel()),
+            new PushMetricExporterModel().setConsole(new ConsoleMetricExporterModel()),
             LoggingMetricExporter.create()),
         Arguments.argumentSet(
             "otlp_file/development",
-            PushMetricExporterModelAccessor.withOtlpFile(
+            PushMetricExporterModelAccessor.setOtlpFile(
                 new PushMetricExporterModel(), new ExperimentalOtlpFileMetricExporterModel()),
             OtlpStdoutMetricExporter.builder().build()));
   }
@@ -205,7 +201,7 @@ class MetricExporterFactoryTest {
         Arguments.argumentSet(
             "unknown component provider",
             new PushMetricExporterModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.metrics.export.MetricExporter with name \"unknown_key\"."));
   }
 
@@ -215,7 +211,7 @@ class MetricExporterFactoryTest {
         MetricExporterFactory.getInstance()
             .create(
                 new PushMetricExporterModel()
-                    .withExtensionProperty("test", Collections.singletonMap("key1", "value1")),
+                    .setExtensionProperty("test", Collections.singletonMap("key1", "value1")),
                 context);
     assertThat(metricExporter)
         .isInstanceOf(MetricExporterComponentProvider.TestMetricExporter.class);
@@ -236,7 +232,7 @@ class MetricExporterFactoryTest {
     MetricExporter result =
         MetricExporterFactory.getInstance()
             .create(
-                new PushMetricExporterModel().withConsole(new ConsoleMetricExporterModel()),
+                new PushMetricExporterModel().setConsole(new ConsoleMetricExporterModel()),
                 context);
     cleanup.addCloseable(result);
 
@@ -256,7 +252,7 @@ class MetricExporterFactoryTest {
     MetricExporter result =
         MetricExporterFactory.getInstance()
             .create(
-                new PushMetricExporterModel().withOtlpGrpc(new OtlpGrpcMetricExporterModel()),
+                new PushMetricExporterModel().setOtlpGrpc(new OtlpGrpcMetricExporterModel()),
                 context);
     cleanup.addCloseable(result);
 
@@ -280,7 +276,7 @@ class MetricExporterFactoryTest {
     MetricExporter result =
         MetricExporterFactory.getInstance()
             .create(
-                new PushMetricExporterModel().withConsole(new ConsoleMetricExporterModel()),
+                new PushMetricExporterModel().setConsole(new ConsoleMetricExporterModel()),
                 context);
     cleanup.addCloseable(result);
 
@@ -298,7 +294,7 @@ class MetricExporterFactoryTest {
             () ->
                 MetricExporterFactory.getInstance()
                     .create(
-                        new PushMetricExporterModel().withConsole(new ConsoleMetricExporterModel()),
+                        new PushMetricExporterModel().setConsole(new ConsoleMetricExporterModel()),
                         context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessageContaining("Customizer returned null for MetricExporter: console");

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactoryTest.java
@@ -105,11 +105,11 @@ class MetricReaderFactoryTest {
                 Arguments.argumentSet(
                     "periodic defaults",
                     new MetricReaderModel()
-                        .withPeriodic(
+                        .setPeriodic(
                             new PeriodicMetricReaderModel()
-                                .withExporter(
+                                .setExporter(
                                     new PushMetricExporterModel()
-                                        .withOtlpHttp(new OtlpHttpMetricExporterModel()))),
+                                        .setOtlpHttp(new OtlpHttpMetricExporterModel()))),
                     PeriodicMetricReader.builder(
                             OtlpHttpMetricExporter.builder().setComponentLoader(context).build())
                         .build(),
@@ -118,15 +118,15 @@ class MetricReaderFactoryTest {
                 Arguments.argumentSet(
                     "periodic configured",
                     new MetricReaderModel()
-                        .withPeriodic(
-                            PeriodicMetricReaderModelAccessor.withMaxExportBatchSize(
+                        .setPeriodic(
+                            PeriodicMetricReaderModelAccessor.setMaxExportBatchSize(
                                 new PeriodicMetricReaderModel()
-                                    .withExporter(
+                                    .setExporter(
                                         new PushMetricExporterModel()
-                                            .withOtlpHttp(new OtlpHttpMetricExporterModel()))
-                                    .withInterval(1)
-                                    .withCardinalityLimits(
-                                        new CardinalityLimitsModel().withDefault(100)),
+                                            .setOtlpHttp(new OtlpHttpMetricExporterModel()))
+                                    .setInterval(1)
+                                    .setCardinalityLimits(
+                                        new CardinalityLimitsModel().setDefault(100)),
                                 200)),
                     SdkMeterProviderUtil.setMaxExportBatchSize(
                             PeriodicMetricReader.builder(
@@ -147,13 +147,13 @@ class MetricReaderFactoryTest {
         Arguments.argumentSet(
             "pull prometheus defaults",
             new MetricReaderModel()
-                .withPull(
+                .setPull(
                     new PullMetricReaderModel()
-                        .withExporter(
-                            PullMetricExporterModelAccessor.withPrometheus(
+                        .setExporter(
+                            PullMetricExporterModelAccessor.setPrometheus(
                                 new PullMetricExporterModel(),
                                 new ExperimentalPrometheusMetricExporterModel()
-                                    .withPort(prom1Port)))),
+                                    .setPort(prom1Port)))),
             prom1Expected,
             null,
             true));
@@ -174,22 +174,22 @@ class MetricReaderFactoryTest {
         Arguments.argumentSet(
             "pull prometheus configured",
             new MetricReaderModel()
-                .withPull(
+                .setPull(
                     new PullMetricReaderModel()
-                        .withCardinalityLimits(new CardinalityLimitsModel().withDefault(100))
-                        .withExporter(
-                            PullMetricExporterModelAccessor.withPrometheus(
+                        .setCardinalityLimits(new CardinalityLimitsModel().setDefault(100))
+                        .setExporter(
+                            PullMetricExporterModelAccessor.setPrometheus(
                                 new PullMetricExporterModel(),
                                 new ExperimentalPrometheusMetricExporterModel()
-                                    .withHost("localhost")
-                                    .withPort(prom2Port)
-                                    .withResourceConstantLabels(
+                                    .setHost("localhost")
+                                    .setPort(prom2Port)
+                                    .setResourceConstantLabels(
                                         new IncludeExcludeModel()
-                                            .withIncluded(singletonList("foo"))
-                                            .withExcluded(singletonList("bar")))
-                                    .withScopeInfoEnabled(false)
-                                    .withTargetInfoEnabledDevelopment(false)
-                                    .withTranslationStrategy(
+                                            .setIncluded(singletonList("foo"))
+                                            .setExcluded(singletonList("bar")))
+                                    .setScopeInfoEnabled(false)
+                                    .setTargetInfoEnabledDevelopment(false)
+                                    .setTranslationStrategy(
                                         ExperimentalPrometheusTranslationStrategyModel
                                             .UNDERSCORE_ESCAPING_WITHOUT_SUFFIXES_DEVELOPMENT)))),
             prom2Expected,
@@ -208,15 +208,15 @@ class MetricReaderFactoryTest {
         Arguments.argumentSet(
             "pull prometheus no translation",
             new MetricReaderModel()
-                .withPull(
+                .setPull(
                     new PullMetricReaderModel()
-                        .withExporter(
-                            PullMetricExporterModelAccessor.withPrometheus(
+                        .setExporter(
+                            PullMetricExporterModelAccessor.setPrometheus(
                                 new PullMetricExporterModel(),
                                 new ExperimentalPrometheusMetricExporterModel()
-                                    .withHost("localhost")
-                                    .withPort(prom3Port)
-                                    .withTranslationStrategy(
+                                    .setHost("localhost")
+                                    .setPort(prom3Port)
+                                    .setTranslationStrategy(
                                         ExperimentalPrometheusTranslationStrategyModel
                                             .NO_TRANSLATION_DEVELOPMENT)))),
             prom3Expected,
@@ -238,16 +238,16 @@ class MetricReaderFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "null periodic reader exporter",
-            new MetricReaderModel().withPeriodic(new PeriodicMetricReaderModel()),
+            new MetricReaderModel().setPeriodic(new PeriodicMetricReaderModel()),
             "periodic metric reader exporter is required but is null"),
         Arguments.argumentSet(
             "null pull reader",
-            new MetricReaderModel().withPull(new PullMetricReaderModel()),
+            new MetricReaderModel().setPull(new PullMetricReaderModel()),
             "pull metric reader exporter is required but is null"),
         Arguments.argumentSet(
             "null pull reader exporter",
             new MetricReaderModel()
-                .withPull(new PullMetricReaderModel().withExporter(new PullMetricExporterModel())),
+                .setPull(new PullMetricReaderModel().setExporter(new PullMetricExporterModel())),
             "metric reader must have exactly one entry but has 0"));
   }
 

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -104,7 +104,7 @@ class OpenTelemetryConfigurationFactoryTest {
   @SuppressLogger(OpenTelemetryConfigurationFactory.class)
   void create_FileFormat(String fileFormat, boolean isValid) {
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().withFileFormat(fileFormat);
+        new OpenTelemetryConfigurationModel().setFileFormat(fileFormat);
 
     if (isValid) {
       assertThatCode(() -> OpenTelemetryConfigurationFactory.getInstance().create(model, context))
@@ -145,7 +145,7 @@ class OpenTelemetryConfigurationFactoryTest {
   @SuppressLogger(OpenTelemetryConfigurationFactory.class)
   void create_FileFormatVersionMismatch_LogsWarning() {
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().withFileFormat("1.0-rc.3");
+        new OpenTelemetryConfigurationModel().setFileFormat("1.0-rc.3");
 
     ExtendedOpenTelemetrySdk sdk =
         OpenTelemetryConfigurationFactory.getInstance().create(model, context).getSdk();
@@ -158,7 +158,7 @@ class OpenTelemetryConfigurationFactoryTest {
   @Test
   void create_FileFormatExactMatch_NoWarning() {
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().withFileFormat("1.1");
+        new OpenTelemetryConfigurationModel().setFileFormat("1.1");
 
     ExtendedOpenTelemetrySdk sdk =
         OpenTelemetryConfigurationFactory.getInstance().create(model, context).getSdk();
@@ -171,7 +171,7 @@ class OpenTelemetryConfigurationFactoryTest {
   void create_Defaults() {
     List<Closeable> closeables = new ArrayList<>();
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().withFileFormat("1.1");
+        new OpenTelemetryConfigurationModel().setFileFormat("1.1");
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdkBuilderUtil.setConfigProvider(
                 OpenTelemetrySdk.builder(),
@@ -192,19 +192,19 @@ class OpenTelemetryConfigurationFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     OpenTelemetryConfigurationModel model =
         new OpenTelemetryConfigurationModel()
-            .withFileFormat("1.1")
-            .withDisabled(true)
+            .setFileFormat("1.1")
+            .setDisabled(true)
             // Logger provider configuration should be ignored since SDK is disabled
-            .withLoggerProvider(
+            .setLoggerProvider(
                 new LoggerProviderModel()
-                    .withProcessors(
+                    .setProcessors(
                         Collections.singletonList(
                             new LogRecordProcessorModel()
-                                .withSimple(
+                                .setSimple(
                                     new SimpleLogRecordProcessorModel()
-                                        .withExporter(
+                                        .setExporter(
                                             new LogRecordExporterModel()
-                                                .withOtlpHttp(new OtlpHttpExporterModel()))))));
+                                                .setOtlpHttp(new OtlpHttpExporterModel()))))));
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdkBuilderUtil.setConfigProvider(
                 OpenTelemetrySdk.builder(),
@@ -235,79 +235,79 @@ class OpenTelemetryConfigurationFactoryTest {
 
     OpenTelemetryConfigurationModel model =
         new OpenTelemetryConfigurationModel()
-            .withFileFormat("1.1")
-            .withPropagator(
-                new PropagatorModel().withCompositeList("tracecontext,baggage,b3multi,b3"))
-            .withResource(
-                ResourceModelAccessor.withDetection(
+            .setFileFormat("1.1")
+            .setPropagator(
+                new PropagatorModel().setCompositeList("tracecontext,baggage,b3multi,b3"))
+            .setResource(
+                ResourceModelAccessor.setDetection(
                         new ResourceModel(),
                         new ExperimentalResourceDetectionModel()
-                            .withDetectors(
+                            .setDetectors(
                                 Arrays.asList(
                                     new ExperimentalResourceDetectorModel()
-                                        .withAdditionalProperty("order_first", null),
+                                        .setAdditionalProperty("order_first", null),
                                     new ExperimentalResourceDetectorModel()
-                                        .withAdditionalProperty("order_second", null),
+                                        .setAdditionalProperty("order_second", null),
                                     new ExperimentalResourceDetectorModel()
-                                        .withAdditionalProperty("shape_color", null))))
-                    .withAttributes(
+                                        .setAdditionalProperty("shape_color", null))))
+                    .setAttributes(
                         Arrays.asList(
                             new AttributeNameValueModel()
-                                .withName("service.name")
-                                .withValue("my-service"),
-                            new AttributeNameValueModel().withName("key").withValue("val"))))
-            .withLoggerProvider(
+                                .setName("service.name")
+                                .setValue("my-service"),
+                            new AttributeNameValueModel().setName("key").setValue("val"))))
+            .setLoggerProvider(
                 new LoggerProviderModel()
-                    .withLimits(
+                    .setLimits(
                         new LogRecordLimitsModel()
-                            .withAttributeValueLengthLimit(1)
-                            .withAttributeCountLimit(2))
-                    .withProcessors(
+                            .setAttributeValueLengthLimit(1)
+                            .setAttributeCountLimit(2))
+                    .setProcessors(
                         Collections.singletonList(
                             new LogRecordProcessorModel()
-                                .withBatch(
+                                .setBatch(
                                     new BatchLogRecordProcessorModel()
-                                        .withExporter(
+                                        .setExporter(
                                             new LogRecordExporterModel()
-                                                .withOtlpHttp(new OtlpHttpExporterModel()))))))
-            .withTracerProvider(
+                                                .setOtlpHttp(new OtlpHttpExporterModel()))))))
+            .setTracerProvider(
                 new TracerProviderModel()
-                    .withLimits(
+                    .setLimits(
                         new SpanLimitsModel()
-                            .withAttributeCountLimit(1)
-                            .withAttributeValueLengthLimit(2)
-                            .withEventCountLimit(3)
-                            .withLinkCountLimit(4)
-                            .withEventAttributeCountLimit(5)
-                            .withLinkAttributeCountLimit(6))
-                    .withSampler(new SamplerModel().withAlwaysOn(new AlwaysOnSamplerModel()))
-                    .withProcessors(
+                            .setAttributeCountLimit(1)
+                            .setAttributeValueLengthLimit(2)
+                            .setEventCountLimit(3)
+                            .setLinkCountLimit(4)
+                            .setEventAttributeCountLimit(5)
+                            .setLinkAttributeCountLimit(6))
+                    .setSampler(new SamplerModel().setAlwaysOn(new AlwaysOnSamplerModel()))
+                    .setProcessors(
                         Collections.singletonList(
                             new SpanProcessorModel()
-                                .withBatch(
+                                .setBatch(
                                     new BatchSpanProcessorModel()
-                                        .withExporter(
+                                        .setExporter(
                                             new SpanExporterModel()
-                                                .withOtlpHttp(new OtlpHttpExporterModel()))))))
-            .withMeterProvider(
+                                                .setOtlpHttp(new OtlpHttpExporterModel()))))))
+            .setMeterProvider(
                 new MeterProviderModel()
-                    .withReaders(
+                    .setReaders(
                         Collections.singletonList(
                             new MetricReaderModel()
-                                .withPeriodic(
+                                .setPeriodic(
                                     new PeriodicMetricReaderModel()
-                                        .withExporter(
+                                        .setExporter(
                                             new PushMetricExporterModel()
-                                                .withOtlpHttp(new OtlpHttpMetricExporterModel())))))
-                    .withViews(
+                                                .setOtlpHttp(new OtlpHttpMetricExporterModel())))))
+                    .setViews(
                         Collections.singletonList(
                             new ViewModel()
-                                .withSelector(
-                                    new ViewSelectorModel().withInstrumentName("instrument-name"))
-                                .withStream(
+                                .setSelector(
+                                    new ViewSelectorModel().setInstrumentName("instrument-name"))
+                                .setStream(
                                     new ViewStreamModel()
-                                        .withName("stream-name")
-                                        .withAttributeKeys(null)))));
+                                        .setName("stream-name")
+                                        .setAttributeKeys(null)))));
 
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdkBuilderUtil.setConfigProvider(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/PropagatorFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/PropagatorFactoryTest.java
@@ -49,13 +49,13 @@ class PropagatorFactoryTest {
         Arguments.argumentSet(
             "structured list",
             new PropagatorModel()
-                .withComposite(
+                .setComposite(
                     Arrays.asList(
                         new TextMapPropagatorModel()
-                            .withTracecontext(new TraceContextPropagatorModel()),
-                        new TextMapPropagatorModel().withBaggage(new BaggagePropagatorModel()),
-                        new TextMapPropagatorModel().withB3multi(new B3MultiPropagatorModel()),
-                        new TextMapPropagatorModel().withB3(new B3PropagatorModel()))),
+                            .setTracecontext(new TraceContextPropagatorModel()),
+                        new TextMapPropagatorModel().setBaggage(new BaggagePropagatorModel()),
+                        new TextMapPropagatorModel().setB3multi(new B3MultiPropagatorModel()),
+                        new TextMapPropagatorModel().setB3(new B3PropagatorModel()))),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     W3CTraceContextPropagator.getInstance(),
@@ -64,7 +64,7 @@ class PropagatorFactoryTest {
                     B3Propagator.injectingSingleHeader()))),
         Arguments.argumentSet(
             "string list",
-            new PropagatorModel().withCompositeList("tracecontext,baggage,b3multi,b3 ,none"),
+            new PropagatorModel().setCompositeList("tracecontext,baggage,b3multi,b3 ,none"),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     W3CTraceContextPropagator.getInstance(),
@@ -74,12 +74,12 @@ class PropagatorFactoryTest {
         Arguments.argumentSet(
             "structured list and string list",
             new PropagatorModel()
-                .withComposite(
+                .setComposite(
                     Arrays.asList(
                         new TextMapPropagatorModel()
-                            .withTracecontext(new TraceContextPropagatorModel()),
-                        new TextMapPropagatorModel().withBaggage(new BaggagePropagatorModel())))
-                .withCompositeList("b3multi,b3"),
+                            .setTracecontext(new TraceContextPropagatorModel()),
+                        new TextMapPropagatorModel().setBaggage(new BaggagePropagatorModel())))
+                .setCompositeList("b3multi,b3"),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     W3CTraceContextPropagator.getInstance(),
@@ -89,12 +89,12 @@ class PropagatorFactoryTest {
         Arguments.argumentSet(
             "structured list and string list with overlap",
             new PropagatorModel()
-                .withComposite(
+                .setComposite(
                     Arrays.asList(
                         new TextMapPropagatorModel()
-                            .withTracecontext(new TraceContextPropagatorModel()),
-                        new TextMapPropagatorModel().withBaggage(new BaggagePropagatorModel())))
-                .withCompositeList("tracecontext,b3multi,b3"),
+                            .setTracecontext(new TraceContextPropagatorModel()),
+                        new TextMapPropagatorModel().setBaggage(new BaggagePropagatorModel())))
+                .setCompositeList("tracecontext,b3multi,b3"),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     W3CTraceContextPropagator.getInstance(),
@@ -104,16 +104,16 @@ class PropagatorFactoryTest {
         Arguments.argumentSet(
             "spi structured list",
             new PropagatorModel()
-                .withComposite(
+                .setComposite(
                     Collections.singletonList(
-                        new TextMapPropagatorModel().withExtensionProperty("test", null))),
+                        new TextMapPropagatorModel().setExtensionProperty("test", null))),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     new TextMapPropagatorComponentProvider.TestTextMapPropagator(
                         DeclarativeConfigProperties.empty())))),
         Arguments.argumentSet(
             "spi string list",
-            new PropagatorModel().withCompositeList("test"),
+            new PropagatorModel().setCompositeList("test"),
             ContextPropagators.create(
                 TextMapPropagator.composite(
                     new TextMapPropagatorComponentProvider.TestTextMapPropagator(
@@ -125,7 +125,7 @@ class PropagatorFactoryTest {
     assertThatThrownBy(
             () ->
                 PropagatorFactory.getInstance()
-                    .create(new PropagatorModel().withCompositeList("foo"), context))
+                    .create(new PropagatorModel().setCompositeList("foo"), context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(
             "No component provider detected for io.opentelemetry.context.propagation.TextMapPropagator with name \"foo\".");

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ResourceFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ResourceFactoryTest.java
@@ -42,13 +42,13 @@ class ResourceFactoryTest {
         Arguments.argumentSet(
             "with attributes",
             new ResourceModel()
-                .withAttributes(
+                .setAttributes(
                     Arrays.asList(
                         new AttributeNameValueModel()
-                            .withName("service.name")
-                            .withValue("my-service"),
-                        new AttributeNameValueModel().withName("key").withValue("val"),
-                        new AttributeNameValueModel().withName("shape").withValue("circle"))),
+                            .setName("service.name")
+                            .setValue("my-service"),
+                        new AttributeNameValueModel().setName("key").setValue("val"),
+                        new AttributeNameValueModel().setName("shape").setValue("circle"))),
             Resource.getDefault().toBuilder()
                 .put("shape", "circle")
                 .put("service.name", "my-service")
@@ -56,11 +56,11 @@ class ResourceFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "with schema url",
-            new ResourceModel().withSchemaUrl("http://foo"),
+            new ResourceModel().setSchemaUrl("http://foo"),
             Resource.getDefault().toBuilder().setSchemaUrl("http://foo").build()),
         Arguments.argumentSet(
             "with attributes list",
-            new ResourceModel().withAttributesList("key1=val1,key2=val2"),
+            new ResourceModel().setAttributesList("key1=val1,key2=val2"),
             Resource.getDefault().toBuilder().put("key1", "val1").put("key2", "val2").build()));
   }
 
@@ -69,19 +69,19 @@ class ResourceFactoryTest {
   void createWithDetectors(
       @Nullable List<String> included, @Nullable List<String> excluded, Resource expectedResource) {
     ResourceModel resourceModel =
-        ResourceModelAccessor.withDetection(
+        ResourceModelAccessor.setDetection(
             new ResourceModel(),
             new ExperimentalResourceDetectionModel()
-                .withDetectors(
+                .setDetectors(
                     Arrays.asList(
                         new ExperimentalResourceDetectorModel()
-                            .withAdditionalProperty("order_first", null),
+                            .setAdditionalProperty("order_first", null),
                         new ExperimentalResourceDetectorModel()
-                            .withAdditionalProperty("order_second", null),
+                            .setAdditionalProperty("order_second", null),
                         new ExperimentalResourceDetectorModel()
-                            .withAdditionalProperty("shape_color", null)))
-                .withAttributes(
-                    new IncludeExcludeModel().withIncluded(included).withExcluded(excluded)));
+                            .setAdditionalProperty("shape_color", null)))
+                .setAttributes(
+                    new IncludeExcludeModel().setIncluded(included).setExcluded(excluded)));
     Resource resource = ResourceFactory.getInstance().create(resourceModel, context);
     assertThat(resource).isEqualTo(expectedResource);
   }
@@ -180,52 +180,52 @@ class ResourceFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "unknown detector",
-            ResourceModelAccessor.withDetection(
+            ResourceModelAccessor.setDetection(
                 new ResourceModel(),
                 new ExperimentalResourceDetectionModel()
-                    .withDetectors(
+                    .setDetectors(
                         Collections.singletonList(
                             new ExperimentalResourceDetectorModel()
-                                .withAdditionalProperty("foo", null)))),
+                                .setAdditionalProperty("foo", null)))),
             "No component provider detected for io.opentelemetry.sdk.resources.Resource with name \"foo\"."),
         Arguments.argumentSet(
             "detector multiple entries",
-            ResourceModelAccessor.withDetection(
+            ResourceModelAccessor.setDetection(
                 new ResourceModel(),
                 new ExperimentalResourceDetectionModel()
-                    .withDetectors(
+                    .setDetectors(
                         Collections.singletonList(
                             new ExperimentalResourceDetectorModel()
-                                .withAdditionalProperty("foo", null)
-                                .withAdditionalProperty("bar", null)))),
+                                .setAdditionalProperty("foo", null)
+                                .setAdditionalProperty("bar", null)))),
             "resource detector must have exactly one entry but has 2: [foo,bar]"),
         Arguments.argumentSet(
             "detector no entries",
-            ResourceModelAccessor.withDetection(
+            ResourceModelAccessor.setDetection(
                 new ResourceModel(),
                 new ExperimentalResourceDetectionModel()
-                    .withDetectors(
+                    .setDetectors(
                         Collections.singletonList(new ExperimentalResourceDetectorModel()))),
             "resource detector must have exactly one entry but has 0"),
         Arguments.argumentSet(
             "included empty list",
-            ResourceModelAccessor.withDetection(
+            ResourceModelAccessor.setDetection(
                 new ResourceModel(),
                 new ExperimentalResourceDetectionModel()
-                    .withAttributes(
+                    .setAttributes(
                         new IncludeExcludeModel()
-                            .withIncluded(Collections.emptyList())
-                            .withExcluded(null))),
+                            .setIncluded(Collections.emptyList())
+                            .setExcluded(null))),
             "included must not be empty"),
         Arguments.argumentSet(
             "excluded empty list",
-            ResourceModelAccessor.withDetection(
+            ResourceModelAccessor.setDetection(
                 new ResourceModel(),
                 new ExperimentalResourceDetectionModel()
-                    .withAttributes(
+                    .setAttributes(
                         new IncludeExcludeModel()
-                            .withIncluded(null)
-                            .withExcluded(Collections.emptyList()))),
+                            .setIncluded(null)
+                            .setExcluded(Collections.emptyList()))),
             "excluded must not be empty"));
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactoryTest.java
@@ -73,50 +73,50 @@ class SamplerFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "always_on",
-            new SamplerModel().withAlwaysOn(new AlwaysOnSamplerModel()),
+            new SamplerModel().setAlwaysOn(new AlwaysOnSamplerModel()),
             Sampler.alwaysOn()),
         Arguments.argumentSet(
             "always_off",
-            new SamplerModel().withAlwaysOff(new AlwaysOffSamplerModel()),
+            new SamplerModel().setAlwaysOff(new AlwaysOffSamplerModel()),
             Sampler.alwaysOff()),
         Arguments.argumentSet(
             "trace_id_ratio_based default",
-            new SamplerModel().withTraceIdRatioBased(new TraceIdRatioBasedSamplerModel()),
+            new SamplerModel().setTraceIdRatioBased(new TraceIdRatioBasedSamplerModel()),
             Sampler.traceIdRatioBased(1.0d)),
         Arguments.argumentSet(
             "trace_id_ratio_based with ratio",
             new SamplerModel()
-                .withTraceIdRatioBased(new TraceIdRatioBasedSamplerModel().withRatio(0.5d)),
+                .setTraceIdRatioBased(new TraceIdRatioBasedSamplerModel().setRatio(0.5d)),
             Sampler.traceIdRatioBased(0.5)),
         Arguments.argumentSet(
             "parent_based default",
-            new SamplerModel().withParentBased(new ParentBasedSamplerModel()),
+            new SamplerModel().setParentBased(new ParentBasedSamplerModel()),
             Sampler.parentBased(Sampler.alwaysOn())),
         Arguments.argumentSet(
             "parent_based with options",
             new SamplerModel()
-                .withParentBased(
+                .setParentBased(
                     new ParentBasedSamplerModel()
-                        .withRoot(
+                        .setRoot(
                             new SamplerModel()
-                                .withTraceIdRatioBased(
-                                    new TraceIdRatioBasedSamplerModel().withRatio(0.1d)))
-                        .withRemoteParentSampled(
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.1d)))
+                        .setRemoteParentSampled(
                             new SamplerModel()
-                                .withTraceIdRatioBased(
-                                    new TraceIdRatioBasedSamplerModel().withRatio(0.2d)))
-                        .withRemoteParentNotSampled(
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.2d)))
+                        .setRemoteParentNotSampled(
                             new SamplerModel()
-                                .withTraceIdRatioBased(
-                                    new TraceIdRatioBasedSamplerModel().withRatio(0.3d)))
-                        .withLocalParentSampled(
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.3d)))
+                        .setLocalParentSampled(
                             new SamplerModel()
-                                .withTraceIdRatioBased(
-                                    new TraceIdRatioBasedSamplerModel().withRatio(0.4d)))
-                        .withLocalParentNotSampled(
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.4d)))
+                        .setLocalParentNotSampled(
                             new SamplerModel()
-                                .withTraceIdRatioBased(
-                                    new TraceIdRatioBasedSamplerModel().withRatio(0.5d)))),
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.5d)))),
             Sampler.parentBasedBuilder(Sampler.traceIdRatioBased(0.1d))
                 .setRemoteParentSampled(Sampler.traceIdRatioBased(0.2d))
                 .setRemoteParentNotSampled(Sampler.traceIdRatioBased(0.3d))
@@ -125,13 +125,13 @@ class SamplerFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "jaeger_remote",
-            SamplerModelAccessor.withJaegerRemote(
+            SamplerModelAccessor.setJaegerRemote(
                 new SamplerModel(),
                 new ExperimentalJaegerRemoteSamplerModel()
-                    .withEndpoint("http://jaeger-remote-endpoint")
-                    .withInterval(10_000)
-                    .withInitialSampler(
-                        new SamplerModel().withAlwaysOff(new AlwaysOffSamplerModel()))),
+                    .setEndpoint("http://jaeger-remote-endpoint")
+                    .setInterval(10_000)
+                    .setInitialSampler(
+                        new SamplerModel().setAlwaysOff(new AlwaysOffSamplerModel()))),
             JaegerRemoteSampler.builder()
                 .setEndpoint("http://jaeger-remote-endpoint")
                 .setPollingInterval(Duration.ofSeconds(10))
@@ -139,43 +139,43 @@ class SamplerFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "composite/development always_on",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withAlwaysOn(new ExperimentalComposableAlwaysOnSamplerModel())),
+                    .setAlwaysOn(new ExperimentalComposableAlwaysOnSamplerModel())),
             CompositeSampler.wrap(ComposableSampler.alwaysOn())),
         Arguments.argumentSet(
             "composite/development always_off",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withAlwaysOff(new ExperimentalComposableAlwaysOffSamplerModel())),
+                    .setAlwaysOff(new ExperimentalComposableAlwaysOffSamplerModel())),
             CompositeSampler.wrap(ComposableSampler.alwaysOff())),
         Arguments.argumentSet(
             "composite/development probability",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withProbability(
-                        new ExperimentalComposableProbabilitySamplerModel().withRatio(0.5))),
+                    .setProbability(
+                        new ExperimentalComposableProbabilitySamplerModel().setRatio(0.5))),
             CompositeSampler.wrap(ComposableSampler.probability(0.5))),
         Arguments.argumentSet(
             "composite/development rule_based",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withRuleBased(new ExperimentalComposableRuleBasedSamplerModel())),
+                    .setRuleBased(new ExperimentalComposableRuleBasedSamplerModel())),
             CompositeSampler.wrap(ComposableSampler.ruleBasedBuilder().build())),
         Arguments.argumentSet(
             "composite/development parent_threshold",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withParentThreshold(
+                    .setParentThreshold(
                         new ExperimentalComposableParentThresholdSamplerModel()
-                            .withRoot(
+                            .setRoot(
                                 new ExperimentalComposableSamplerModel()
-                                    .withAlwaysOn(
+                                    .setAlwaysOn(
                                         new ExperimentalComposableAlwaysOnSamplerModel())))),
             CompositeSampler.wrap(
                 ComposableSampler.parentThreshold(ComposableSampler.alwaysOn()))));
@@ -195,27 +195,27 @@ class SamplerFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "jaeger_remote missing endpoint",
-            SamplerModelAccessor.withJaegerRemote(
+            SamplerModelAccessor.setJaegerRemote(
                 new SamplerModel(), new ExperimentalJaegerRemoteSamplerModel()),
             "jaeger remote sampler endpoint is required"),
         Arguments.argumentSet(
             "jaeger_remote missing initialSampler",
-            SamplerModelAccessor.withJaegerRemote(
+            SamplerModelAccessor.setJaegerRemote(
                 new SamplerModel(),
                 new ExperimentalJaegerRemoteSamplerModel()
-                    .withEndpoint("http://jaeger-remote-endpoint")),
+                    .setEndpoint("http://jaeger-remote-endpoint")),
             "jaeger remote sampler initial_sampler is required"),
         Arguments.argumentSet(
             "parent_threshold missing root",
-            SamplerModelAccessor.withComposite(
+            SamplerModelAccessor.setComposite(
                 new SamplerModel(),
                 new ExperimentalComposableSamplerModel()
-                    .withParentThreshold(new ExperimentalComposableParentThresholdSamplerModel())),
+                    .setParentThreshold(new ExperimentalComposableParentThresholdSamplerModel())),
             "parent threshold sampler root is required but is null"),
         Arguments.argumentSet(
             "unknown component provider",
             new SamplerModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.trace.samplers.Sampler with name \"unknown_key\"."));
   }
 
@@ -225,7 +225,7 @@ class SamplerFactoryTest {
         SamplerFactory.getInstance()
             .create(
                 new SamplerModel()
-                    .withExtensionProperty("test", Collections.singletonMap("key1", "value1")),
+                    .setExtensionProperty("test", Collections.singletonMap("key1", "value1")),
                 context);
     assertThat(sampler).isInstanceOf(SamplerComponentProvider.TestSampler.class);
     assertThat(((SamplerComponentProvider.TestSampler) sampler).config.getString("key1"))

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanExporterFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanExporterFactoryTest.java
@@ -98,27 +98,25 @@ class SpanExporterFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "otlp_http default",
-            new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()),
+            new SpanExporterModel().setOtlpHttp(new OtlpHttpExporterModel()),
             OtlpHttpSpanExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_http with options",
             new SpanExporterModel()
-                .withOtlpHttp(
+                .setOtlpHttp(
                     new OtlpHttpExporterModel()
-                        .withEndpoint("http://example:4318/v1/traces")
-                        .withHeaders(
+                        .setEndpoint("http://example:4318/v1/traces")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new HttpTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))),
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))),
             OtlpHttpSpanExporter.builder()
                 .setEndpoint("http://example:4318/v1/traces")
                 .addHeader("key1", "value1")
@@ -129,27 +127,25 @@ class SpanExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "otlp_grpc default",
-            new SpanExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()),
+            new SpanExporterModel().setOtlpGrpc(new OtlpGrpcExporterModel()),
             OtlpGrpcSpanExporter.getDefault().toBuilder().setComponentLoader(context).build()),
         Arguments.argumentSet(
             "otlp_grpc with options",
             new SpanExporterModel()
-                .withOtlpGrpc(
+                .setOtlpGrpc(
                     new OtlpGrpcExporterModel()
-                        .withEndpoint("http://example:4317")
-                        .withHeaders(
+                        .setEndpoint("http://example:4317")
+                        .setHeaders(
                             Arrays.asList(
-                                new NameStringValuePairModel().withName("key1").withValue("value1"),
-                                new NameStringValuePairModel()
-                                    .withName("key2")
-                                    .withValue("value2")))
-                        .withCompression("gzip")
-                        .withTimeout(15_000)
-                        .withTls(
+                                new NameStringValuePairModel().setName("key1").setValue("value1"),
+                                new NameStringValuePairModel().setName("key2").setValue("value2")))
+                        .setCompression("gzip")
+                        .setTimeout(15_000)
+                        .setTls(
                             new GrpcTlsModel()
-                                .withCaFile(certificatePath)
-                                .withKeyFile(clientKeyPath)
-                                .withCertFile(clientCertificatePath))),
+                                .setCaFile(certificatePath)
+                                .setKeyFile(clientKeyPath)
+                                .setCertFile(clientCertificatePath))),
             OtlpGrpcSpanExporter.builder()
                 .setEndpoint("http://example:4317")
                 .addHeader("key1", "value1")
@@ -160,11 +156,11 @@ class SpanExporterFactoryTest {
                 .build()),
         Arguments.argumentSet(
             "console",
-            new SpanExporterModel().withConsole(new ConsoleExporterModel()),
+            new SpanExporterModel().setConsole(new ConsoleExporterModel()),
             LoggingSpanExporter.create()),
         Arguments.argumentSet(
             "otlp_file/development",
-            SpanExporterModelAccessor.withOtlpFile(
+            SpanExporterModelAccessor.setOtlpFile(
                 new SpanExporterModel(), new ExperimentalOtlpFileExporterModel()),
             OtlpStdoutSpanExporter.builder().build()));
   }
@@ -182,7 +178,7 @@ class SpanExporterFactoryTest {
         Arguments.argumentSet(
             "unknown component provider",
             new SpanExporterModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.trace.export.SpanExporter with name \"unknown_key\"."));
   }
 
@@ -192,7 +188,7 @@ class SpanExporterFactoryTest {
         SpanExporterFactory.getInstance()
             .create(
                 new SpanExporterModel()
-                    .withExtensionProperty("test", Collections.singletonMap("key1", "value1")),
+                    .setExtensionProperty("test", Collections.singletonMap("key1", "value1")),
                 context);
     assertThat(spanExporter).isInstanceOf(SpanExporterComponentProvider.TestSpanExporter.class);
     assertThat(
@@ -213,7 +209,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter result =
         SpanExporterFactory.getInstance()
-            .create(new SpanExporterModel().withConsole(new ConsoleExporterModel()), context);
+            .create(new SpanExporterModel().setConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(result.toString()).contains("LoggingSpanExporter");
@@ -231,7 +227,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter result =
         SpanExporterFactory.getInstance()
-            .create(new SpanExporterModel().withOtlpGrpc(new OtlpGrpcExporterModel()), context);
+            .create(new SpanExporterModel().setOtlpGrpc(new OtlpGrpcExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(result).isInstanceOf(OtlpGrpcSpanExporter.class);
@@ -253,7 +249,7 @@ class SpanExporterFactoryTest {
 
     SpanExporter result =
         SpanExporterFactory.getInstance()
-            .create(new SpanExporterModel().withConsole(new ConsoleExporterModel()), context);
+            .create(new SpanExporterModel().setConsole(new ConsoleExporterModel()), context);
     cleanup.addCloseable(result);
 
     assertThat(callCount.get()).isEqualTo(0);
@@ -270,7 +266,7 @@ class SpanExporterFactoryTest {
             () ->
                 SpanExporterFactory.getInstance()
                     .create(
-                        new SpanExporterModel().withConsole(new ConsoleExporterModel()), context))
+                        new SpanExporterModel().setConsole(new ConsoleExporterModel()), context))
         .isInstanceOf(DeclarativeConfigException.class)
         .hasMessageContaining("Customizer returned null for SpanExporter: console");
   }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanLimitsFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanLimitsFactoryTest.java
@@ -39,23 +39,23 @@ class SpanLimitsFactoryTest {
             "attribute limits only",
             SpanLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
-                    .withAttributeCountLimit(1)
-                    .withAttributeValueLengthLimit(2),
+                    .setAttributeCountLimit(1)
+                    .setAttributeValueLengthLimit(2),
                 new SpanLimitsModel()),
             SpanLimits.builder().setMaxNumberOfAttributes(1).setMaxAttributeValueLength(2).build()),
         Arguments.argumentSet(
             "span limits override attribute limits",
             SpanLimitsAndAttributeLimits.create(
                 new AttributeLimitsModel()
-                    .withAttributeCountLimit(1)
-                    .withAttributeValueLengthLimit(2),
+                    .setAttributeCountLimit(1)
+                    .setAttributeValueLengthLimit(2),
                 new SpanLimitsModel()
-                    .withAttributeCountLimit(3)
-                    .withAttributeValueLengthLimit(4)
-                    .withEventCountLimit(5)
-                    .withLinkCountLimit(6)
-                    .withEventAttributeCountLimit(7)
-                    .withLinkAttributeCountLimit(8)),
+                    .setAttributeCountLimit(3)
+                    .setAttributeValueLengthLimit(4)
+                    .setEventCountLimit(5)
+                    .setLinkCountLimit(6)
+                    .setEventAttributeCountLimit(7)
+                    .setLinkAttributeCountLimit(8)),
             SpanLimits.builder()
                 .setMaxNumberOfAttributes(3)
                 .setMaxAttributeValueLength(4)

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanProcessorFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SpanProcessorFactoryTest.java
@@ -58,23 +58,23 @@ class SpanProcessorFactoryTest {
         Arguments.argumentSet(
             "batch default",
             new SpanProcessorModel()
-                .withBatch(
+                .setBatch(
                     new BatchSpanProcessorModel()
-                        .withExporter(
-                            new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()))),
+                        .setExporter(
+                            new SpanExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))),
             BatchSpanProcessor.builder(
                     OtlpHttpSpanExporter.builder().setComponentLoader(context).build())
                 .build()),
         Arguments.argumentSet(
             "batch with options",
             new SpanProcessorModel()
-                .withBatch(
+                .setBatch(
                     new BatchSpanProcessorModel()
-                        .withExporter(
-                            new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()))
-                        .withScheduleDelay(1)
-                        .withMaxExportBatchSize(2)
-                        .withExportTimeout(3)),
+                        .setExporter(
+                            new SpanExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))
+                        .setScheduleDelay(1)
+                        .setMaxExportBatchSize(2)
+                        .setExportTimeout(3)),
             BatchSpanProcessor.builder(
                     OtlpHttpSpanExporter.builder().setComponentLoader(context).build())
                 .setScheduleDelay(Duration.ofMillis(1))
@@ -84,10 +84,10 @@ class SpanProcessorFactoryTest {
         Arguments.argumentSet(
             "simple",
             new SpanProcessorModel()
-                .withSimple(
+                .setSimple(
                     new SimpleSpanProcessorModel()
-                        .withExporter(
-                            new SpanExporterModel().withOtlpHttp(new OtlpHttpExporterModel()))),
+                        .setExporter(
+                            new SpanExporterModel().setOtlpHttp(new OtlpHttpExporterModel()))),
             SimpleSpanProcessor.create(
                 OtlpHttpSpanExporter.builder().setComponentLoader(context).build())));
   }
@@ -104,16 +104,16 @@ class SpanProcessorFactoryTest {
     return Stream.of(
         Arguments.argumentSet(
             "batch missing exporter",
-            new SpanProcessorModel().withBatch(new BatchSpanProcessorModel()),
+            new SpanProcessorModel().setBatch(new BatchSpanProcessorModel()),
             "batch span processor exporter is required but is null"),
         Arguments.argumentSet(
             "simple missing exporter",
-            new SpanProcessorModel().withSimple(new SimpleSpanProcessorModel()),
+            new SpanProcessorModel().setSimple(new SimpleSpanProcessorModel()),
             "simple span processor exporter is required but is null"),
         Arguments.argumentSet(
             "unknown component provider",
             new SpanProcessorModel()
-                .withExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
+                .setExtensionProperty("unknown_key", Collections.singletonMap("key1", "value1")),
             "No component provider detected for io.opentelemetry.sdk.trace.SpanProcessor with name \"unknown_key\"."));
   }
 
@@ -123,7 +123,7 @@ class SpanProcessorFactoryTest {
         SpanProcessorFactory.getInstance()
             .create(
                 new SpanProcessorModel()
-                    .withExtensionProperty("test", Collections.singletonMap("key1", "value1")),
+                    .setExtensionProperty("test", Collections.singletonMap("key1", "value1")),
                 context);
     assertThat(spanProcessor).isInstanceOf(SpanProcessorComponentProvider.TestSpanProcessor.class);
     assertThat(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/TestDeclarativeConfigurationCustomizerProvider.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/TestDeclarativeConfigurationCustomizerProvider.java
@@ -21,23 +21,23 @@ public class TestDeclarativeConfigurationCustomizerProvider
           ResourceModel resource = model.getResource();
           if (resource == null) {
             resource = new ResourceModel();
-            model.withResource(resource);
+            model.setResource(resource);
           }
           List<AttributeNameValueModel> attributes = resource.getAttributes();
           if (attributes == null) {
             attributes = new ArrayList<>();
-            resource.withAttributes(attributes);
+            resource.setAttributes(attributes);
           }
           attributes.add(
               new AttributeNameValueModel()
-                  .withName("foo")
-                  .withType(AttributeTypeModel.STRING)
-                  .withValue("bar"));
+                  .setName("foo")
+                  .setType(AttributeTypeModel.STRING)
+                  .setValue("bar"));
           attributes.add(
               new AttributeNameValueModel()
-                  .withName("color")
-                  .withType(AttributeTypeModel.STRING)
-                  .withValue("blue"));
+                  .setName("color")
+                  .setType(AttributeTypeModel.STRING)
+                  .setValue("blue"));
           return model;
         });
   }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/TracerProviderFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/TracerProviderFactoryTest.java
@@ -84,33 +84,33 @@ class TracerProviderFactoryTest {
             "full configuration",
             TracerProviderAndAttributeLimits.create(
                 new AttributeLimitsModel(),
-                TracerProviderModelAccessor.withTracerConfigurator(
+                TracerProviderModelAccessor.setTracerConfigurator(
                     new TracerProviderModel()
-                        .withLimits(
+                        .setLimits(
                             new SpanLimitsModel()
-                                .withAttributeCountLimit(1)
-                                .withAttributeValueLengthLimit(2)
-                                .withEventCountLimit(3)
-                                .withLinkCountLimit(4)
-                                .withEventAttributeCountLimit(5)
-                                .withLinkAttributeCountLimit(6))
-                        .withSampler(new SamplerModel().withAlwaysOn(new AlwaysOnSamplerModel()))
-                        .withProcessors(
+                                .setAttributeCountLimit(1)
+                                .setAttributeValueLengthLimit(2)
+                                .setEventCountLimit(3)
+                                .setLinkCountLimit(4)
+                                .setEventAttributeCountLimit(5)
+                                .setLinkAttributeCountLimit(6))
+                        .setSampler(new SamplerModel().setAlwaysOn(new AlwaysOnSamplerModel()))
+                        .setProcessors(
                             Collections.singletonList(
                                 new SpanProcessorModel()
-                                    .withBatch(
+                                    .setBatch(
                                         new BatchSpanProcessorModel()
-                                            .withExporter(
+                                            .setExporter(
                                                 new SpanExporterModel()
-                                                    .withOtlpHttp(new OtlpHttpExporterModel()))))),
+                                                    .setOtlpHttp(new OtlpHttpExporterModel()))))),
                     new ExperimentalTracerConfiguratorModel()
-                        .withDefaultConfig(new ExperimentalTracerConfigModel().withEnabled(false))
-                        .withTracers(
+                        .setDefaultConfig(new ExperimentalTracerConfigModel().setEnabled(false))
+                        .setTracers(
                             Collections.singletonList(
                                 new ExperimentalTracerMatcherAndConfigModel()
-                                    .withName("foo")
-                                    .withConfig(
-                                        new ExperimentalTracerConfigModel().withEnabled(true)))))),
+                                    .setName("foo")
+                                    .setConfig(
+                                        new ExperimentalTracerConfigModel().setEnabled(true)))))),
             addTracerConfigurator(
                     SdkTracerProvider.builder(),
                     ScopeConfigurator.<TracerConfig>builder()

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ViewFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/ViewFactoryTest.java
@@ -35,14 +35,14 @@ class ViewFactoryTest {
   private static Stream<Arguments> createArguments() {
     return Stream.of(
         Arguments.argumentSet(
-            "defaults", new ViewStreamModel().withAttributeKeys(null), View.builder().build()),
+            "defaults", new ViewStreamModel().setAttributeKeys(null), View.builder().build()),
         // https://github.com/open-telemetry/opentelemetry-java/issues/8337
         Arguments.argumentSet(
             "included only no excluded",
             new ViewStreamModel()
-                .withAttributeKeys(
+                .setAttributeKeys(
                     new IncludeExcludeModel()
-                        .withIncluded(
+                        .setIncluded(
                             Arrays.asList(
                                 "url.full", "http.request.method", "http.response.status_code"))),
             View.builder()
@@ -55,17 +55,17 @@ class ViewFactoryTest {
         Arguments.argumentSet(
             "full configuration",
             new ViewStreamModel()
-                .withName("name")
-                .withDescription("description")
-                .withAttributeKeys(
+                .setName("name")
+                .setDescription("description")
+                .setAttributeKeys(
                     new IncludeExcludeModel()
-                        .withIncluded(Arrays.asList("foo", "bar"))
-                        .withExcluded(Collections.singletonList("baz")))
-                .withAggregation(
+                        .setIncluded(Arrays.asList("foo", "bar"))
+                        .setExcluded(Collections.singletonList("baz")))
+                .setAggregation(
                     new AggregationModel()
-                        .withExplicitBucketHistogram(
+                        .setExplicitBucketHistogram(
                             new ExplicitBucketHistogramAggregationModel()
-                                .withBoundaries(Arrays.asList(1.0, 2.0)))),
+                                .setBoundaries(Arrays.asList(1.0, 2.0)))),
             View.builder()
                 .setName("name")
                 .setDescription("description")

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelEqualsHashCodeTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelEqualsHashCodeTest.java
@@ -49,17 +49,17 @@ class ModelEqualsHashCodeTest {
         .withPrefabValues(
             SamplerModel.class,
             new SamplerModel(),
-            new SamplerModel().withAlwaysOn(new AlwaysOnSamplerModel()))
+            new SamplerModel().setAlwaysOn(new AlwaysOnSamplerModel()))
         .withPrefabValues(
             ExperimentalComposableSamplerModel.class,
             new ExperimentalComposableSamplerModel(),
             new ExperimentalComposableSamplerModel()
-                .withAlwaysOff(new ExperimentalComposableAlwaysOffSamplerModel()))
+                .setAlwaysOff(new ExperimentalComposableAlwaysOffSamplerModel()))
         .withPrefabValues(
             ExperimentalComposableParentThresholdSamplerModel.class,
             new ExperimentalComposableParentThresholdSamplerModel(),
             new ExperimentalComposableParentThresholdSamplerModel()
-                .withRoot(new ExperimentalComposableSamplerModel()))
+                .setRoot(new ExperimentalComposableSamplerModel()))
         .verify();
   }
 

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelJacksonRoundTripTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelJacksonRoundTripTest.java
@@ -21,7 +21,7 @@ class ModelJacksonRoundTripTest {
 
   @Test
   void deserializesThroughBuilderWithSnakeCaseNames() throws Exception {
-    // @JsonProperty is on the getter and withX, not the field, so Jackson binds through the
+    // @JsonProperty is on the getter and setX, not the field, so Jackson binds through the
     // builder using the snake_case name.
     BatchSpanProcessorModel model = new BatchSpanProcessorModel().setScheduleDelay(5000);
 

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelJacksonRoundTripTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/ModelJacksonRoundTripTest.java
@@ -23,7 +23,7 @@ class ModelJacksonRoundTripTest {
   void deserializesThroughBuilderWithSnakeCaseNames() throws Exception {
     // @JsonProperty is on the getter and withX, not the field, so Jackson binds through the
     // builder using the snake_case name.
-    BatchSpanProcessorModel model = new BatchSpanProcessorModel().withScheduleDelay(5000);
+    BatchSpanProcessorModel model = new BatchSpanProcessorModel().setScheduleDelay(5000);
 
     String json = mapper.writeValueAsString(model);
     assertThat(json).isEqualTo("{\"schedule_delay\":5000}");
@@ -36,7 +36,7 @@ class ModelJacksonRoundTripTest {
     // additionalProperties contents flatten to top-level keys via @JsonAnyGetter/@JsonAnySetter
     // rather than serializing under an "additionalProperties" key.
     ExperimentalComposableSamplerPropertyModel model =
-        new ExperimentalComposableSamplerPropertyModel().withAdditionalProperty("foo", "bar");
+        new ExperimentalComposableSamplerPropertyModel().setAdditionalProperty("foo", "bar");
 
     String json = mapper.writeValueAsString(model);
     assertThat(json).isEqualTo("{\"foo\":\"bar\"}");


### PR DESCRIPTION
Related to #8402 

Currently, declarative pojos have `<PojoType> with<Prop>(<PropType> propName)` methods for setting properties on mutable pojo types in a fluid manner. This is problematic, because `with<Prop>` heavily implies the the result is an immutable copy with the property changed. 

This PR changes to  `<PojoType> set<Prop>(<PropType> propName)`, which I think is the best option for us:

- Model classes stay mutable. Changing to immutable instances is much more invasive. It requires constructors which know which fields are required at initialization time, and the API changes when that changes. 
- Keep the fluent API. I.e. return the pojo type and not void. This means that these aren't valid java beans. But we don't need them to be java beans and the ergonomic benefit to keeping the fluent API is extremely good.
- No builders. Builders would be another option, but add to an already large API surface area. Overkill for what we're doing here.

Despite the seeming large size of the PR, there is only one meaningful file changed in this PR: https://github.com/open-telemetry/opentelemetry-java/pull/8742/changes#diff-7a86335581560379612dfc344b0c7da937cec60da747e29f4873386fd9473f2f

The rest are find/replace. 