### PR TITLE
Fix OkHttpGrpcSender mTLS when using the platform default trust store

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSender.java
@@ -25,6 +25,7 @@ package io.opentelemetry.exporter.sender.okhttp.internal;
 
 import io.opentelemetry.api.impl.InstrumentationUtil;
 import io.opentelemetry.exporter.internal.RetryUtil;
+import io.opentelemetry.exporter.internal.TlsUtil;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.export.Compressor;
 import io.opentelemetry.sdk.common.export.GrpcResponse;
@@ -50,6 +51,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -129,8 +131,16 @@ public final class OkHttpGrpcSender implements GrpcSender {
       clientBuilder.protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE));
     } else {
       clientBuilder.protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
-      if (sslContext != null && trustManager != null) {
-        clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+      if (sslContext != null) {
+        X509TrustManager effectiveTrustManager = trustManager;
+        if (effectiveTrustManager == null) {
+          try {
+            effectiveTrustManager = TlsUtil.defaultTrustManager();
+          } catch (SSLException e) {
+            throw new IllegalStateException("Unable to initialize default trust manager", e);
+          }
+        }
+        clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), effectiveTrustManager);
       }
       if (enabledProtocols != null && !enabledProtocols.isEmpty()) {
         TlsVersion[] versions =

--- a/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderTest.java
+++ b/exporters/sender/okhttp/src/test/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpGrpcSenderTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.exporter.sender.okhttp.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,6 +19,7 @@ import io.opentelemetry.sdk.common.export.MessageWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.ServerSocket;
+import java.security.Security;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
@@ -27,6 +30,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -303,6 +308,61 @@ class OkHttpGrpcSenderTest {
     assertTrue(
         shutdownResult.join(10, TimeUnit.SECONDS).isSuccess(),
         "Shutdown should succeed even when interrupted");
+  }
+
+  @Test
+  void constructor_usesDefaultTrustManagerWhenTrustManagerIsNull() throws Exception {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, null, null);
+
+    assertThatCode(
+            () ->
+                new OkHttpGrpcSender(
+                    "https://localhost",
+                    null,
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(10),
+                    Collections::emptyMap,
+                    null,
+                    sslContext,
+                    null,
+                    null,
+                    Long.MAX_VALUE,
+                    null))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void constructor_wrapsDefaultTrustManagerFailure() throws Exception {
+    String originalAlgorithm = Security.getProperty("ssl.TrustManagerFactory.algorithm");
+
+    try {
+      Security.setProperty("ssl.TrustManagerFactory.algorithm", "invalid");
+
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, null, null);
+
+      assertThatThrownBy(
+              () ->
+                  new OkHttpGrpcSender(
+                      "https://localhost",
+                      null,
+                      Duration.ofSeconds(10),
+                      Duration.ofSeconds(10),
+                      Collections::emptyMap,
+                      null,
+                      sslContext,
+                      null,
+                      null,
+                      Long.MAX_VALUE,
+                      null))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Unable to initialize default trust manager")
+          .hasCauseInstanceOf(SSLException.class);
+
+    } finally {
+      Security.setProperty("ssl.TrustManagerFactory.algorithm", originalAlgorithm);
+    }
   }
 
   /** Simple test marshaler for testing purposes. */


### PR DESCRIPTION
Fixes #8754

## Description

- `OkHttpGrpcSender` installed the client `SSLSocketFactory` only when both an `SSLContext` and an `X509TrustManager` were present. `TlsConfigHelper.getTrustManager()` stays null unless trusted certificates are configured, so `setClientTls(...)` alone skipped the branch and the client certificate was never presented.
- It now falls back to `TlsUtil.defaultTrustManager()`, mirroring `OkHttpHttpSender`, which #8565 (issue #8562) fixed the same way without touching the gRPC sender.
- `HttpExporterBuilder.build()` and `GrpcExporterBuilder.build()` pass the same `isPlainHttp ? null : getSslContext()`, so since #8565 OTLP HTTP exporters already install an explicit `SSLSocketFactory` on https endpoints with no TLS configured; gRPC now matches.
- gRPC sender only. No public API change, so no apidiff update.

## Testing done

- Added `OkHttpGrpcSenderTest#constructor_usesDefaultTrustManagerWhenTrustManagerIsNull` and `#constructor_wrapsDefaultTrustManagerFailure`, mirroring the tests #8565 added to `OkHttpHttpSenderTest`.
- `./gradlew :exporters:sender:okhttp:check` — 48 tests passed.
- Reverting the production change makes `constructor_wrapsDefaultTrustManagerFailure` fail: OkHttp's own trust manager lookup throws `NoSuchAlgorithmException` instead of the wrapped `IllegalStateException`. `constructor_usesDefaultTrustManagerWhenTrustManagerIsNull` still passes, since without the fix the branch is skipped rather than throwing.
