### PR TITLE
To validate Base16 strings with null and odd length handling

### DIFF
--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -143,7 +143,7 @@ public final class OtelEncodingUtils {
 
   /** Returns whether the {@link CharSequence} is a valid hex string. */
   public static boolean isValidBase16String(CharSequence value) {
-    if (value == null || value.length() == 0 || value.length() % 2 != 0) {
+    if (value == null || value.length() == 0) {
       return false;
     }
     int len = value.length();

--- a/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
+++ b/api/all/src/main/java/io/opentelemetry/api/internal/OtelEncodingUtils.java
@@ -143,6 +143,9 @@ public final class OtelEncodingUtils {
 
   /** Returns whether the {@link CharSequence} is a valid hex string. */
   public static boolean isValidBase16String(CharSequence value) {
+    if (value == null || value.length() == 0 || value.length() % 2 != 0) {
+      return false;
+    }
     int len = value.length();
     for (int i = 0; i < len; i++) {
       char b = value.charAt(i);

--- a/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
@@ -59,9 +59,9 @@ class OtelEncodingUtilsTest {
   @Test
   void validHex() {
     assertThat(OtelEncodingUtils.isValidBase16String("abcdef1234567890")).isTrue();
+    assertThat(OtelEncodingUtils.isValidBase16String("abc")).isTrue();
     assertThat(OtelEncodingUtils.isValidBase16String("")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String(null)).isFalse();
-    assertThat(OtelEncodingUtils.isValidBase16String("abc")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("abcdefg1234567890")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("<abcdef1234567890")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("(abcdef1234567890")).isFalse();

--- a/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
+++ b/api/all/src/test/java/io/opentelemetry/api/internal/OtelEncodingUtilsTest.java
@@ -59,6 +59,9 @@ class OtelEncodingUtilsTest {
   @Test
   void validHex() {
     assertThat(OtelEncodingUtils.isValidBase16String("abcdef1234567890")).isTrue();
+    assertThat(OtelEncodingUtils.isValidBase16String("")).isFalse();
+    assertThat(OtelEncodingUtils.isValidBase16String(null)).isFalse();
+    assertThat(OtelEncodingUtils.isValidBase16String("abc")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("abcdefg1234567890")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("<abcdef1234567890")).isFalse();
     assertThat(OtelEncodingUtils.isValidBase16String("(abcdef1234567890")).isFalse();


### PR DESCRIPTION
This PR fixes an issue in `OtelEncodingUtils.isValidBase16String()`, which currently accepts strings with odd lengths even though the encoding utilities in this class operate on byte pairs, where each byte must be represented by exactly two hexadecimal characters.

The fix ensures that the method `rejects odd length Base16 strings and properly handles null and empty CharSequence inputs`.

Regression tests have also been added to cover these cases and verify the expected validation behavior.