### PR TITLE
Fix B3 propagator Javadoc markup and grammar

### DIFF
--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/B3ConfigurablePropagator.java
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 
 /**
  * A {@link ConfigurablePropagatorProvider} which allows enabling the {@linkplain
- * B3Propagator#injectingSingleHeader()} B3-single propagator} with the propagator name {@code b3}.
+ * B3Propagator#injectingSingleHeader() B3-single propagator} with the propagator name {@code b3}.
  */
 public final class B3ConfigurablePropagator implements ConfigurablePropagatorProvider {
   @Override

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/internal/B3ComponentProvider.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/internal/B3ComponentProvider.java
@@ -11,7 +11,7 @@ import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 
 /**
- * Declarative configuration SPI implementation for {@link B3Propagator} which allows enables the
+ * Declarative configuration SPI implementation for {@link B3Propagator} which allows enabling
  * {@link B3Propagator#injectingSingleHeader()}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change

--- a/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/internal/B3MultiComponentProvider.java
+++ b/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/internal/B3MultiComponentProvider.java
@@ -11,7 +11,7 @@ import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 
 /**
- * Declarative configuration SPI implementation for {@link B3Propagator} which allows enables the
+ * Declarative configuration SPI implementation for {@link B3Propagator} which allows enabling
  * {@link B3Propagator#injectingMultiHeaders()}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change


### PR DESCRIPTION
## Description

- `B3ConfigurablePropagator`: the `{@linkplain}` tag closed right after `injectingSingleHeader()`, so the label "B3-single propagator" rendered as plain text followed by a stray `}`. Moved the closing brace after the label, matching the sibling `B3MultiConfigurablePropagator`.
- `B3ComponentProvider` and `B3MultiComponentProvider`: "which allows enables the" is not a sentence. Changed to "which allows enabling", matching the four `*ConfigurablePropagator` classes in the same module.
- Same markup error as #8588, which fixed the `context` module and left `extensions` untouched.

## Testing done

- Docs-only, test-exempt: javadoc text only, no signature, bytecode, or runtime change.
- `./gradlew :extensions:trace-propagators:spotlessApply` then `:extensions:trace-propagators:check` — BUILD SUCCESSFUL.
- `docs/apidiffs/current_vs_latest/` unchanged after `check`.

