### PR TITLE
Fix javadoc crawler reading a Maven Central index that stopped updating

### DIFF
--- a/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/JavaDocsCrawler.java
+++ b/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/JavaDocsCrawler.java
@@ -40,9 +40,11 @@ public final class JavaDocsCrawler {
           "io.opentelemetry.proto", "1.10.0");
 
   private static final String MAVEN_CENTRAL_BASE_URL =
-      "https://search.maven.org/solrsearch/select?q=g:";
+      "https://central.sonatype.com/solrsearch/select?q=g:";
   private static final String JAVA_DOCS_BASE_URL = "https://javadoc.io/doc/";
-  private static final int PAGE_SIZE = 20;
+  // Every group is fetched in a single request, so no paging parameter is sent. The largest group
+  // currently holds fewer than 200 artifacts and getArtifacts fails if the response is incomplete.
+  private static final int MAX_ROWS = 500;
   private static final int THROTTLE_MS = 500;
 
   // visible for testing
@@ -81,30 +83,26 @@ public final class JavaDocsCrawler {
 
   static List<Artifact> getArtifacts(HttpClient client, String group)
       throws IOException, InterruptedException {
-    int start = 0;
-    Integer numFound;
-    List<Artifact> result = new ArrayList<>();
+    Map<?, ?> map = queryMavenCentral(client, group, MAX_ROWS);
 
-    do {
-      if (start != 0) {
-        Thread.sleep(THROTTLE_MS); // try not to DDoS the site, it gets knocked over easily
-      }
+    Integer numFound =
+        Optional.ofNullable(map)
+            .map(mavenResult -> (Map<?, ?>) mavenResult.get("response"))
+            .map(response -> (Integer) response.get("numFound"))
+            .orElse(null);
 
-      Map<?, ?> map = queryMavenCentral(client, group, start);
+    List<Artifact> artifacts = convertToArtifacts(map);
+    if (numFound != null && artifacts.size() < numFound) {
+      throw new IOException(
+          String.format(
+              Locale.ROOT,
+              "Received %d of %d artifacts for group %s, raise MAX_ROWS",
+              artifacts.size(),
+              numFound,
+              group));
+    }
 
-      numFound =
-          Optional.ofNullable(map)
-              .map(mavenResult -> (Map<?, ?>) mavenResult.get("response"))
-              .map(response -> (Integer) response.get("numFound"))
-              .orElse(null);
-
-      List<Artifact> artifacts = convertToArtifacts(map);
-      result.addAll(artifacts);
-
-      start += PAGE_SIZE;
-    } while (numFound != null && start < numFound);
-
-    return result;
+    return artifacts;
   }
 
   private static List<Artifact> convertToArtifacts(Map<?, ?> map) {
@@ -127,17 +125,12 @@ public final class JavaDocsCrawler {
         .orElseGet(ArrayList::new);
   }
 
-  private static Map<?, ?> queryMavenCentral(HttpClient client, String group, int start)
+  private static Map<?, ?> queryMavenCentral(HttpClient client, String group, int rows)
       throws IOException, InterruptedException {
     URI uri =
         URI.create(
             String.format(
-                Locale.ROOT,
-                "%s%s&rows=%d&start=%d&wt=json",
-                MAVEN_CENTRAL_BASE_URL,
-                group,
-                PAGE_SIZE,
-                start));
+                Locale.ROOT, "%s%s&rows=%d&wt=json", MAVEN_CENTRAL_BASE_URL, group, rows));
 
     HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
 

--- a/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/JavaDocsCrawler.java
+++ b/javadoc-crawler/src/main/java/io/opentelemetry/javadocs/JavaDocsCrawler.java
@@ -85,14 +85,21 @@ public final class JavaDocsCrawler {
       throws IOException, InterruptedException {
     Map<?, ?> map = queryMavenCentral(client, group, MAX_ROWS);
 
-    Integer numFound =
+    // a 200 response without numFound means the endpoint changed shape; failing here keeps that
+    // from silently disabling the completeness check below
+    int numFound =
         Optional.ofNullable(map)
             .map(mavenResult -> (Map<?, ?>) mavenResult.get("response"))
             .map(response -> (Integer) response.get("numFound"))
-            .orElse(null);
+            .orElseThrow(
+                () ->
+                    new IOException(
+                        "Maven Central response for group "
+                            + group
+                            + " did not contain response.numFound"));
 
     List<Artifact> artifacts = convertToArtifacts(map);
-    if (numFound != null && artifacts.size() < numFound) {
+    if (artifacts.size() < numFound) {
       throw new IOException(
           String.format(
               Locale.ROOT,

--- a/javadoc-crawler/src/test/java/io/opentelemetry/javadocs/JavaDocsCrawlerTest.java
+++ b/javadoc-crawler/src/test/java/io/opentelemetry/javadocs/JavaDocsCrawlerTest.java
@@ -94,6 +94,30 @@ class JavaDocsCrawlerTest {
   }
 
   @Test
+  void testGetArtifactsFailsWithoutNumFound() throws IOException, InterruptedException {
+    String response =
+        """
+            {
+              "response": {
+                "docs": [
+                  {"g": "group", "a": "artifact1", "latestVersion": "1.0"}
+                ]
+              }
+            }
+        """;
+
+    when(mockMavenCentralRequest1.body()).thenReturn(response);
+    when(mockMavenCentralRequest1.statusCode()).thenReturn(200);
+
+    when(mockClient.send(any(), any())).thenReturn(mockMavenCentralRequest1);
+
+    assertThatThrownBy(() -> JavaDocsCrawler.getArtifacts(mockClient, "io.opentelemetry"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("numFound")
+        .hasMessageContaining("io.opentelemetry");
+  }
+
+  @Test
   void testCrawler() throws IOException, InterruptedException {
     Artifact artifact = new Artifact("io.opentelemetry", "opentelemetry-context", "1.49.0");
     ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);

--- a/javadoc-crawler/src/test/java/io/opentelemetry/javadocs/JavaDocsCrawlerTest.java
+++ b/javadoc-crawler/src/test/java/io/opentelemetry/javadocs/JavaDocsCrawlerTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javadocs;
 
 import static io.opentelemetry.javadocs.JavaDocsCrawler.JAVA_DOC_DOWNLOADED_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -32,8 +34,43 @@ class JavaDocsCrawlerTest {
   @Mock HttpResponse<Object> mockJavaDocResponse;
 
   @Test
-  void testGetArtifactsHandlesPagination() throws IOException, InterruptedException {
-    String page1Response =
+  void testGetArtifactsUsesASingleRequest() throws IOException, InterruptedException {
+    String response =
+        """
+            {
+              "response": {
+                "numFound": 2,
+                "docs": [
+                  {"g": "group", "a": "artifact1", "latestVersion": "1.0"},
+                  {"g": "group", "a": "artifact2", "latestVersion": "1.1"}
+                ]
+              }
+            }
+        """;
+    ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+    when(mockMavenCentralRequest1.body()).thenReturn(response);
+    when(mockMavenCentralRequest1.statusCode()).thenReturn(200);
+
+    when(mockClient.send(any(), any())).thenReturn(mockMavenCentralRequest1);
+
+    List<Artifact> artifacts = JavaDocsCrawler.getArtifacts(mockClient, "io.opentelemetry");
+
+    verify(mockClient, times(1)).send(requestCaptor.capture(), any());
+
+    String uri = requestCaptor.getValue().uri().toString();
+    assertThat(uri)
+        .startsWith("https://central.sonatype.com/solrsearch/select?q=g:io.opentelemetry");
+    assertThat(uri).contains("rows=500");
+    assertThat(uri).doesNotContain("start=");
+    assertThat(artifacts)
+        .extracting(Artifact::getGroup, Artifact::getName, Artifact::getVersion)
+        .containsExactly(tuple("group", "artifact1", "1.0"), tuple("group", "artifact2", "1.1"));
+  }
+
+  @Test
+  void testGetArtifactsFailsOnIncompleteResponse() throws IOException, InterruptedException {
+    String response =
         """
             {
               "response": {
@@ -45,32 +82,15 @@ class JavaDocsCrawlerTest {
               }
             }
         """;
-    String page2Response =
-        """
-            {
-              "response": {
-                "numFound": 40,
-                "docs": [
-                  {"g": "group", "a": "artifact3", "latestVersion": "2.0"}
-                ]
-              }
-            }
-        """;
 
-    when(mockMavenCentralRequest1.body()).thenReturn(page1Response);
-    when(mockMavenCentralRequest1.statusCode()).thenReturn(200);
-    when(mockMavenCentralRequest2.body()).thenReturn(page2Response);
+    when(mockMavenCentralRequest2.body()).thenReturn(response);
     when(mockMavenCentralRequest2.statusCode()).thenReturn(200);
 
-    when(mockClient.send(any(), any()))
-        .thenReturn(mockMavenCentralRequest1)
-        .thenReturn(mockMavenCentralRequest2);
+    when(mockClient.send(any(), any())).thenReturn(mockMavenCentralRequest2);
 
-    List<Artifact> artifacts = JavaDocsCrawler.getArtifacts(mockClient, "io.opentelemetry");
-
-    // 2 calls for the pagination
-    verify(mockClient, times(2)).send(any(), any());
-    assertThat(artifacts.size()).isEqualTo(3);
+    assertThatThrownBy(() -> JavaDocsCrawler.getArtifacts(mockClient, "io.opentelemetry"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("io.opentelemetry");
   }
 
   @Test


### PR DESCRIPTION
Fixes #8792

## Description

- `JavaDocsCrawler` queries `search.maven.org/solrsearch`, whose index stopped updating on 2025-06-06 and reports `latestVersion=1.51.0` for every `io.opentelemetry` artifact.
- Switch to `central.sonatype.com/solrsearch`. It is absent from Sonatype's REST API guide, but their FAQ says that index refreshes within minutes of a release while search.maven.org's does not (https://central.sonatype.org/faq/what-happened-to-search-maven-org/), and Apache's `maven-indexer` ships the same host as `SmoSearchBackendFactory.CSC_SMO_URI`.
- The hosts read `start` differently, so `getArtifacts` sends one request with `rows=500` and no `start`, failing if it receives fewer documents than `numFound`.
- Runs 34300382073 and 34177613796 each log 246 `Skipping crawling` lines and no `Crawling` line, yet exit success. The fix restores 168 crawl requests across five groups.
- Triggering javadoc.io's lazy loading is the module's intent, not measured here.
- Follow-up idea: fail the job when nothing is crawled.

## Testing done

- Replaced `testGetArtifactsHandlesPagination` with `testGetArtifactsUsesASingleRequest` (one request; URI has `rows=500`, no `start=`) and `testGetArtifactsFailsOnIncompleteResponse` (short response throws `IOException` naming the group).
- `./gradlew :javadoc-crawler:check` passes; both new tests fail against the unpatched code.
- Unpublished module: no apidiff or API change.

