### PR TITLE
Handle completion callback exceptions

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/CompletableResultCode.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.common;
 import io.opentelemetry.api.internal.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -100,14 +101,18 @@ public final class CompletableResultCode {
 
   /** Complete this {@link CompletableResultCode} successfully if it is not already completed. */
   public CompletableResultCode succeed() {
+    List<Runnable> actions;
     synchronized (lock) {
-      if (succeeded == null) {
-        succeeded = true;
-        for (Runnable action : completionActions) {
-          action.run();
-        }
+      if (succeeded != null) {
+        return this;
       }
+
+      succeeded = true;
+      actions = new ArrayList<>(completionActions);
+      completionActions.clear();
     }
+
+    runCompletionActions(actions);
     return this;
   }
 
@@ -131,16 +136,38 @@ public final class CompletableResultCode {
   }
 
   private CompletableResultCode failInternal(@Nullable Throwable throwable) {
+    List<Runnable> actions;
     synchronized (lock) {
-      if (succeeded == null) {
-        succeeded = false;
-        this.throwable = throwable;
-        for (Runnable action : completionActions) {
-          action.run();
+      if (succeeded != null) {
+        return this;
+      }
+
+      succeeded = false;
+      this.throwable = throwable;
+      actions = new ArrayList<>(completionActions);
+      completionActions.clear();
+    }
+
+    runCompletionActions(actions);
+    return this;
+  }
+
+  private static void runCompletionActions(List<Runnable> actions) {
+    RuntimeException firstFailure = null;
+
+    for (Runnable action : actions) {
+      try {
+        action.run();
+      } catch (RuntimeException e) {
+        if (firstFailure == null) {
+          firstFailure = e;
         }
       }
     }
-    return this;
+
+    if (firstFailure != null) {
+      throw firstFailure;
+    }
   }
 
   /**
@@ -188,7 +215,7 @@ public final class CompletableResultCode {
       }
     }
     if (runNow) {
-      action.run();
+      runCompletionActions(Collections.singletonList(action));
     }
     return this;
   }

--- a/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
+++ b/sdk/common/src/test/java/io/opentelemetry/sdk/common/CompletableResultCodeTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -121,6 +123,87 @@ class CompletableResultCodeTest {
     completions.await(3, TimeUnit.SECONDS);
 
     assertThat(resultCode.isSuccess()).isTrue();
+  }
+
+  @Test
+  void completionCallbacksDoNotDeadlockWhenCompletingEachOther() throws InterruptedException {
+    CompletableResultCode first = new CompletableResultCode();
+    CompletableResultCode second = new CompletableResultCode();
+
+    CountDownLatch callbacksEntered = new CountDownLatch(2);
+    CountDownLatch release = new CountDownLatch(1);
+
+    first.whenComplete(
+        () -> {
+          callbacksEntered.countDown();
+          Uninterruptibles.awaitUninterruptibly(release);
+          second.succeed();
+        });
+
+    second.whenComplete(
+        () -> {
+          callbacksEntered.countDown();
+          Uninterruptibles.awaitUninterruptibly(release);
+          first.succeed();
+        });
+
+    Thread firstThread = new Thread(first::succeed);
+    Thread secondThread = new Thread(second::succeed);
+    firstThread.setDaemon(true);
+    secondThread.setDaemon(true);
+
+    firstThread.start();
+    secondThread.start();
+
+    assertThat(callbacksEntered.await(3, TimeUnit.SECONDS)).isTrue();
+
+    release.countDown();
+
+    firstThread.join(3_000);
+    secondThread.join(3_000);
+
+    assertThat(firstThread.isAlive()).isFalse();
+    assertThat(secondThread.isAlive()).isFalse();
+  }
+
+  @Test
+  void callbackExceptionDoesNotPreventLaterCallbacks() {
+    CompletableResultCode resultCode = new CompletableResultCode();
+    AtomicBoolean laterCallbackInvoked = new AtomicBoolean();
+
+    resultCode.whenComplete(
+        () -> {
+          throw new RuntimeException("callback failure");
+        });
+
+    resultCode.whenComplete(() -> laterCallbackInvoked.set(true));
+
+    assertThatThrownBy(resultCode::succeed)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("callback failure");
+
+    assertThat(laterCallbackInvoked).isTrue();
+  }
+
+  @Test
+  void callbackExceptionDoesNotPreventOfAllCompletion() {
+    CompletableResultCode source = new CompletableResultCode();
+    CompletableResultCode other = new CompletableResultCode();
+
+    source.whenComplete(
+        () -> {
+          throw new RuntimeException("callback failure");
+        });
+
+    CompletableResultCode all = CompletableResultCode.ofAll(Arrays.asList(source, other));
+
+    other.succeed();
+
+    assertThatThrownBy(source::succeed)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("callback failure");
+
+    assertThat(all.isDone()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description

Ensure exceptions thrown by completion callbacks do not prevent subsequent callbacks from being executed.

### Changes

* Execute all completion callbacks even when one callback throws a `RuntimeException`.
* Propagate the first callback exception after all callbacks have been executed.
* Apply the same behavior when callbacks are registered after completion.
* Added tests covering callback exception handling and `ofAll` completion.

### Testing

* Added test coverage to verify later callbacks are still invoked.
* Verified `ofAll` completes even when a completion callback throws.


Fixes #8771 