### PR TITLE
Fix OkHttpUtil.newDispatcher javadoc to state the concurrency bounds

### DIFF
--- a/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
+++ b/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpUtil.java
@@ -30,7 +30,11 @@ public final class OkHttpUtil {
     OkHttpUtil.propagateContextForTestingInDispatcher = propagateContextForTestingInDispatcher;
   }
 
-  /** Returns a {@link Dispatcher} using daemon threads, otherwise matching the OkHttp default. */
+  /**
+   * Returns a {@link Dispatcher} using daemon threads, with both the maximum number of concurrent
+   * requests and the maximum size of the backing thread pool bounded to {@code
+   * max(availableProcessors, 5)}, matching the bound used by {@code JdkHttpSender}.
+   */
   public static Dispatcher newDispatcher() {
     int maxRequests = Math.max(Runtime.getRuntime().availableProcessors(), 5);
     Dispatcher dispatcher =


### PR DESCRIPTION
No closing keyword: #8316 also asks for `RejectedExecutionException` handling, which this javadoc-only change does not address, so it should stay open.

## Description

- `OkHttpUtil.newDispatcher()` says the returned `Dispatcher` matches the OkHttp default apart from using daemon threads, but that has not been true since #8422 (`9dd6c38e0`), which changed the code and left the sentence behind.
- OkHttp's `Dispatcher` defaults to `maxRequests = 64` and an executor with an unbounded maximum pool size; this method bounds both to `max(availableProcessors, 5)`.
- That bound was requested during the #8422 review to line the OkHttp sender up with `JdkHttpSender.newExecutor()`, so the javadoc now names it.
- Javadoc only — no code change. `maxRequestsPerHost` is left out because it is still OkHttp's own default.

## Testing done

- Docs-only, test-exempt: no test added. `OkHttpUtilTest.newDispatcher_isBounded()`, added by #8422, already asserts the `max(availableProcessors, 5)` bound the new javadoc describes.
- `./gradlew :exporters:sender:okhttp:check` — 46 tests passed.
- `docs/apidiffs/current_vs_latest/opentelemetry-exporter-sender-okhttp.txt` is unchanged (japicmp does not read javadoc text).
