### PR TITLE
Accept RFC 1123 hostnames in EndpointUtil.validateEndpoint

### DIFF
--- a/exporters/common/src/main/java/io/opentelemetry/exporter/internal/EndpointUtil.java
+++ b/exporters/common/src/main/java/io/opentelemetry/exporter/internal/EndpointUtil.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.exporter.internal;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 
 /**
  * Utilities for validating exporter endpoints.
@@ -30,11 +32,28 @@ public final class EndpointUtil {
       throw new IllegalArgumentException(
           "Invalid endpoint, must start with http:// or https://: " + uri);
     }
-    if (uri.getHost() == null) {
+    if (!hasHost(uri, endpoint)) {
       throw new IllegalArgumentException(
           "Invalid endpoint, must start with http:// or https://: " + uri);
     }
     return uri;
+  }
+
+  /**
+   * {@link URI#getHost()} follows RFC 2396 and returns {@code null} for some valid DNS names
+   * (JDK-8188305), for example a label that starts with a digit. {@link URL#getHost()} accepts
+   * those names, matching {@code OtlpConfigUtil.validateEndpoint}.
+   */
+  private static boolean hasHost(URI uri, String endpoint) {
+    if (uri.getHost() != null) {
+      return true;
+    }
+    try {
+      String host = new URL(endpoint).getHost();
+      return host != null && !host.isEmpty();
+    } catch (MalformedURLException e) {
+      return false;
+    }
   }
 
   private EndpointUtil() {}

--- a/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
+++ b/exporters/common/src/test/java/io/opentelemetry/exporter/internal/EndpointUtilTest.java
@@ -27,7 +27,15 @@ class EndpointUtilTest {
         Arguments.argumentSet("http", "http://localhost:4318"),
         Arguments.argumentSet("https", "https://localhost:4317"),
         Arguments.argumentSet("path", "http://localhost:4318/v1/traces"),
-        Arguments.argumentSet("userinfo", "http://foo:bar@localhost:4317/path"));
+        Arguments.argumentSet("userinfo", "http://foo:bar@localhost:4317/path"),
+        // URI.getHost() is null for these (JDK-8188305); they are valid DNS names.
+        Arguments.argumentSet(
+            "dns label starting with digit", "http://otlp.1234-k8s-namespace:4318"),
+        Arguments.argumentSet(
+            "dns label starting with digit, path",
+            "http://otlp-collector.14014-mosaik:4318/v1/metrics"),
+        Arguments.argumentSet(
+            "dns label starting with digit, userinfo", "http://foo:bar@otlp.1234-ns:4317/path"));
   }
 
   @ParameterizedTest
@@ -42,6 +50,7 @@ class EndpointUtilTest {
     return Stream.of(
         Arguments.argumentSet("opaque, no host", "http:localhost:4317"),
         Arguments.argumentSet("single slash, no host", "https:/foo"),
+        Arguments.argumentSet("empty host with port", "http://:4318"),
         Arguments.argumentSet("no scheme", "localhost"),
         Arguments.argumentSet("wrong scheme", "gopher://localhost"));
   }


### PR DESCRIPTION
## Description

`EndpointUtil.validateEndpoint` rejects hostnames that `java.net.URI#getHost()` cannot parse even when they are valid DNS names. That is [JDK-8188305](https://bugs.openjdk.org/browse/JDK-8188305): RFC 2396 host parsing returns `null` for labels that start with a digit, which is common for Kubernetes namespaces such as `otlp.1234-k8s-namespace`.

The existing `uri.getHost() == null` check was added in #8489 to reject truly host-less URIs (`http:localhost:4317`, `https:/foo`). That check is still needed, but it is too strict when `getHost()` is `null` and a host is present.

This falls back to `URL.getHost()`, the same parser used by `OtlpConfigUtil.validateEndpoint`. Host-less URIs still fail; RFC 1123 names that `URI.getHost()` misses are accepted.

This unblocks the default OkHttp sender (`OkHttpHttpSender` re-parses via `HttpUrl.get`). It does not make `JdkHttpSender` or `UpstreamGrpcSenderProvider` work: those still call `URI.getHost()` / `URI.getPort()`, which stay `null` / `-1` for these names. There is no standard way to build a `java.net.URI` whose `getHost()` returns an RFC 1123 hostname the JDK parser rejects.

Related to #8745. Leaving that issue open to track the JDK HTTP and managed-channel gRPC senders.

## Testing done

- `./gradlew :exporters:common:test --tests io.opentelemetry.exporter.internal.EndpointUtilTest` - 12 tests, 0 failed
  - RED: the three new RFC 1123 cases failed on `URI.getHost() == null` before the change
  - GREEN: all 12 pass after the fallback
- `./gradlew :exporters:common:check` - passed (tests, checkstyle, spotless, japicmp, animalsniffer)
