### PR TITLE
Fix B3Propagator javadoc examples to use current registration API

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3Propagator.java
@@ -26,21 +26,17 @@ import javax.annotation.concurrent.Immutable;
  * <p>To register the default B3 propagator, which injects a single header, use:
  *
  * <pre>{@code
- * OpenTelemetry.setPropagators(
- *   DefaultContextPropagators
- *     .builder()
- *     .addTextMapPropagator(B3Propagator.injectingSingleHeader())
- *     .build());
+ * OpenTelemetrySdk.builder()
+ *     .setPropagators(ContextPropagators.create(B3Propagator.injectingSingleHeader()))
+ *     .build();
  * }</pre>
  *
  * <p>To register a B3 propagator that injects multiple headers, use:
  *
  * <pre>{@code
- * OpenTelemetry.setPropagators(
- *   DefaultContextPropagators
- *     .builder()
- *     .addTextMapPropagator(B3Propagator.injectingMultiHeaders())
- *     .build());
+ * OpenTelemetrySdk.builder()
+ *     .setPropagators(ContextPropagators.create(B3Propagator.injectingMultiHeaders()))
+ *     .build();
  * }</pre>
  */
 @Immutable


### PR DESCRIPTION
Fixes #8765

## Description

- The two registration examples in the `B3Propagator` class javadoc do not compile: `OpenTelemetry.setPropagators(...)` was removed in #2341, and `DefaultContextPropagators` became package-private in #2089, losing `builder()` and `addTextMapPropagator()`.
- Rewrites both examples as `OpenTelemetrySdk.builder().setPropagators(ContextPropagators.create(...)).build()`, the form already used in `integration-tests/.../B3PropagationIntegrationTest.java`.
- The examples stay inside `<pre>{@code ...}</pre>`, so this adds no `{@link}` target and no SDK dependency for this module.
- The module has no README, so this javadoc is the only documentation on registering the B3 propagator.
- Same kind of fix as #8715, which corrected javadoc examples in the context propagation interfaces.

## Testing done

- Docs-only, test-exempt: javadoc text only, no behavior, signature, or public API change.
- `./gradlew :extensions:trace-propagators:spotlessApply` then `:extensions:trace-propagators:check` — BUILD SUCCESSFUL.
- No `docs/apidiffs/current_vs_latest/*.txt` change.

