### PR TITLE
Require explanations for suppressed warnings in SDK common

### DIFF
--- a/sdk/common/build.gradle.kts
+++ b/sdk/common/build.gradle.kts
@@ -10,7 +10,6 @@ apply<OtelVersionClassPlugin>()
 
 description = "OpenTelemetry SDK Common"
 otelJava.moduleName.set("io.opentelemetry.sdk.common")
-otelJava.requireSuppressWarningsExplanation.set(false)
 otelJava.osgiOptionalPackages.set(listOf("io.opentelemetry.api.incubator"))
 
 dependencies {

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributeUtil.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributeUtil.java
@@ -32,6 +32,7 @@ public final class AttributeUtil {
    * with the limits applied. {@code countLimit} limits the number of unique attribute keys. {@code
    * lengthLimit} limits the length of attribute string and string list values.
    */
+  // Attributes guarantees matching key/value types, and length limiting preserves value types.
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Attributes applyAttributesLimit(
       Attributes attributes, int countLimit, int lengthLimit) {
@@ -78,10 +79,12 @@ public final class AttributeUtil {
       ByteBuffer buffer = (ByteBuffer) value.getValue();
       return buffer.remaining() <= lengthLimit;
     } else if (type == ValueType.ARRAY) {
+      // ValueType.ARRAY guarantees a List<Value<?>>.
       @SuppressWarnings("unchecked")
       List<Value<?>> array = (List<Value<?>>) value.getValue();
       return allMatch(array, element -> isValidLengthValue(element, lengthLimit));
     } else if (type == ValueType.KEY_VALUE_LIST) {
+      // ValueType.KEY_VALUE_LIST guarantees a List<KeyValue>.
       @SuppressWarnings("unchecked")
       List<KeyValue> kvList = (List<KeyValue>) value.getValue();
       return allMatch(kvList, kv -> isValidLengthValue(kv.getValue(), lengthLimit));
@@ -135,6 +138,7 @@ public final class AttributeUtil {
     return value;
   }
 
+  // The ValueType checks below ensure the list casts match Value.getValue()'s contract.
   @SuppressWarnings("unchecked")
   private static Value<?> applyValueLengthLimit(Value<?> value, int lengthLimit) {
     ValueType type = value.getType();

--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/internal/AttributesMap.java
@@ -162,6 +162,7 @@ public final class AttributesMap implements Attributes {
     return totalAddedValues;
   }
 
+  // put requires matching key/value types, and the stored key type is checked before casting.
   @SuppressWarnings("unchecked")
   @Override
   @Nullable


### PR DESCRIPTION
Adds explanations for the attribute key and value casts in `AttributeUtil` and `AttributesMap`, and enables the suppression check for `:sdk:common` by removing its opt out.

Part of #7874.

Verified on Windows with JDK 21 using `.\gradlew.bat :sdk:common:check :sdk:common:compileJmhJava --no-build-cache`. All 215 module tests passed. With only the opt out removed, `:sdk:common:compileJava` failed on four `SuppressWarningsWithoutExplanation` errors; the explanations resolve them.