### PR TITLE
Disable ossIndexAudit on :integration-tests

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -16,3 +16,8 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.testcontainers:testcontainers-junit-jupiter")
 }
+
+// Skip ossIndexAudit on test module
+tasks.named("ossIndexAudit") {
+  enabled = false
+}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java/issues/8454