### PR TITLE
To Fix ArrayIndexOutOfBoundsException in for VALID_HEX array in OtelEncodingUtils

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -43,7 +43,7 @@ public final class OtelEncodingUtils {
   }
 
   private static boolean[] buildValidHexArray() {
-    boolean[] validHex = new boolean[Character.MAX_VALUE];
+    boolean[] validHex = new boolean[Character.MAX_VALUE + 1];
     // Use the fact that the default initial boolean value is false
     // and only explicitly init the values between the extreme HEX values
     // This minimized impact during process startup esp. on mobile.

--- a/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
@@ -66,6 +66,19 @@ class OtelEncodingUtilsTest {
   }
 
   @Test
+  void isValidBase16Character_doesNotThrowForAnyChar() {
+    // Regression test: VALID_HEX must be indexable by every possible char value,
+    // including Character.MAX_VALUE, without throwing ArrayIndexOutOfBoundsException.
+    assertThat(OtelEncodingUtils.isValidBase16Character(Character.MAX_VALUE)).isFalse();
+    for (int c = 0; c <= Character.MAX_VALUE; c++) {
+      boolean expected = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+      assertThat(OtelEncodingUtils.isValidBase16Character((char) c))
+          .as("char 0x%04x", c)
+          .isEqualTo(expected);
+    }
+  }
+
+  @Test
   void longFromBase16String() {
     assertThat(OtelEncodingUtils.longFromBase16String(CharBuffer.wrap(FIRST_CHAR_ARRAY), 0))
         .isEqualTo(FIRST_LONG);


### PR DESCRIPTION
This PR fixes an issue caused by the `VALID_HEX` array. If we pass `Character.MAX_VALUE`, it throws an `ArrayIndexOutOfBoundsException` instead of returning `false`, so I updated the size from `Character.MAX_VALUE` to `Character.MAX_VALUE + 1`.  I believe this is a valid issue, please let me know if any changes are required, I’ll be happy to update it accordingly.