### PR TITLE
Run CompletableResultCode completion action outside the lock

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -8,12 +8,15 @@ package io.opentelemetry.sdk.common;
 import io.opentelemetry.api.internal.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -24,6 +27,9 @@ import javax.annotation.Nullable;
  * convey a result at a later time. CompletableResultCode facilitates this.
  */
 public final class CompletableResultCode {
+
+  private static final Logger logger = Logger.getLogger(CompletableResultCode.class.getName());
+
   /** Returns a {@link CompletableResultCode} that has been completed successfully. */
   public static CompletableResultCode ofSuccess() {
     return SUCCESS;
@@ -100,15 +106,7 @@ public final class CompletableResultCode {
 
   /** Complete this {@link CompletableResultCode} successfully if it is not already completed. */
   public CompletableResultCode succeed() {
-    synchronized (lock) {
-      if (succeeded == null) {
-        succeeded = true;
-        for (Runnable action : completionActions) {
-          action.run();
-        }
-      }
-    }
-    return this;
+    return complete(/* success= */ true, /* throwable= */ null);
   }
 
   /**
@@ -131,16 +129,47 @@ public final class CompletableResultCode {
   }
 
   private CompletableResultCode failInternal(@Nullable Throwable throwable) {
+    return complete(/* success= */ false, throwable);
+  }
+
+  private CompletableResultCode complete(boolean success, @Nullable Throwable throwable) {
+    List<Runnable> actions = null;
     synchronized (lock) {
       if (succeeded == null) {
-        succeeded = false;
-        this.throwable = throwable;
-        for (Runnable action : completionActions) {
-          action.run();
+        succeeded = success;
+        if (!success) {
+          this.throwable = throwable;
+        }
+        if (!completionActions.isEmpty()) {
+          actions = new ArrayList<>(completionActions);
+          completionActions.clear();
         }
       }
     }
+    // Completion actions run without the lock held. Running them under the lock lets an action
+    // which completes another result deadlock through lock inversion.
+    if (actions != null) {
+      runActions(actions);
+    }
     return this;
+  }
+
+  private static void runActions(List<Runnable> actions) {
+    RuntimeException firstException = null;
+    for (Runnable action : actions) {
+      try {
+        action.run();
+      } catch (RuntimeException e) {
+        // Continue executing the remaining actions, so ofAll is not blocked from completing.
+        logger.log(Level.WARNING, "Exception thrown by completion action.", e);
+        if (firstException == null) {
+          firstException = e;
+        }
+      }
+    }
+    if (firstException != null) {
+      throw firstException;
+    }
   }
 
   /**
@@ -173,7 +202,10 @@ public final class CompletableResultCode {
   }
 
   /**
-   * Perform an action on completion. Actions are guaranteed to be called only once.
+   * Perform an action on completion. Actions are guaranteed to be called only once. Actions are not
+   * invoked while internal locks are held. Every action runs even if an earlier one throws a {@link
+   * RuntimeException}. Each exception is logged, and the first one is rethrown after all the
+   * actions have executed.
    *
    * @param action the action to perform
    * @return this completable result so that it may be further composed
@@ -188,7 +220,7 @@ public final class CompletableResultCode {
       }
     }
     if (runNow) {
-      action.run();
+      runActions(Collections.singletonList(action));
     }
     return this;
   }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -233,5 +235,98 @@ class CompletableResultCodeTest {
     await().untilAsserted(() -> assertThat(interrupted).hasValue(true));
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.isDone()).isFalse();
+  }
+
+  @Test
+  void callbackCompletionAnotherResultDoesNotDeadlock() throws InterruptedException {
+    CompletableResultCode first = new CompletableResultCode();
+    CompletableResultCode second = new CompletableResultCode();
+    CountDownLatch callbackEntered = new CountDownLatch(2);
+    CountDownLatch release = new CountDownLatch(1);
+
+    first.whenComplete(
+        () -> {
+          callbackEntered.countDown();
+          Uninterruptibles.awaitUninterruptibly(release);
+          second.succeed();
+        });
+
+    second.whenComplete(
+        () -> {
+          callbackEntered.countDown();
+          Uninterruptibles.awaitUninterruptibly(release);
+          first.succeed();
+        });
+
+    Thread firstThread = new Thread(first::succeed, "complete-first");
+    Thread secondThread = new Thread(second::succeed, "complete-second");
+    firstThread.setDaemon(true);
+    secondThread.setDaemon(true);
+    firstThread.start();
+    secondThread.start();
+
+    assertThat(callbackEntered.await(10, TimeUnit.SECONDS)).isTrue();
+    release.countDown();
+
+    firstThread.join(10_000);
+    secondThread.join(10_000);
+
+    assertThat(firstThread.isAlive()).isFalse();
+    assertThat(secondThread.isAlive()).isFalse();
+    assertThat(first.isSuccess()).isTrue();
+    assertThat(second.isSuccess()).isTrue();
+  }
+
+  @Test
+  void completionActionExceptionDoesNotAbortLaterActions() {
+    CompletableResultCode result = new CompletableResultCode();
+    AtomicBoolean actionInvoked = new AtomicBoolean();
+
+    result.whenComplete(
+        () -> {
+          throw new RuntimeException("callback failure");
+        });
+    result.whenComplete(() -> actionInvoked.set(true));
+    assertThatThrownBy(result::succeed)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("callback failure");
+
+    assertThat(actionInvoked).isTrue();
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
+  void completionActionExceptionDoesNotPreventOfAllCompletion() {
+    CompletableResultCode source = new CompletableResultCode();
+    CompletableResultCode other = new CompletableResultCode();
+
+    // Registered before ofAll so that it runs before ofAll's bookkeeping action.
+    source.whenComplete(
+        () -> {
+          throw new RuntimeException("callback failure");
+        });
+    CompletableResultCode all = CompletableResultCode.ofAll(Arrays.asList(source, other));
+    other.succeed();
+
+    assertThatThrownBy(source::succeed)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("callback failure");
+
+    assertThat(all.isDone()).isTrue();
+    assertThat(all.isSuccess()).isTrue();
+  }
+
+  @Test
+  void completionActionExceptionPropagatesWhenAlreadyComplete() {
+    CompletableResultCode result = new CompletableResultCode().succeed();
+
+    assertThatThrownBy(
+            () ->
+                result.whenComplete(
+                    () -> {
+                      throw new RuntimeException("callback failure");
+                    }))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("callback failure");
   }
 }


### PR DESCRIPTION
Fixes #8771

**Problem**

CompletableResultCode#succeed and failInternal run completion actions while holding a lock. This can cause a deadlock if two actions try to complete each other. Also, if an action throws an exception, the remaining actions are skipped and the result may never complete.

**Solution**

Both methods now use a shared complete method. It updates the result and copies the actions while holding the lock, then releases the lock before running them. runActions logs each exception, continues running the remaining actions, and rethrows the first exception at the end. whenComplete also uses runActions when the result is already complete.

