### PR TITLE
Exclude META-INF/*.kotlin_module from tracecontext integration test

### DIFF
--- a/integration-tests/tracecontext/build.gradle.kts
+++ b/integration-tests/tracecontext/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 tasks {
   val shadowJar = named<Jar>("shadowJar") {
     archiveFileName.set("tracecontext-tests.jar")
+    exclude("META-INF/*.kotlin_module") // not needed at runtime. avoids KotlinModuleMetadataTransformer warning
 
     manifest {
       attributes("Main-Class" to "io.opentelemetry.Application")


### PR DESCRIPTION
Gets rid of build output of the form:

```
META-INF/micrometer-core.kotlin_module' is matched by KotlinModuleMetadataTransformer_Decorated but its DuplicatesStrategy is EXCLUDE - duplicates may be silently dropped before the transformer processes them.
```