### PR TITLE
Complete the truncated channel shutdown comment in UpstreamGrpcSenderProvider

### DIFF
--- a/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
+++ b/exporters/sender/grpc-managed-channel/src/main/java/io/opentelemetry/exporter/sender/grpc/managedchannel/internal/UpstreamGrpcSenderProvider.java
@@ -39,7 +39,7 @@ public class UpstreamGrpcSenderProvider implements GrpcSenderProvider {
       }
       managedChannel = (ManagedChannel) configManagedChannel;
     } else {
-      // Shutdown the channel as part of the exporter shutdown sequence if
+      // Shutdown the channel as part of the exporter shutdown sequence if we created it.
       shutdownChannel = true;
       managedChannel = minimalFallbackManagedChannel(grpcSenderConfig.getEndpoint());
     }


### PR DESCRIPTION
No issue: trivial comment fix, PR-only per contribution policy.

## Description

- The comment on the fallback branch in `UpstreamGrpcSenderProvider#createSender` ends mid-sentence at "if", so it never states the condition. It has been truncated since #6110 (`da7796b3b`) added it — no full sentence ever existed, so this wording is newly written, not restored.
- The clause comes from the branch itself: this `else` runs when no `ManagedChannel` was configured, so the sender creates the fallback channel and owns it. `shutdownChannel` starts `false`, is set `true` only here, and is read only by `UpstreamGrpcSender.shutdown()` — it expresses channel ownership. Different wording is welcome.
- Comment-only; no behavior, signature, or public API change.

## Testing done

- Comment-only, test-exempt: no test added.
- `./gradlew :exporters:sender:grpc-managed-channel:check` — BUILD SUCCESSFUL, 3 tests passed (`UpstreamGrpcSenderTest`); includes spotless, ErrorProne/NullAway, and jApiCmp.
- `docs/apidiffs/current_vs_latest/opentelemetry-exporter-sender-grpc-managed-channel.txt` still reads `No changes.`, so no apidiff was staged.
- Integration (`*IT`) and GraalVM native-image tests were not run locally.
