### PR TITLE
Fix inverted scope_info_enabled and target_info_enabled declarative config flags

### DIFF
--- a/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/internal/PrometheusComponentProvider.java
+++ b/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/internal/PrometheusComponentProvider.java
@@ -47,13 +47,13 @@ public class PrometheusComponentProvider implements ComponentProvider {
       prometheusBuilder.setHost(host);
     }
 
-    Boolean withoutTargetInfo = config.getBoolean("target_info_enabled/development");
-    if (withoutTargetInfo != null) {
-      prometheusBuilder.setTargetInfoMetricEnabled(!withoutTargetInfo);
+    Boolean targetInfoEnabled = config.getBoolean("target_info_enabled/development");
+    if (targetInfoEnabled != null) {
+      prometheusBuilder.setTargetInfoMetricEnabled(targetInfoEnabled);
     }
-    Boolean withoutScopeInfo = config.getBoolean("scope_info_enabled");
-    if (withoutScopeInfo != null) {
-      prometheusBuilder.setOtelScopeLabelsEnabled(!withoutScopeInfo);
+    Boolean scopeInfoEnabled = config.getBoolean("scope_info_enabled");
+    if (scopeInfoEnabled != null) {
+      prometheusBuilder.setOtelScopeLabelsEnabled(scopeInfoEnabled);
     }
     String translationStrategy = config.getString("translation_strategy");
     if (translationStrategy != null) {

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/MetricReaderFactoryTest.java
@@ -163,6 +163,8 @@ class MetricReaderFactoryTest {
         PrometheusHttpServer.builder()
             .setHost("localhost")
             .setPort(prom2Port)
+            .setOtelScopeLabelsEnabled(false)
+            .setTargetInfoMetricEnabled(false)
             .setTranslationStrategy(TranslationStrategy.UNDERSCORE_ESCAPING_WITHOUT_SUFFIXES)
             .setAllowedResourceAttributesFilter(
                 IncludeExcludePredicate.createPatternMatching(


### PR DESCRIPTION


Fixes #8749

## Description

- `PrometheusComponentProvider.create()` passed `!value` to `setOtelScopeLabelsEnabled` and `setTargetInfoMetricEnabled`, so both declarative config options did the opposite of what they say.
- The negation is left over from #8451, which renamed the keys from `without_scope_info` / `without_target_info` to the positive form but kept the `!`.
- The `opentelemetry-configuration` schema and the generated `ExperimentalPrometheusMetricExporterModel` javadoc define both keys as "if omitted or null, true is used".
- Local variables renamed to match the keys.

## Testing done

- `MetricReaderFactoryTest`'s "pull prometheus configured" case feeds `false` for both keys but expected the builder defaults (`true`), so it only passed while the bug existed. The corrected expectation fails before this change and passes after.
- That test lives in `:sdk-extensions:declarative-config` because that is where `ComponentProvider` coverage sits; `:exporters:prometheus` has `:api:incubator` only as `compileOnly`.
- `./gradlew :exporters:prometheus:check` (202 tests) and `:sdk-extensions:declarative-config:check` (514 tests) pass.
- No apidiff update: alpha artifact, `internal` package, no file under `docs/apidiffs/current_vs_latest/`.

