### PR TITLE
Add number of affected items to Exporter error logging

### DIFF
--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
@@ -137,9 +137,7 @@ public final class GrpcExporter {
         e);
     if (logger.isLoggable(Level.FINEST)) {
       logger.log(
-          Level.FINEST,
-          "Failed to export " + numItems + " " + type + "(s). Details follow:",
-          e);
+          Level.FINEST, "Failed to export " + numItems + " " + type + "(s). Details follow:", e);
     }
     result.failExceptionally(FailedExportException.grpcFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
@@ -68,8 +68,8 @@ public final class GrpcExporter {
 
     grpcSender.send(
         exportRequest.toBinaryMessageWriter(),
-        grpcResponse -> onResponse(result, metricRecording, grpcResponse),
-        throwable -> onError(result, metricRecording, throwable));
+        grpcResponse -> onResponse(result, metricRecording, grpcResponse, numItems),
+        throwable -> onError(result, metricRecording, throwable, numItems));
 
     return result;
   }
@@ -77,7 +77,8 @@ public final class GrpcExporter {
   private void onResponse(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      GrpcResponse grpcResponse) {
+      GrpcResponse grpcResponse,
+      int numItems) {
     GrpcStatusCode statusCode = grpcResponse.getStatusCode();
 
     metricRecording.setGrpcStatusCode(statusCode);
@@ -100,8 +101,10 @@ public final class GrpcExporter {
         logger.log(
             Level.SEVERE,
             "Failed to export "
+                + numItems
+                + " "
                 + type
-                + "s. Server is UNAVAILABLE. "
+                + "(s). Server is UNAVAILABLE. "
                 + "Make sure your collector is running and reachable from this network. "
                 + "Full error message:"
                 + grpcResponse.getStatusDescription());
@@ -110,8 +113,10 @@ public final class GrpcExporter {
         logger.log(
             Level.WARNING,
             "Failed to export "
+                + numItems
+                + " "
                 + type
-                + "s. Server responded with gRPC status code "
+                + "(s). Server responded with gRPC status code "
                 + statusCode.getValue()
                 + ". Error message: "
                 + grpcResponse.getStatusDescription());
@@ -123,12 +128,18 @@ public final class GrpcExporter {
   private void onError(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      Throwable e) {
+      Throwable e,
+      int numItems) {
     metricRecording.finishFailed(e);
     logger.log(
-        Level.SEVERE, "Failed to export " + type + "s. The request could not be executed.", e);
+        Level.SEVERE,
+        "Failed to export " + numItems + " " + type + "(s). The request could not be executed.",
+        e);
     if (logger.isLoggable(Level.FINEST)) {
-      logger.log(Level.FINEST, "Failed to export " + type + "s. Details follow:", e);
+      logger.log(
+          Level.FINEST,
+          "Failed to export " + numItems + " " + type + "(s). Details follow:",
+          e);
     }
     result.failExceptionally(FailedExportException.grpcFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
@@ -101,31 +101,25 @@ public final class GrpcExporter {
         logger.log(
             Level.SEVERE,
             "Failed to export "
+                + numItems
+                + " "
                 + type
                 + "s. Server is UNAVAILABLE. "
                 + "Make sure your collector is running and reachable from this network. "
                 + "Full error message:"
-                + grpcResponse.getStatusDescription()
-                + ". Failed to export "
-                + numItems
-                + " "
-                + type
-                + "(s).");
+                + grpcResponse.getStatusDescription());
         break;
       default:
         logger.log(
             Level.WARNING,
             "Failed to export "
+                + numItems
+                + " "
                 + type
                 + "s. Server responded with gRPC status code "
                 + statusCode.getValue()
                 + ". Error message: "
-                + grpcResponse.getStatusDescription()
-                + ". Failed to export "
-                + numItems
-                + " "
-                + type
-                + "(s).");
+                + grpcResponse.getStatusDescription());
         break;
     }
     result.failExceptionally(FailedExportException.grpcFailedWithResponse(grpcResponse));
@@ -139,25 +133,11 @@ public final class GrpcExporter {
     metricRecording.finishFailed(e);
     logger.log(
         Level.SEVERE,
-        "Failed to export "
-            + type
-            + "s. The request could not be executed. Failed to export "
-            + numItems
-            + " "
-            + type
-            + "(s).",
+        "Failed to export " + numItems + " " + type + "s. The request could not be executed.",
         e);
     if (logger.isLoggable(Level.FINEST)) {
       logger.log(
-          Level.FINEST,
-          "Failed to export "
-              + type
-              + "s. Failed to export "
-              + numItems
-              + " "
-              + type
-              + "(s). Details follow:",
-          e);
+          Level.FINEST, "Failed to export " + numItems + " " + type + "s. Details follow:", e);
     }
     result.failExceptionally(FailedExportException.grpcFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/GrpcExporter.java
@@ -69,7 +69,7 @@ public final class GrpcExporter {
     grpcSender.send(
         exportRequest.toBinaryMessageWriter(),
         grpcResponse -> onResponse(result, metricRecording, grpcResponse, numItems),
-        throwable -> onError(result, metricRecording, throwable, numItems));
+        throwable -> onError(result, metricRecording, numItems, throwable));
 
     return result;
   }
@@ -101,25 +101,31 @@ public final class GrpcExporter {
         logger.log(
             Level.SEVERE,
             "Failed to export "
+                + type
+                + "s. Server is UNAVAILABLE. "
+                + "Make sure your collector is running and reachable from this network. "
+                + "Full error message:"
+                + grpcResponse.getStatusDescription()
+                + ". Failed to export "
                 + numItems
                 + " "
                 + type
-                + "(s). Server is UNAVAILABLE. "
-                + "Make sure your collector is running and reachable from this network. "
-                + "Full error message:"
-                + grpcResponse.getStatusDescription());
+                + "(s).");
         break;
       default:
         logger.log(
             Level.WARNING,
             "Failed to export "
+                + type
+                + "s. Server responded with gRPC status code "
+                + statusCode.getValue()
+                + ". Error message: "
+                + grpcResponse.getStatusDescription()
+                + ". Failed to export "
                 + numItems
                 + " "
                 + type
-                + "(s). Server responded with gRPC status code "
-                + statusCode.getValue()
-                + ". Error message: "
-                + grpcResponse.getStatusDescription());
+                + "(s).");
         break;
     }
     result.failExceptionally(FailedExportException.grpcFailedWithResponse(grpcResponse));
@@ -128,16 +134,30 @@ public final class GrpcExporter {
   private void onError(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      Throwable e,
-      int numItems) {
+      int numItems,
+      Throwable e) {
     metricRecording.finishFailed(e);
     logger.log(
         Level.SEVERE,
-        "Failed to export " + numItems + " " + type + "(s). The request could not be executed.",
+        "Failed to export "
+            + type
+            + "s. The request could not be executed. Failed to export "
+            + numItems
+            + " "
+            + type
+            + "(s).",
         e);
     if (logger.isLoggable(Level.FINEST)) {
       logger.log(
-          Level.FINEST, "Failed to export " + numItems + " " + type + "(s). Details follow:", e);
+          Level.FINEST,
+          "Failed to export "
+              + type
+              + "s. Failed to export "
+              + numItems
+              + " "
+              + type
+              + "(s). Details follow:",
+          e);
     }
     result.failExceptionally(FailedExportException.grpcFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
@@ -105,16 +105,13 @@ public final class HttpExporter {
     logger.log(
         Level.WARNING,
         "Failed to export "
+            + numItems
+            + " "
             + type
             + "s. Server responded with HTTP status code "
             + statusCode
             + ". Error message: "
-            + status
-            + ". Failed to export "
-            + numItems
-            + " "
-            + type
-            + "(s).");
+            + status);
 
     result.failExceptionally(FailedExportException.httpFailedWithResponse(httpResponse));
   }
@@ -127,13 +124,7 @@ public final class HttpExporter {
     metricRecording.finishFailed(e);
     logger.log(
         Level.SEVERE,
-        "Failed to export "
-            + type
-            + "s. The request could not be executed. Failed to export "
-            + numItems
-            + " "
-            + type
-            + "(s).",
+        "Failed to export " + numItems + " " + type + "s. The request could not be executed.",
         e);
     result.failExceptionally(FailedExportException.httpFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
@@ -76,7 +76,7 @@ public final class HttpExporter {
     httpSender.send(
         messageWriter,
         httpResponse -> onResponse(result, metricRecording, httpResponse, numItems),
-        throwable -> onError(result, metricRecording, throwable, numItems));
+        throwable -> onError(result, metricRecording, numItems, throwable));
 
     return result;
   }
@@ -105,13 +105,16 @@ public final class HttpExporter {
     logger.log(
         Level.WARNING,
         "Failed to export "
+            + type
+            + "s. Server responded with HTTP status code "
+            + statusCode
+            + ". Error message: "
+            + status
+            + ". Failed to export "
             + numItems
             + " "
             + type
-            + "(s). Server responded with HTTP status code "
-            + statusCode
-            + ". Error message: "
-            + status);
+            + "(s).");
 
     result.failExceptionally(FailedExportException.httpFailedWithResponse(httpResponse));
   }
@@ -119,12 +122,18 @@ public final class HttpExporter {
   private void onError(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      Throwable e,
-      int numItems) {
+      int numItems,
+      Throwable e) {
     metricRecording.finishFailed(e);
     logger.log(
         Level.SEVERE,
-        "Failed to export " + numItems + " " + type + "(s). The request could not be executed.",
+        "Failed to export "
+            + type
+            + "s. The request could not be executed. Failed to export "
+            + numItems
+            + " "
+            + type
+            + "(s).",
         e);
     result.failExceptionally(FailedExportException.httpFailedExceptionally(e));
   }

--- a/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
+++ b/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/internal/HttpExporter.java
@@ -75,8 +75,8 @@ public final class HttpExporter {
 
     httpSender.send(
         messageWriter,
-        httpResponse -> onResponse(result, metricRecording, httpResponse),
-        throwable -> onError(result, metricRecording, throwable));
+        httpResponse -> onResponse(result, metricRecording, httpResponse, numItems),
+        throwable -> onError(result, metricRecording, throwable, numItems));
 
     return result;
   }
@@ -84,7 +84,8 @@ public final class HttpExporter {
   private void onResponse(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      HttpResponse httpResponse) {
+      HttpResponse httpResponse,
+      int numItems) {
     int statusCode = httpResponse.getStatusCode();
 
     metricRecording.setHttpStatusCode(statusCode);
@@ -104,8 +105,10 @@ public final class HttpExporter {
     logger.log(
         Level.WARNING,
         "Failed to export "
+            + numItems
+            + " "
             + type
-            + "s. Server responded with HTTP status code "
+            + "(s). Server responded with HTTP status code "
             + statusCode
             + ". Error message: "
             + status);
@@ -116,10 +119,13 @@ public final class HttpExporter {
   private void onError(
       CompletableResultCode result,
       ExporterInstrumentation.Recording metricRecording,
-      Throwable e) {
+      Throwable e,
+      int numItems) {
     metricRecording.finishFailed(e);
     logger.log(
-        Level.SEVERE, "Failed to export " + type + "s. The request could not be executed.", e);
+        Level.SEVERE,
+        "Failed to export " + numItems + " " + type + "(s). The request could not be executed.",
+        e);
     result.failExceptionally(FailedExportException.httpFailedExceptionally(e));
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -826,10 +826,11 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export 1 "
+              "Failed to export "
                   + type
-                  + "(s). Server responded with gRPC status code 13. Error message:");
+                  + "s. Server responded with gRPC status code 13. Error message:");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
+      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -870,10 +871,11 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export 1 "
+              "Failed to export "
                   + type
-                  + "(s). Server responded with gRPC status code 8. Error message: out of quota");
+                  + "s. Server responded with gRPC status code 8. Error message: out of quota");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
+      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -891,10 +893,11 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export 1 "
+              "Failed to export "
                   + type
-                  + "(s). Server responded with gRPC status code 5. Error message: クマ🐻");
+                  + "s. Server responded with gRPC status code 5. Error message: クマ🐻");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
+      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -912,11 +915,12 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export 1 "
+              "Failed to export "
                   + type
-                  + "(s). Server is UNAVAILABLE. "
+                  + "s. Server is UNAVAILABLE. "
                   + "Make sure your collector is running and reachable from this network.");
       assertThat(log.getLevel()).isEqualTo(Level.ERROR);
+      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -826,9 +826,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
-                  + "s. Server responded with gRPC status code 13. Error message:");
+                  + "(s). Server responded with gRPC status code 13. Error message:");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
     }
   }
@@ -870,9 +870,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
-                  + "s. Server responded with gRPC status code 8. Error message: out of quota");
+                  + "(s). Server responded with gRPC status code 8. Error message: out of quota");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
     }
   }
@@ -891,9 +891,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
-                  + "s. Server responded with gRPC status code 5. Error message: クマ🐻");
+                  + "(s). Server responded with gRPC status code 5. Error message: クマ🐻");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
     }
   }
@@ -912,9 +912,9 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
-                  + "s. Server is UNAVAILABLE. "
+                  + "(s). Server is UNAVAILABLE. "
                   + "Make sure your collector is running and reachable from this network.");
       assertThat(log.getLevel()).isEqualTo(Level.ERROR);
     }

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractGrpcTelemetryExporterTest.java
@@ -826,11 +826,10 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
 
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
                   + "s. Server responded with gRPC status code 13. Error message:");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
-      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -871,11 +870,10 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
                   + "s. Server responded with gRPC status code 8. Error message: out of quota");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
-      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -893,11 +891,10 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
                   + "s. Server responded with gRPC status code 5. Error message: クマ🐻");
       assertThat(log.getLevel()).isEqualTo(Level.WARN);
-      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 
@@ -915,12 +912,11 @@ public abstract class AbstractGrpcTelemetryExporterTest<T, U extends Message> {
           .isFalse();
       LoggingEvent log =
           logs.assertContains(
-              "Failed to export "
+              "Failed to export 1 "
                   + type
                   + "s. Server is UNAVAILABLE. "
                   + "Make sure your collector is running and reachable from this network.");
       assertThat(log.getLevel()).isEqualTo(Level.ERROR);
-      assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
     }
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -611,9 +611,9 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
 
     LoggingEvent log =
         logs.assertContains(
-            "Failed to export "
+            "Failed to export 1 "
                 + type
-                + "s. Server responded with HTTP status code 500. Error message:");
+                + "(s). Server responded with HTTP status code 500. Error message:");
     assertThat(log.getLevel()).isEqualTo(Level.WARN);
   }
 

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -611,11 +611,10 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
 
     LoggingEvent log =
         logs.assertContains(
-            "Failed to export "
+            "Failed to export 1 "
                 + type
                 + "s. Server responded with HTTP status code 500. Error message:");
     assertThat(log.getLevel()).isEqualTo(Level.WARN);
-    assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
   }
 
   @Test

--- a/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
+++ b/exporters/otlp/testing-internal/src/main/java/io/opentelemetry/exporter/otlp/testing/internal/AbstractHttpTelemetryExporterTest.java
@@ -611,10 +611,11 @@ public abstract class AbstractHttpTelemetryExporterTest<T, U extends Message> {
 
     LoggingEvent log =
         logs.assertContains(
-            "Failed to export 1 "
+            "Failed to export "
                 + type
-                + "(s). Server responded with HTTP status code 500. Error message:");
+                + "s. Server responded with HTTP status code 500. Error message:");
     assertThat(log.getLevel()).isEqualTo(Level.WARN);
+    assertThat(log.getMessage()).endsWith("Failed to export 1 " + type + "(s).");
   }
 
   @Test


### PR DESCRIPTION
when debugging exported traces, it was hard for me to asses impact the issue, because it was not known how many spans weren't exported. this is similar to what was added to `BatchSpanProcessor` in https://github.com/open-telemetry/opentelemetry-java/pull/8167 . here the change was even simpler - we just push down the value we already had in exporter