### PR TITLE
Remove unused parameter from B3 propagation integration tests

### DIFF
--- a/integration-tests/src/test/java/io/opentelemetry/B3PropagationIntegrationTest.java
+++ b/integration-tests/src/test/java/io/opentelemetry/B3PropagationIntegrationTest.java
@@ -161,7 +161,7 @@ class B3PropagationIntegrationTest {
 
   @ParameterizedTest
   @ArgumentsSource(WebClientArgumentSupplier.class)
-  void propagation(String testType, WebClient client) {
+  void propagation(WebClient client) {
     OpenTelemetrySdk clientSdk = setupClient();
 
     Span span = clientSdk.getTracer("testTracer").spanBuilder("clientSpan").startSpan();
@@ -182,7 +182,7 @@ class B3PropagationIntegrationTest {
 
   @ParameterizedTest
   @ArgumentsSource(WebClientArgumentSupplier.class)
-  void noClientTracing(String testType, WebClient client) {
+  void noClientTracing(WebClient client) {
     assertThat(client.get("/frontend").aggregate().join().contentUtf8()).isEqualTo("OK");
 
     List<SpanData> finishedSpanItems = spanExporter.getFinishedSpanItems();
@@ -240,8 +240,8 @@ class B3PropagationIntegrationTest {
     public Stream<? extends Arguments> provideArguments(
         ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
-          Arguments.argumentSet("b3multi", "b3multi", b3MultiClient),
-          Arguments.argumentSet("b3single", "b3single", b3SingleClient));
+          Arguments.argumentSet("b3multi", b3MultiClient),
+          Arguments.argumentSet("b3single", b3SingleClient));
     }
   }
 }


### PR DESCRIPTION
<!-- No issue: test-only cleanup. Comparable cleanups (#8286, #7970, #7870) were merged without a linked issue. -->

## Description

- `B3PropagationIntegrationTest#propagation` and `#noClientTracing` declare a `String testType` parameter that neither method body reads.
- Since #8471 moved the parameterized display name into `Arguments.argumentSet(name, ...)`, that parameter no longer serves any purpose, not even as a label.
- Drop the parameter and the now-redundant second argument in `WebClientArgumentSupplier`, so each argument set supplies only the `WebClient` the tests use.
- ErrorProne's `UnusedVariable` misses it because it only reports unused parameters on private methods; these are package-private.
- #8471 applied the same cleanup to the display-only `String name` parameter in `AbstractOtlpStdoutExporterTest`: https://github.com/open-telemetry/opentelemetry-java/pull/8471

## Testing done

- No new tests: this is a cleanup, not a bug fix. Assertions and observable behavior are unchanged.
- `./gradlew :integration-tests:check` — 6 tests, 5 passed, 1 skipped, 0 failures.
- Test display names stay `b3multi` and `b3single`, confirming the removed argument was not what produced them.
- No public API change; `docs/apidiffs/` untouched.

