### PR TITLE
Fix TraceStateBuilder.remove double-counting a repeated removal

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
+++ b/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java
@@ -92,8 +92,13 @@ final class ArrayBasedTraceStateBuilder implements TraceStateBuilder {
     }
     for (int i = 0; i < reversedEntries.size(); i += 2) {
       if (reversedEntries.get(i).equals(key)) {
-        reversedEntries.set(i + 1, null);
-        numEntries--;
+        // Only account for the removal if the entry is still present. A repeated remove of an
+        // already-removed key must be a no-op, mirroring the guard in put(); otherwise numEntries
+        // is decremented twice and build() drops unrelated entries or emits a null-valued entry.
+        if (reversedEntries.get(i + 1) != null) {
+          reversedEntries.set(i + 1, null);
+          numEntries--;
+        }
         return this;
       }
     }

--- a/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/trace/TraceStateTest.java
@@ -304,6 +304,40 @@ class TraceStateTest {
   }
 
   @Test
+  void removeAlreadyRemovedKeyKeepsOtherEntries() {
+    TraceState state =
+        TraceState.builder()
+            .put("a", "1")
+            .put("b", "2")
+            .remove("a")
+            .remove("a") // removing an already-removed key must be a no-op
+            .build();
+    assertThat(state.get("b")).isEqualTo("2");
+    assertThat(state.size()).isEqualTo(1);
+  }
+
+  @Test
+  void removeAlreadyRemovedKeyDoesNotProduceNullValue() {
+    TraceState state = TraceState.builder().put("a", "1").remove("a").remove("a").build();
+    assertThat(state.isEmpty()).isTrue();
+    assertThat(state.get("a")).isNull();
+  }
+
+  @Test
+  void removeAlreadyRemovedKeyWithMultipleEntriesDoesNotThrow() {
+    assertThatCode(
+            () ->
+                TraceState.builder()
+                    .put("a", "1")
+                    .put("b", "2")
+                    .put("c", "3")
+                    .remove("a")
+                    .remove("a")
+                    .build())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   void addAndRemoveEntry() {
     assertThat(
             TraceState.builder()


### PR DESCRIPTION
### Problem

`ArrayBasedTraceStateBuilder.remove(key)` decrements `numEntries` unconditionally, even when the key's slot is already a `null` tombstone from a previous `remove` of the same key. `put()` guards the symmetric update (`if (currentValue == null) { numEntries++; }`); `remove()` has no mirror guard, so a repeated `remove` of an already-removed key double-decrements the count.

Because `build()` trusts `numEntries`, a repeated removal corrupts the result three different ways:

```java
// 1) silent data loss — a valid entry disappears
TraceState.builder().put("a","1").put("b","2").remove("a").remove("a").build();
// numEntries: 2 -> 1 -> 0  =>  build() returns empty();  get("b") == null

// 2) null-valued entry — violates the non-null value contract
TraceState.builder().put("a","1").remove("a").remove("a").build();
// numEntries: 1 -> 0 -> -1 => size()==2 fast path returns [a, null]; size()==1, get("a")==null

// 3) crash
TraceState.builder().put("a","1").put("b","2").put("c","3").remove("a").remove("a").build();
// numEntries under-counts => entries[] is too small => ArrayIndexOutOfBoundsException
```

The `remove` javadoc says it removes the entry "if it is present", so a second `remove` of a key that is no longer present must be a no-op — the same as removing a key that was never added (which `removeNotPresent` already covers).

### Fix

Only account for the removal (set the tombstone and decrement) when the entry is still present, mirroring the guard in `put()`.

### Tests

Added three cases in `TraceStateTest` for the data-loss, null-value, and `ArrayIndexOutOfBoundsException` paths. All three fail against the current code and pass with the fix; the existing `TraceStateTest` cases stay green.
