### PR TITLE
Require explanations for suppressed warnings in OTLP profiles exporter

### DIFF
--- a/exporters/otlp/profiles/build.gradle.kts
+++ b/exporters/otlp/profiles/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 description = "OpenTelemetry - Profiles Exporter"
 otelJava.moduleName.set("io.opentelemetry.exporter.otlp.profiles")
-otelJava.requireSuppressWarningsExplanation.set(false)
 
 val versions = project.property("versions") as Map<*, *>
 

--- a/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/ProfilesRequestMarshalerTest.java
+++ b/exporters/otlp/profiles/src/test/java/io/opentelemetry/exporter/otlp/profiles/ProfilesRequestMarshalerTest.java
@@ -472,7 +472,7 @@ public class ProfilesRequestMarshalerTest {
     return Collections.unmodifiableList(list);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("unchecked") // The prototype's builder produces the same message type T.
   private static <T extends Message> T parse(T prototype, Marshaler marshaler) {
     byte[] serialized = toByteArray(marshaler);
     T result;


### PR DESCRIPTION
Related to #7874

## Description

- #8741 enabled the `SuppressWarningsWithoutExplanation` ErrorProne check for `exporters/logging-otlp` and added a temporary opt-out to every other module. This does the same for `:exporters:otlp:profiles`.
- Removes `otelJava.requireSuppressWarningsExplanation.set(false)` from `build.gradle.kts`, so the default `convention(true)` applies.
- Adds an explanation to the `@SuppressWarnings("unchecked")` in `ProfilesRequestMarshalerTest#parse`, the one suppression here the check flags. Same form as the comments #8741 added.
- The module's other two suppressions (`ReferenceEquality`, `AvoidObjectArrays`) are out of scope: the check only flags `deprecation`, `rawtypes` and `unchecked`.
- This covers one module, so the issue stays open.

## Testing done

- Build flag and one comment only, so no test added.
- `./gradlew :exporters:otlp:profiles:check` — BUILD SUCCESSFUL.
- Confirmed the check is live: with the flag removed but the comment reverted, `compileTestJava` fails with one `SuppressWarningsWithoutExplanation` error, at `ProfilesRequestMarshalerTest.java:475`.
- No apidiff change: alpha artifact, public API untouched.

