### PR TITLE
Fix bound instruments pinning context-derived attributes

### DIFF
--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleCounter.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * record directly without the per-recording attribute processing and map lookup that {@link
  * DoubleCounter#add(double, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundDoubleCounter {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleGauge.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleGauge.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * record directly without the per-recording attribute processing and map lookup that {@link
  * DoubleGauge#set(double, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundDoubleGauge {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * record directly without the per-recording attribute processing and map lookup that {@link
  * DoubleHistogram#record(double, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundDoubleHistogram {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleUpDownCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundDoubleUpDownCounter.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * record directly without the per-recording attribute processing and map lookup that {@link
  * DoubleUpDownCounter#add(double, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundDoubleUpDownCounter {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongCounter.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * directly without the per-recording attribute processing and map lookup that {@link
  * LongCounter#add(long, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundLongCounter {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongGauge.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongGauge.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * directly without the per-recording attribute processing and map lookup that {@link
  * LongGauge#set(long, Attributes)} performs. This is useful when the set of attribute combinations
  * is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundLongGauge {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongHistogram.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongHistogram.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * record directly without the per-recording attribute processing and map lookup that {@link
  * LongHistogram#record(long, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundLongHistogram {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongUpDownCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/BoundLongUpDownCounter.java
@@ -18,6 +18,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * directly without the per-recording attribute processing and map lookup that {@link
  * LongUpDownCounter#add(long, Attributes)} performs. This is useful when the set of attribute
  * combinations is known ahead of time and the same series is recorded to repeatedly.
+ *
+ * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+ * not apply: each record call performs the same attribute processing and lookup as an unbound
+ * recording.
  */
 @ThreadSafe
 public interface BoundLongUpDownCounter {

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleCounter.java
@@ -19,6 +19,10 @@ public interface ExtendedDoubleCounter extends DoubleCounter {
    * processing and map lookup performed by {@link #add(double, Attributes)}. Prefer this when the
    * set of attribute combinations is known ahead of time and the same series is recorded to
    * repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundDoubleCounter bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleGauge.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleGauge.java
@@ -19,6 +19,10 @@ public interface ExtendedDoubleGauge extends DoubleGauge {
    * processing and map lookup performed by {@link #set(double, Attributes)}. Prefer this when the
    * set of attribute combinations is known ahead of time and the same series is recorded to
    * repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundDoubleGauge bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleHistogram.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleHistogram.java
@@ -19,6 +19,10 @@ public interface ExtendedDoubleHistogram extends DoubleHistogram {
    * processing and map lookup performed by {@link #record(double, Attributes)}. Prefer this when
    * the set of attribute combinations is known ahead of time and the same series is recorded to
    * repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundDoubleHistogram bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleUpDownCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedDoubleUpDownCounter.java
@@ -19,6 +19,10 @@ public interface ExtendedDoubleUpDownCounter extends DoubleUpDownCounter {
    * processing and map lookup performed by {@link #add(double, Attributes)}. Prefer this when the
    * set of attribute combinations is known ahead of time and the same series is recorded to
    * repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundDoubleUpDownCounter bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongCounter.java
@@ -18,6 +18,10 @@ public interface ExtendedLongCounter extends LongCounter {
    * <p>Binding resolves the underlying timeseries once, eliminating the per-recording attribute
    * processing and map lookup performed by {@link #add(long, Attributes)}. Prefer this when the set
    * of attribute combinations is known ahead of time and the same series is recorded to repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundLongCounter bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongGauge.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongGauge.java
@@ -18,6 +18,10 @@ public interface ExtendedLongGauge extends LongGauge {
    * <p>Binding resolves the underlying timeseries once, eliminating the per-recording attribute
    * processing and map lookup performed by {@link #set(long, Attributes)}. Prefer this when the set
    * of attribute combinations is known ahead of time and the same series is recorded to repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundLongGauge bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongHistogram.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongHistogram.java
@@ -19,6 +19,10 @@ public interface ExtendedLongHistogram extends LongHistogram {
    * processing and map lookup performed by {@link #record(long, Attributes)}. Prefer this when the
    * set of attribute combinations is known ahead of time and the same series is recorded to
    * repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundLongHistogram bind(Attributes attributes);
 

--- a/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongUpDownCounter.java
+++ b/api/incubator/src/main/java/io/opentelemetry/api/incubator/metrics/ExtendedLongUpDownCounter.java
@@ -18,6 +18,10 @@ public interface ExtendedLongUpDownCounter extends LongUpDownCounter {
    * <p>Binding resolves the underlying timeseries once, eliminating the per-recording attribute
    * processing and map lookup performed by {@link #add(long, Attributes)}. Prefer this when the set
    * of attribute combinations is known ahead of time and the same series is recorded to repeatedly.
+   *
+   * <p>If the metric's view derives attributes from context (e.g. baggage), this optimization does
+   * not apply: each record call performs the same attribute processing and lookup as an unbound
+   * recording.
    */
   BoundLongUpDownCounter bind(Attributes attributes);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/BoundStorageHandle.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/BoundStorageHandle.java
@@ -6,14 +6,20 @@
 package io.opentelemetry.sdk.metrics.internal.state;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor;
 
 /**
- * A record target for a single timeseries, resolved once via {@link
- * WriteableMetricStorage#bind(io.opentelemetry.api.common.Attributes)}.
+ * A record target obtained via {@link
+ * WriteableMetricStorage#bind(io.opentelemetry.api.common.Attributes)}, backing bound instruments.
  *
- * <p>Records bypass the per-recording attribute processing and series lookup that {@link
- * WriteableMetricStorage#recordLong} / {@link WriteableMetricStorage#recordDouble} perform, since
- * the series is resolved at bind time. Backs bound instruments.
+ * <p>Usually a single timeseries resolved once at bind time, in which case records bypass the
+ * per-recording attribute processing and series lookup that {@link
+ * WriteableMetricStorage#recordLong} / {@link WriteableMetricStorage#recordDouble} perform.
+ *
+ * <p>When the view's {@link AttributesProcessor} derives attributes from {@link Context} (see
+ * {@link AttributesProcessor#usesContext()}), binding cannot fix a series ahead of time; the handle
+ * instead re-runs attribute processing and series lookup on every record call, forwarding straight
+ * back to the storage's own {@code recordLong}/{@code recordDouble}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/CumulativeSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/CumulativeSynchronousMetricStorage.java
@@ -59,6 +59,14 @@ class CumulativeSynchronousMetricStorage<T extends PointData>
 
   @Override
   public BoundStorageHandle bind(Attributes attributes) {
+    Objects.requireNonNull(attributes, "attributes");
+    if (attributesProcessor.usesContext()) {
+      // The view derives (part of) the series identity from the record-time Context (e.g.
+      // baggage), which isn't known yet. Defer attribute processing and series resolution to each
+      // recordLong/recordDouble call instead of fixing them to whatever Context happens to be
+      // current now.
+      return lateBoundHandle(attributes);
+    }
     // Cumulative handles are stable for the instrument's lifetime (the map is never swapped and
     // handles are never reset/pooled), so resolve the handle once here and record straight onto it.
     AggregatorHandle<T> handle = getAggregatorHandle(attributes, Context.current());

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java
@@ -127,6 +127,37 @@ public abstract class DefaultSynchronousMetricStorage<T extends PointData>
 
   abstract void doRecordDouble(double value, Attributes attributes, Context context);
 
+  /**
+   * Returns a deferred bound handle for use when the view's {@link AttributesProcessor} derives
+   * (part of) its output from {@link Context} (see {@link AttributesProcessor#usesContext()}).
+   * {@code attributes} is stored as-is; every {@link BoundStorageHandle#recordLong}/{@link
+   * BoundStorageHandle#recordDouble} call forwards straight back through this storage's own {@link
+   * #recordLong}/{@link #recordDouble}, so attribute processing and series resolution happen fresh
+   * on every measurement, using the {@link Context} supplied to that call — the same path an
+   * unbound {@code counter.add(value, attributes, context)} call takes.
+   */
+  final BoundStorageHandle lateBoundHandle(Attributes attributes) {
+    return new LateBoundStorageHandle(attributes);
+  }
+
+  private final class LateBoundStorageHandle implements BoundStorageHandle {
+    private final Attributes attributes;
+
+    LateBoundStorageHandle(Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    @Override
+    public void recordLong(long value, Context context) {
+      DefaultSynchronousMetricStorage.this.recordLong(value, attributes, context);
+    }
+
+    @Override
+    public void recordDouble(double value, Context context) {
+      DefaultSynchronousMetricStorage.this.recordDouble(value, attributes, context);
+    }
+  }
+
   @Override
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DeltaSynchronousMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DeltaSynchronousMetricStorage.java
@@ -163,6 +163,12 @@ class DeltaSynchronousMetricStorage<T extends PointData>
 
   @Override
   public BoundStorageHandle bind(Attributes attributes) {
+    Objects.requireNonNull(attributes, "attributes");
+    if (attributesProcessor.usesContext()) {
+      // See CumulativeSynchronousMetricStorage.bind() for rationale: a context-using view (e.g.
+      // baggage) cannot have its series fixed at bind time.
+      return lateBoundHandle(attributes);
+    }
     Attributes processed = attributesProcessor.process(attributes, Context.current());
     return new DeltaBoundHandle<>(bindHandle(processed), attributes);
   }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/WriteableMetricStorage.java
@@ -24,9 +24,16 @@ public interface WriteableMetricStorage {
   void recordDouble(double value, Attributes attributes, Context context);
 
   /**
-   * Binds the given {@code attributes}, returning a {@link BoundStorageHandle} that records to the
-   * corresponding timeseries directly. The series is resolved once here, so subsequent records via
-   * the returned handle skip per-recording attribute processing and series lookup.
+   * Binds the given {@code attributes}, returning a {@link BoundStorageHandle} that records
+   * directly to the corresponding timeseries.
+   *
+   * <p>When the view's {@link
+   * io.opentelemetry.sdk.metrics.internal.view.AttributesProcessor#usesContext()} is false, the
+   * series is resolved once here, and subsequent records via the returned handle skip per-recording
+   * attribute processing and series lookup. Otherwise (e.g. a baggage-derived view), the series
+   * cannot be fixed at bind time: the returned handle re-runs attribute processing and series
+   * resolution on every record call, using the {@link Context} supplied to that call, same as an
+   * unbound {@link #recordLong}/{@link #recordDouble} call.
    */
   BoundStorageHandle bind(Attributes attributes);
 

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessor.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/AttributesProcessor.java
@@ -40,9 +40,16 @@ public abstract class AttributesProcessor {
   public abstract Attributes process(Attributes incoming, Context context);
 
   /**
-   * If true, this ensures the `Context` argument of the attributes processor is always accurate.
-   * This will prevents bound instruments from pre-locking their metric-attributes and defer until
-   * context is available.
+   * Returns true if this processor derives (part of) its output from the {@link Context} argument
+   * to {@link #process}, e.g. by reading {@link Baggage}, as opposed to using only the incoming
+   * {@code Attributes}.
+   *
+   * <p>Bound instruments ({@link
+   * io.opentelemetry.sdk.metrics.internal.state.WriteableMetricStorage#bind}) use this to decide
+   * whether a series can be resolved once at bind time: when true, the metric-attributes cannot be
+   * pinned ahead of time because they depend on {@link Context} that is only available at each
+   * individual recording, so binding must defer attribute processing and series resolution to every
+   * record call instead.
    */
   public abstract boolean usesContext();
 

--- a/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentBaggageTest.java
+++ b/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentBaggageTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.metrics;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.BoundLongCounter;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+
+class BoundInstrumentBaggageTest {
+
+  private static ExtendedLongCounter counterWithBaggageView(InMemoryMetricReader reader) {
+    ViewBuilder viewBuilder = View.builder().setAggregation(Aggregation.sum());
+    SdkMeterProviderUtil.appendAllBaggageAttributes(viewBuilder);
+    SdkMeterProvider provider =
+        SdkMeterProvider.builder()
+            .registerView(
+                InstrumentSelector.builder().setName("counter").build(), viewBuilder.build())
+            .registerMetricReader(reader)
+            .build();
+    Meter meter = provider.get(BoundInstrumentBaggageTest.class.getName());
+    return (ExtendedLongCounter) meter.counterBuilder("counter").build();
+  }
+
+  private static Context withTenant(String tenant) {
+    return Context.root().with(Baggage.builder().put("tenant", tenant).build());
+  }
+
+  @Test
+  void cumulative_boundAtStartup_recordsUnderDifferentBaggagePerCall() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    ExtendedLongCounter counter = counterWithBaggageView(reader);
+
+    // Bind outside any baggage scope, as recommended for "attribute combinations known ahead of
+    // time" - except here the view's attributes are NOT known ahead of time, since they come from
+    // context.
+    BoundLongCounter bound = counter.bind(Attributes.empty());
+
+    bound.add(1, withTenant("acme"));
+    bound.add(1, withTenant("globex"));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("counter")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.isCumulative()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(
+                                                Attributes.builder().put("tenant", "acme").build())
+                                            .hasValue(1),
+                                    point ->
+                                        point
+                                            .hasAttributes(
+                                                Attributes.builder()
+                                                    .put("tenant", "globex")
+                                                    .build())
+                                            .hasValue(1))));
+  }
+
+  @Test
+  void delta_boundAtStartup_recordsUnderDifferentBaggagePerCall() {
+    InMemoryMetricReader reader = InMemoryMetricReader.createDelta();
+    ExtendedLongCounter counter = counterWithBaggageView(reader);
+
+    BoundLongCounter bound = counter.bind(Attributes.empty());
+
+    bound.add(1, withTenant("acme"));
+    bound.add(1, withTenant("globex"));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("counter")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.isDelta()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasAttributes(
+                                                Attributes.builder().put("tenant", "acme").build())
+                                            .hasValue(1),
+                                    point ->
+                                        point
+                                            .hasAttributes(
+                                                Attributes.builder()
+                                                    .put("tenant", "globex")
+                                                    .build())
+                                            .hasValue(1))));
+  }
+
+  @Test
+  void boundInOneRequest_reusedInAnother_doesNotMisattribute() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    ExtendedLongCounter counter = counterWithBaggageView(reader);
+
+    BoundLongCounter bound;
+    try (Scope ignored = withTenant("acme").makeCurrent()) {
+      bound = counter.bind(Attributes.empty());
+      bound.add(1);
+    }
+    bound.add(1, withTenant("globex"));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("counter")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasAttributes(
+                                            Attributes.builder().put("tenant", "acme").build())
+                                        .hasValue(1),
+                                point ->
+                                    point
+                                        .hasAttributes(
+                                            Attributes.builder().put("tenant", "globex").build())
+                                        .hasValue(1))));
+  }
+
+  @Test
+  void repeatedBindUnderDifferentBaggage_createsNoSeriesUntilRecorded() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    ExtendedLongCounter counter = counterWithBaggageView(reader);
+
+    BoundLongCounter boundAcme;
+    BoundLongCounter boundGlobex;
+    try (Scope ignored = withTenant("acme").makeCurrent()) {
+      boundAcme = counter.bind(Attributes.empty());
+    }
+    try (Scope ignored = withTenant("globex").makeCurrent()) {
+      boundGlobex = counter.bind(Attributes.empty());
+    }
+    try (Scope ignored = withTenant("initrode").makeCurrent()) {
+      counter.bind(Attributes.empty()); // never recorded to
+    }
+
+    assertThat(reader.collectAllMetrics()).isEmpty();
+
+    boundAcme.add(1, withTenant("acme"));
+    boundGlobex.add(1, withTenant("globex"));
+
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("counter")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasAttributes(
+                                            Attributes.builder().put("tenant", "acme").build())
+                                        .hasValue(1),
+                                point ->
+                                    point
+                                        .hasAttributes(
+                                            Attributes.builder().put("tenant", "globex").build())
+                                        .hasValue(1))));
+  }
+}

--- a/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentBaggageTest.java
+++ b/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentBaggageTest.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.Test;
 
-
 class BoundInstrumentBaggageTest {
 
   private static ExtendedLongCounter counterWithBaggageView(InMemoryMetricReader reader) {

--- a/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentExemplarTest.java
+++ b/sdk/metrics/src/testIncubating/java/io/opentelemetry/sdk/metrics/BoundInstrumentExemplarTest.java
@@ -12,6 +12,8 @@ import io.opentelemetry.api.incubator.metrics.BoundLongCounter;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.time.TestClock;
+import java.time.Duration;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
@@ -68,5 +70,45 @@ class BoundInstrumentExemplarTest {
                                                             Attributes.builder()
                                                                 .put("drop", "first")
                                                                 .build())))));
+  }
+
+  /**
+   * Control for the context-deferred bind path exercised by {@code BoundInstrumentBaggageTest}: for
+   * a view whose {@code AttributesProcessor} does not use context, binding must still resolve the
+   * series eagerly, at bind() time, not on the first record call.
+   */
+  @Test
+  void cumulative_nonContextView_bindResolvesSeriesEagerly() {
+    TestClock clock = TestClock.create();
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder()
+            .setClock(clock)
+            .registerView(
+                InstrumentSelector.builder().setName("test-counter").build(),
+                View.builder().setAttributeFilter(Collections.singleton("keep")).build())
+            .registerMetricReader(reader)
+            .build();
+    Meter meter = meterProvider.get(BoundInstrumentExemplarTest.class.getName());
+    ExtendedLongCounter counter =
+        (ExtendedLongCounter) meter.counterBuilder("test-counter").build();
+
+    long bindEpochNanos = clock.now();
+    BoundLongCounter bound = counter.bind(Attributes.builder().put("keep", "k").build());
+    clock.advance(Duration.ofSeconds(5));
+    bound.add(1);
+
+    // The cumulative aggregator's creation time (used as the point's start time) is stamped when
+    // the series is resolved. If it matches bind time rather than the later add() time, the series
+    // was resolved eagerly at bind(), confirming the fast path wasn't silently deferred.
+    assertThat(reader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.isCumulative()
+                                .hasPointsSatisfying(
+                                    point -> point.hasStartEpochNanos(bindEpochNanos))));
   }
 }


### PR DESCRIPTION
`ExtendedLongCounter.bind(Attributes)` and its sibling APIs currently resolve their target time series at bind time. As part of that lookup, each applicable view's `AttributesProcessor` runs against `Context.current()`. If a view derives attributes from context (the only currently supported examples are `SdkMeterProviderUtil.appendAllBaggageAttributes` and `appendFilteredBaggageAttributes`) then subsequent measurements through the bound instrument remain pinned to the baggage that was current at bind time, rather than using the context supplied at record time.

Depending on the usage pattern, this either drops the context-derived attributes entirely when binding at startup, misattributes later requests to an earlier request's baggage when a binding is reused, or eagerly creates one series per distinct bind-time baggage set when binding per request, eventually exhausting the cardinality limit.

`AttributesProcessor.usesContext()` prevents this eager binding and is still documented as doing so. Before bound instruments were removed, [`DefaultSynchronousMetricStorage.bind()` returned a late-bound handle when `usesContext()` was true](https://github.com/open-telemetry/opentelemetry-java/blob/0ac01c6cec04e2943c0baf9c61537de0d9f54122/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/DefaultSynchronousMetricStorage.java#L68-L92).

That guard and fallback handle were [deleted from `DefaultSynchronousMetricStorage` in #5157](https://github.com/open-telemetry/opentelemetry-java/commit/249d09747faf4d4010a1fa24cfa22bedeb961dd3#diff-52769866ca75f4c80faa69e780289fd43259a08881f6cb5cc51c62290ce24b4d).

When bound instruments returned in #8527, the new cumulative and delta bind paths processed attributes against `Context.current()` without restoring that check.