### PR TITLE
Issue 6459 otel assertions no extends

### DIFF
--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/assertj/OpenTelemetryAssertions.java
@@ -31,6 +31,18 @@ import org.assertj.core.api.ObjectAssert;
  * Entry point for assertion methods for OpenTelemetry types. To use type-specific assertions,
  * static import any {@code assertThat} method in this class instead of {@code
  * Assertions.assertThat}.
+ *
+ * <p>Note: This class extends {@link Assertions}, which brings in AssertJ's generic {@code
+ * assertThat(T)} method. This causes ambiguity when using static imports alongside other assertion
+ * libraries like Truth. To avoid ambiguity, use a non-static import for this class and reference
+ * methods explicitly:
+ *
+ * <pre>{@code
+ * import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
+ *
+ * // Use explicit class reference instead of static import
+ * OpenTelemetryAssertions.assertThat(spanData).hasName("my-span");
+ * }</pre>
  */
 public final class OpenTelemetryAssertions extends Assertions {
 

--- a/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
+++ b/sdk/testing/src/test/java/io/opentelemetry/sdk/testing/assertj/TraceAssertionsTest.java
@@ -317,6 +317,17 @@ class TraceAssertionsTest {
   }
 
   @Test
+  @SuppressWarnings("UnnecessarilyFullyQualified")
+  void nonStaticImportWorkaround() {
+    // Demonstrates the workaround for issue #6459:
+    // When mixing OpenTelemetryAssertions with other assertion libraries (e.g., Truth),
+    // use a non-static import and reference methods explicitly to avoid ambiguity.
+    io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat(SPAN1).hasName("span");
+    io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat(SPAN1)
+        .hasTraceId(TRACE_ID);
+  }
+
+  @Test
   @SuppressWarnings("Convert2MethodRef")
   void failure() {
     assertThatThrownBy(() -> assertThat(SPAN1).hasTraceId("foo"))


### PR DESCRIPTION
## Description

Fixes #6459

This PR documents the existing workaround for the ambiguity caused when `OpenTelemetryAssertions` is statically imported alongside other assertion libraries such as Truth.

`OpenTelemetryAssertions` currently extends AssertJ's `Assertions`, which can introduce an ambiguous `assertThat(...)` reference when multiple assertion libraries are used together.

### Changes

* Added Javadoc to `OpenTelemetryAssertions` explaining the assertion ambiguity.
* Documented the recommended workaround:

  * Avoid a static import of `OpenTelemetryAssertions`.
  * Reference `OpenTelemetryAssertions.assertThat(...)` explicitly.
* Added a test demonstrating that the non-static import workaround works as expected.

### Compatibility

This approach intentionally avoids removing `extends Assertions`, which would be an API-breaking change for existing users.

The change therefore provides documentation and an example of the existing non-breaking workaround without modifying the public API.

### Validation

* `TraceAssertionsTest` passes.
* Spotless formatting checks pass.
* Changes are isolated to the `#6459` work.

### Related

Fixes #6459