### PR TITLE
Restore detect-api-changes permission to write pull requests

### DIFF
--- a/.github/workflows/detect-api-changes.yml
+++ b/.github/workflows/detect-api-changes.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Check for API changes and update PR
         env:


### PR DESCRIPTION
The #8592 PR broken the `detect-api-changes.yml` workflow: https://github.com/open-telemetry/opentelemetry-java/actions/runs/32775533627/job/97585615343?pr=8717

This fixes it. 

cc @trask 