### PR TITLE
Rename inverted grpc detection test in GrpcJavaOtlpIntegrationTest

### DIFF
--- a/integration-tests/otlp/src/testGrpcJava/java/io/opentelemetry/integrationtest/GrpcJavaOtlpIntegrationTest.java
+++ b/integration-tests/otlp/src/testGrpcJava/java/io/opentelemetry/integrationtest/GrpcJavaOtlpIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class GrpcJavaOtlpIntegrationTest extends OtlpExporterIntegrationTest {
 
   @Test
-  void noGrpcFound() {
+  void grpcFound() {
     assertThatCode(() -> Class.forName("io.grpc.ManagedChannel")).doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
No issue filed: identifier-only test cleanup, like #8672 and #8689, merged without one.

## Description

- `GrpcJavaOtlpIntegrationTest.noGrpcFound()` asserts the opposite of its name: the body checks that `io.grpc.ManagedChannel` loads, i.e. grpc-java *is* present. The `testGrpcJava` suite puts grpc-java on the runtime classpath, so the assertion is right and the name is wrong. Rename it to `grpcFound()`.
- The old name is a copy-paste remnant of the sibling `NoGrpcJavaOtlpIntegrationTest.noGrpcFound()`, which correctly asserts grpc-java is absent and is left untouched.
- Nothing else referenced `noGrpcFound`.

## Testing done

- Test-exempt: no behavior, signature, API or output change; no test added.
- `:integration-tests:otlp:check` is BUILD SUCCESSFUL and the result XML lists the renamed `grpcFound()`. All 19 testcontainers tests were skipped, though: Docker is unavailable here and the base class is `@Testcontainers(disabledWithoutDocker = true)`. I did not run them locally; CI does, on the ubuntu-latest runner.
