### PR TITLE
Update declarative configuration to schema v1.2.0

### DIFF
--- a/integration-tests/graal-incubating/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingApiTests.java
+++ b/integration-tests/graal-incubating/src/test/java/io/opentelemetry/integrationtests/graal/IncubatingApiTests.java
@@ -109,7 +109,7 @@ class IncubatingApiTests {
     // make sure to test enums too: "instrument_type: histogram"
     String string =
         """
-      file_format: "1.0"
+      file_format: "1.2"
       tracer_provider:
         processors:
           - batch:

--- a/integration-tests/osgi/src/testAutoconfigureDeclarativeConfig/java/io/opentelemetry/integrationtest/osgi/AutoconfigureDeclarativeConfigTest.java
+++ b/integration-tests/osgi/src/testAutoconfigureDeclarativeConfig/java/io/opentelemetry/integrationtest/osgi/AutoconfigureDeclarativeConfigTest.java
@@ -45,7 +45,7 @@ public class AutoconfigureDeclarativeConfigTest {
   @Test
   void declarativeConfigSdkInitializes(@TempDir Path tempDir) throws IOException {
     String yaml =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/test/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -32,7 +32,7 @@ class DeclarativeConfigurationTest {
   @Test
   void configFile(@TempDir Path tempDir) throws IOException {
     String yaml =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/autoconfigure/src/testDeclarativeConfigSpi/java/io/opentelemetry/sdk/autoconfigure/TestDeclarativeConfigurationProvider.java
+++ b/sdk-extensions/autoconfigure/src/testDeclarativeConfigSpi/java/io/opentelemetry/sdk/autoconfigure/TestDeclarativeConfigurationProvider.java
@@ -15,7 +15,7 @@ public class TestDeclarativeConfigurationProvider implements DeclarativeConfigur
   @Override
   public OpenTelemetryConfigurationModel getConfigurationModel() {
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  detection/development:\n"
             + "    detectors:\n"

--- a/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
+++ b/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/DeclarativeConfigurationTest.java
@@ -63,7 +63,7 @@ class DeclarativeConfigurationTest {
   @BeforeEach
   void setup() throws IOException {
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"
@@ -189,7 +189,7 @@ class DeclarativeConfigurationTest {
   @Test
   void configFile_Error(@TempDir Path tempDir) throws IOException {
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/FullDeclarativeConfigTest.java
+++ b/sdk-extensions/autoconfigure/src/testIncubating/java/io/opentelemetry/sdk/autoconfigure/FullDeclarativeConfigTest.java
@@ -129,7 +129,7 @@ public class FullDeclarativeConfigTest {
 
     String endpoint = "http://localhost:" + server.httpPort();
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"

--- a/sdk-extensions/declarative-config/build.gradle.kts
+++ b/sdk-extensions/declarative-config/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
 // The generated POJOs are committed to src/main/java and are NOT regenerated as part of the normal build.
 // To regenerate (e.g. after a schema update), run: ./gradlew :sdk-extensions:declarative-config:syncPojoModelsToSrc
 
-val configurationTag = "1.1.0"
+val configurationTag = "1.2.0"
 val configurationRef = "refs/tags/v$configurationTag" // Replace with commit SHA to point to experiment with a specific commit
 val configurationRepoZip = "https://github.com/open-telemetry/opentelemetry-configuration/archive/$configurationRef.zip"
 val buildDirectory = layout.buildDirectory.asFile.get()

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactory.java
@@ -29,7 +29,7 @@ final class OpenTelemetryConfigurationFactory
       Logger.getLogger(OpenTelemetryConfigurationFactory.class.getName());
   private static final Pattern SUPPORTED_FILE_FORMATS =
       Pattern.compile("^(0.4)|(1.\\d+(-rc.\\d+)?)$");
-  private static final String EXPECTED_FILE_FORMAT = "1.1";
+  private static final String EXPECTED_FILE_FORMAT = "1.2";
 
   private static final OpenTelemetryConfigurationFactory INSTANCE =
       new OpenTelemetryConfigurationFactory();

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactory.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactory.java
@@ -5,12 +5,15 @@
 
 package io.opentelemetry.sdk.autoconfigure.declarativeconfig;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AlwaysRecordSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ParentBasedSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.TraceIdRatioBasedSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalComposableSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalProbabilitySamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.SamplerModelAccessor;
+import io.opentelemetry.sdk.extension.incubator.trace.samplers.AlwaysRecordSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
 import io.opentelemetry.sdk.trace.samplers.ParentBasedSamplerBuilder;
@@ -44,6 +47,9 @@ final class SamplerFactory implements Factory<SamplerModel, Sampler> {
     }
     if (model.getParentBased() != null) {
       return createParedBasedSampler(model.getParentBased(), context);
+    }
+    if (model.getAlwaysRecord() != null) {
+      return createAlwaysRecordSampler(model.getAlwaysRecord(), context);
     }
     ExperimentalProbabilitySamplerModel probabilityDevelopment =
         SamplerModelAccessor.getProbability(model);
@@ -92,6 +98,15 @@ final class SamplerFactory implements Factory<SamplerModel, Sampler> {
       builder.setLocalParentNotSampled(sampler);
     }
     return builder.build();
+  }
+
+  private static Sampler createAlwaysRecordSampler(
+      AlwaysRecordSamplerModel alwaysRecordModel, DeclarativeConfigContext context) {
+    SamplerModel rootModel = alwaysRecordModel.getRoot();
+    if (rootModel == null) {
+      throw new DeclarativeConfigException("always_record sampler .root is required");
+    }
+    return AlwaysRecordSampler.create(INSTANCE.create(rootModel, context));
   }
 
   private static Sampler createProbabilitySampler(

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AlwaysRecordSamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AlwaysRecordSamplerModel.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model;
 
-import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.MetricProducerModel.OPENCENSUS;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AlwaysRecordSamplerModel.ROOT;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -21,52 +21,45 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({OPENCENSUS})
+@JsonPropertyOrder({ROOT})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
-public class MetricProducerModel {
+public class AlwaysRecordSamplerModel {
 
-  static final String OPENCENSUS = "opencensus";
+  static final String ROOT = "root";
 
   private static final Map<String, Class<?>> STABLE_PROPERTIES;
 
   static {
     STABLE_PROPERTIES = new HashMap<>();
-    STABLE_PROPERTIES.put(OPENCENSUS, OpenCensusMetricProducerModel.class);
+    STABLE_PROPERTIES.put(ROOT, SamplerModel.class);
   }
 
-  private static final boolean ALLOWS_ADDITIONAL_PROPERTIES = true;
+  private static final boolean ALLOWS_ADDITIONAL_PROPERTIES = false;
 
-  @Nullable private OpenCensusMetricProducerModel opencensus;
+  @Nullable private SamplerModel root;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
 
   /**
-   * Configure metric producer to be opencensus.
+   * Configure the wrapped sampler which provides the original sampling
    *
-   * <p>**Deprecated** as of v1.2.0, may be removed in v2.0.0. The OpenCensus
+   * <p>decision that AlwaysRecord modifies. DROP decisions are converted
    *
-   * <p>compatibility specification it relies on was deprecated in
+   * <p>to RECORD_ONLY, allowing processors to see all spans without sending them to exporters.
    *
-   * <p>https://github.com/open-telemetry/opentelemetry-specification/pull/5138.
-   *
-   * <p>SDKs MAY continue to support this entry for backwards compatibility;
-   *
-   * <p>new configurations SHOULD NOT use it.
-   *
-   * <p>If omitted, ignore.
+   * <p>Property is required and must be non-null.
    */
-  @JsonProperty(OPENCENSUS)
+  @JsonProperty(ROOT)
   @Nullable
-  public OpenCensusMetricProducerModel getOpencensus() {
-    if (opencensus == null) {
-      return ExtensionPropertyUtil.getGraduated(
-          OPENCENSUS, extensionProperties, OpenCensusMetricProducerModel.class);
+  public SamplerModel getRoot() {
+    if (root == null) {
+      return ExtensionPropertyUtil.getGraduated(ROOT, extensionProperties, SamplerModel.class);
     }
-    return opencensus;
+    return root;
   }
 
-  @JsonProperty(OPENCENSUS)
-  public MetricProducerModel setOpencensus(OpenCensusMetricProducerModel opencensus) {
-    this.opencensus = opencensus;
+  @JsonProperty(ROOT)
+  public AlwaysRecordSamplerModel setRoot(SamplerModel root) {
+    this.root = root;
     return this;
   }
 
@@ -76,7 +69,7 @@ public class MetricProducerModel {
   }
 
   @JsonAnySetter
-  public MetricProducerModel setExtensionProperty(String name, @Nullable Object value) {
+  public AlwaysRecordSamplerModel setExtensionProperty(String name, @Nullable Object value) {
     ExtensionPropertyUtil.handleAnySetter(
         name,
         value,
@@ -89,9 +82,9 @@ public class MetricProducerModel {
 
   @Override
   public String toString() {
-    return "MetricProducerModel{"
-        + "opencensus="
-        + opencensus
+    return "AlwaysRecordSamplerModel{"
+        + "root="
+        + root
         + ", extensionProperties="
         + extensionProperties
         + "}";
@@ -101,7 +94,7 @@ public class MetricProducerModel {
   public int hashCode() {
     int h = 1;
     h *= 1000003;
-    h ^= (this.getOpencensus() == null) ? 0 : this.getOpencensus().hashCode();
+    h ^= (this.getRoot() == null) ? 0 : this.getRoot().hashCode();
     h *= 1000003;
     h ^= (this.getExtensionProperties() == null) ? 0 : this.getExtensionProperties().hashCode();
     return h;
@@ -112,11 +105,11 @@ public class MetricProducerModel {
     if (o == this) {
       return true;
     }
-    if (o instanceof MetricProducerModel) {
-      MetricProducerModel that = (MetricProducerModel) o;
-      return (this.getOpencensus() == null
-              ? that.getOpencensus() == null
-              : this.getOpencensus().equals(that.getOpencensus()))
+    if (o instanceof AlwaysRecordSamplerModel) {
+      AlwaysRecordSamplerModel that = (AlwaysRecordSamplerModel) o;
+      return (this.getRoot() == null
+              ? that.getRoot() == null
+              : this.getRoot().equals(that.getRoot()))
           && (this.getExtensionProperties() == null
               ? that.getExtensionProperties() == null
               : this.getExtensionProperties().equals(that.getExtensionProperties()));

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/AttributeLimitsModel.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model;
 
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AttributeLimitsModel.ATTRIBUTE_COUNT_LIMIT;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AttributeLimitsModel.ATTRIBUTE_VALUE_DEPTH_LIMIT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AttributeLimitsModel.ATTRIBUTE_VALUE_LENGTH_LIMIT;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -22,11 +23,16 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ATTRIBUTE_VALUE_LENGTH_LIMIT, ATTRIBUTE_COUNT_LIMIT})
+@JsonPropertyOrder({
+  ATTRIBUTE_VALUE_LENGTH_LIMIT,
+  ATTRIBUTE_VALUE_DEPTH_LIMIT,
+  ATTRIBUTE_COUNT_LIMIT
+})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
 public class AttributeLimitsModel {
 
   static final String ATTRIBUTE_VALUE_LENGTH_LIMIT = "attribute_value_length_limit";
+  static final String ATTRIBUTE_VALUE_DEPTH_LIMIT = "attribute_value_depth_limit";
   static final String ATTRIBUTE_COUNT_LIMIT = "attribute_count_limit";
 
   private static final Map<String, Class<?>> STABLE_PROPERTIES;
@@ -34,12 +40,14 @@ public class AttributeLimitsModel {
   static {
     STABLE_PROPERTIES = new HashMap<>();
     STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_LENGTH_LIMIT, Integer.class);
+    STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_DEPTH_LIMIT, Integer.class);
     STABLE_PROPERTIES.put(ATTRIBUTE_COUNT_LIMIT, Integer.class);
   }
 
   private static final boolean ALLOWS_ADDITIONAL_PROPERTIES = false;
 
   @Nullable private Integer attributeValueLengthLimit;
+  @Nullable private Integer attributeValueDepthLimit;
   @Nullable private Integer attributeCountLimit;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
 
@@ -63,6 +71,34 @@ public class AttributeLimitsModel {
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
   public AttributeLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
+    return this;
+  }
+
+  /**
+   * Configure the maximum attribute value depth for nested array and map values.
+   *
+   * <p>Depth starts at 1 for the top-level attribute value and increments when descending into
+   * array elements or map values.
+   *
+   * <p>Array or map values deeper than the limit are replaced with an empty value.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 64 is used.
+   */
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  @Nullable
+  public Integer getAttributeValueDepthLimit() {
+    if (attributeValueDepthLimit == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          ATTRIBUTE_VALUE_DEPTH_LIMIT, extensionProperties, Integer.class);
+    }
+    return attributeValueDepthLimit;
+  }
+
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  public AttributeLimitsModel setAttributeValueDepthLimit(Integer attributeValueDepthLimit) {
+    this.attributeValueDepthLimit = attributeValueDepthLimit;
     return this;
   }
 
@@ -111,6 +147,8 @@ public class AttributeLimitsModel {
     return "AttributeLimitsModel{"
         + "attributeValueLengthLimit="
         + attributeValueLengthLimit
+        + ", attributeValueDepthLimit="
+        + attributeValueDepthLimit
         + ", attributeCountLimit="
         + attributeCountLimit
         + ", extensionProperties="
@@ -126,6 +164,11 @@ public class AttributeLimitsModel {
         (this.getAttributeValueLengthLimit() == null)
             ? 0
             : this.getAttributeValueLengthLimit().hashCode();
+    h *= 1000003;
+    h ^=
+        (this.getAttributeValueDepthLimit() == null)
+            ? 0
+            : this.getAttributeValueDepthLimit().hashCode();
     h *= 1000003;
     h ^= (this.getAttributeCountLimit() == null) ? 0 : this.getAttributeCountLimit().hashCode();
     h *= 1000003;
@@ -143,6 +186,9 @@ public class AttributeLimitsModel {
       return (this.getAttributeValueLengthLimit() == null
               ? that.getAttributeValueLengthLimit() == null
               : this.getAttributeValueLengthLimit().equals(that.getAttributeValueLengthLimit()))
+          && (this.getAttributeValueDepthLimit() == null
+              ? that.getAttributeValueDepthLimit() == null
+              : this.getAttributeValueDepthLimit().equals(that.getAttributeValueDepthLimit()))
           && (this.getAttributeCountLimit() == null
               ? that.getAttributeCountLimit() == null
               : this.getAttributeCountLimit().equals(that.getAttributeCountLimit()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/LogRecordLimitsModel.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model;
 
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordLimitsModel.ATTRIBUTE_COUNT_LIMIT;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordLimitsModel.ATTRIBUTE_VALUE_DEPTH_LIMIT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordLimitsModel.ATTRIBUTE_VALUE_LENGTH_LIMIT;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -22,11 +23,16 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ATTRIBUTE_VALUE_LENGTH_LIMIT, ATTRIBUTE_COUNT_LIMIT})
+@JsonPropertyOrder({
+  ATTRIBUTE_VALUE_LENGTH_LIMIT,
+  ATTRIBUTE_VALUE_DEPTH_LIMIT,
+  ATTRIBUTE_COUNT_LIMIT
+})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
 public class LogRecordLimitsModel {
 
   static final String ATTRIBUTE_VALUE_LENGTH_LIMIT = "attribute_value_length_limit";
+  static final String ATTRIBUTE_VALUE_DEPTH_LIMIT = "attribute_value_depth_limit";
   static final String ATTRIBUTE_COUNT_LIMIT = "attribute_count_limit";
 
   private static final Map<String, Class<?>> STABLE_PROPERTIES;
@@ -34,12 +40,14 @@ public class LogRecordLimitsModel {
   static {
     STABLE_PROPERTIES = new HashMap<>();
     STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_LENGTH_LIMIT, Integer.class);
+    STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_DEPTH_LIMIT, Integer.class);
     STABLE_PROPERTIES.put(ATTRIBUTE_COUNT_LIMIT, Integer.class);
   }
 
   private static final boolean ALLOWS_ADDITIONAL_PROPERTIES = false;
 
   @Nullable private Integer attributeValueLengthLimit;
+  @Nullable private Integer attributeValueDepthLimit;
   @Nullable private Integer attributeCountLimit;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
 
@@ -63,6 +71,35 @@ public class LogRecordLimitsModel {
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
   public LogRecordLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
+    return this;
+  }
+
+  /**
+   * Configure the maximum attribute value depth for nested array and map values. Overrides
+   * .attribute_limits.attribute_value_depth_limit.
+   *
+   * <p>Depth starts at 1 for the top-level attribute value and increments when descending into
+   * array elements or map values.
+   *
+   * <p>Array or map values deeper than the limit are replaced with an empty value.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 64 is used.
+   */
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  @Nullable
+  public Integer getAttributeValueDepthLimit() {
+    if (attributeValueDepthLimit == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          ATTRIBUTE_VALUE_DEPTH_LIMIT, extensionProperties, Integer.class);
+    }
+    return attributeValueDepthLimit;
+  }
+
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  public LogRecordLimitsModel setAttributeValueDepthLimit(Integer attributeValueDepthLimit) {
+    this.attributeValueDepthLimit = attributeValueDepthLimit;
     return this;
   }
 
@@ -111,6 +148,8 @@ public class LogRecordLimitsModel {
     return "LogRecordLimitsModel{"
         + "attributeValueLengthLimit="
         + attributeValueLengthLimit
+        + ", attributeValueDepthLimit="
+        + attributeValueDepthLimit
         + ", attributeCountLimit="
         + attributeCountLimit
         + ", extensionProperties="
@@ -126,6 +165,11 @@ public class LogRecordLimitsModel {
         (this.getAttributeValueLengthLimit() == null)
             ? 0
             : this.getAttributeValueLengthLimit().hashCode();
+    h *= 1000003;
+    h ^=
+        (this.getAttributeValueDepthLimit() == null)
+            ? 0
+            : this.getAttributeValueDepthLimit().hashCode();
     h *= 1000003;
     h ^= (this.getAttributeCountLimit() == null) ? 0 : this.getAttributeCountLimit().hashCode();
     h *= 1000003;
@@ -143,6 +187,9 @@ public class LogRecordLimitsModel {
       return (this.getAttributeValueLengthLimit() == null
               ? that.getAttributeValueLengthLimit() == null
               : this.getAttributeValueLengthLimit().equals(that.getAttributeValueLengthLimit()))
+          && (this.getAttributeValueDepthLimit() == null
+              ? that.getAttributeValueDepthLimit() == null
+              : this.getAttributeValueDepthLimit().equals(that.getAttributeValueDepthLimit()))
           && (this.getAttributeCountLimit() == null
               ? that.getAttributeCountLimit() == null
               : this.getAttributeCountLimit().equals(that.getAttributeCountLimit()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcExporterModel.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrp
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.ENDPOINT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.HEADERS;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.HEADERS_LIST;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.MAX_REQUEST_SIZE;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.MAX_RESPONSE_SIZE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.TIMEOUT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcExporterModel.TLS;
 
@@ -27,7 +29,16 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ENDPOINT, TLS, HEADERS, HEADERS_LIST, COMPRESSION, TIMEOUT})
+@JsonPropertyOrder({
+  ENDPOINT,
+  TLS,
+  HEADERS,
+  HEADERS_LIST,
+  COMPRESSION,
+  MAX_REQUEST_SIZE,
+  MAX_RESPONSE_SIZE,
+  TIMEOUT
+})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
 public class OtlpGrpcExporterModel {
 
@@ -36,6 +47,8 @@ public class OtlpGrpcExporterModel {
   static final String HEADERS = "headers";
   static final String HEADERS_LIST = "headers_list";
   static final String COMPRESSION = "compression";
+  static final String MAX_REQUEST_SIZE = "max_request_size";
+  static final String MAX_RESPONSE_SIZE = "max_response_size";
   static final String TIMEOUT = "timeout";
 
   private static final Map<String, Class<?>> STABLE_PROPERTIES;
@@ -46,6 +59,8 @@ public class OtlpGrpcExporterModel {
     STABLE_PROPERTIES.put(TLS, GrpcTlsModel.class);
     STABLE_PROPERTIES.put(HEADERS_LIST, String.class);
     STABLE_PROPERTIES.put(COMPRESSION, String.class);
+    STABLE_PROPERTIES.put(MAX_REQUEST_SIZE, Integer.class);
+    STABLE_PROPERTIES.put(MAX_RESPONSE_SIZE, Integer.class);
     STABLE_PROPERTIES.put(TIMEOUT, Integer.class);
   }
 
@@ -56,6 +71,8 @@ public class OtlpGrpcExporterModel {
   @Nullable private List<NameStringValuePairModel> headers;
   @Nullable private String headersList;
   @Nullable private String compression;
+  @Nullable private Integer maxRequestSize;
+  @Nullable private Integer maxResponseSize;
   @Nullable private Integer timeout;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
 
@@ -166,6 +183,53 @@ public class OtlpGrpcExporterModel {
   }
 
   /**
+   * Configure the maximum size of each export request message in bytes, before compression.
+   *
+   * <p>Value must be non-negative. A value of 0 indicates no limit (infinity) and is not
+   * recommended.
+   *
+   * <p>If omitted or null, 67108864 (64 MiB) is used.
+   */
+  @JsonProperty(MAX_REQUEST_SIZE)
+  @Nullable
+  public Integer getMaxRequestSize() {
+    if (maxRequestSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_REQUEST_SIZE, extensionProperties, Integer.class);
+    }
+    return maxRequestSize;
+  }
+
+  @JsonProperty(MAX_REQUEST_SIZE)
+  public OtlpGrpcExporterModel setMaxRequestSize(Integer maxRequestSize) {
+    this.maxRequestSize = maxRequestSize;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export response in bytes, after decompression.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 4194304 (4 MiB) is used.
+   */
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  @Nullable
+  public Integer getMaxResponseSize() {
+    if (maxResponseSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_RESPONSE_SIZE, extensionProperties, Integer.class);
+    }
+    return maxResponseSize;
+  }
+
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  public OtlpGrpcExporterModel setMaxResponseSize(Integer maxResponseSize) {
+    this.maxResponseSize = maxResponseSize;
+    return this;
+  }
+
+  /**
    * Configure max time (in milliseconds) to wait for each export.
    *
    * <p>Value must be non-negative. A value of 0 indicates no limit (infinity).
@@ -217,6 +281,10 @@ public class OtlpGrpcExporterModel {
         + headersList
         + ", compression="
         + compression
+        + ", maxRequestSize="
+        + maxRequestSize
+        + ", maxResponseSize="
+        + maxResponseSize
         + ", timeout="
         + timeout
         + ", extensionProperties="
@@ -237,6 +305,10 @@ public class OtlpGrpcExporterModel {
     h ^= (this.getHeadersList() == null) ? 0 : this.getHeadersList().hashCode();
     h *= 1000003;
     h ^= (this.getCompression() == null) ? 0 : this.getCompression().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxRequestSize() == null) ? 0 : this.getMaxRequestSize().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxResponseSize() == null) ? 0 : this.getMaxResponseSize().hashCode();
     h *= 1000003;
     h ^= (this.getTimeout() == null) ? 0 : this.getTimeout().hashCode();
     h *= 1000003;
@@ -262,6 +334,12 @@ public class OtlpGrpcExporterModel {
           && (this.getCompression() == null
               ? that.getCompression() == null
               : this.getCompression().equals(that.getCompression()))
+          && (this.getMaxRequestSize() == null
+              ? that.getMaxRequestSize() == null
+              : this.getMaxRequestSize().equals(that.getMaxRequestSize()))
+          && (this.getMaxResponseSize() == null
+              ? that.getMaxResponseSize() == null
+              : this.getMaxResponseSize().equals(that.getMaxResponseSize()))
           && (this.getTimeout() == null
               ? that.getTimeout() == null
               : this.getTimeout().equals(that.getTimeout()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpGrpcMetricExporterModel.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrp
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.ENDPOINT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.HEADERS;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.HEADERS_LIST;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.MAX_REQUEST_SIZE;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.MAX_RESPONSE_SIZE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.TEMPORALITY_PREFERENCE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.TIMEOUT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpGrpcMetricExporterModel.TLS;
@@ -35,6 +37,8 @@ import javax.annotation.Nullable;
   HEADERS,
   HEADERS_LIST,
   COMPRESSION,
+  MAX_REQUEST_SIZE,
+  MAX_RESPONSE_SIZE,
   TIMEOUT,
   TEMPORALITY_PREFERENCE,
   DEFAULT_HISTOGRAM_AGGREGATION
@@ -47,6 +51,8 @@ public class OtlpGrpcMetricExporterModel {
   static final String HEADERS = "headers";
   static final String HEADERS_LIST = "headers_list";
   static final String COMPRESSION = "compression";
+  static final String MAX_REQUEST_SIZE = "max_request_size";
+  static final String MAX_RESPONSE_SIZE = "max_response_size";
   static final String TIMEOUT = "timeout";
   static final String TEMPORALITY_PREFERENCE = "temporality_preference";
   static final String DEFAULT_HISTOGRAM_AGGREGATION = "default_histogram_aggregation";
@@ -59,6 +65,8 @@ public class OtlpGrpcMetricExporterModel {
     STABLE_PROPERTIES.put(TLS, GrpcTlsModel.class);
     STABLE_PROPERTIES.put(HEADERS_LIST, String.class);
     STABLE_PROPERTIES.put(COMPRESSION, String.class);
+    STABLE_PROPERTIES.put(MAX_REQUEST_SIZE, Integer.class);
+    STABLE_PROPERTIES.put(MAX_RESPONSE_SIZE, Integer.class);
     STABLE_PROPERTIES.put(TIMEOUT, Integer.class);
     STABLE_PROPERTIES.put(TEMPORALITY_PREFERENCE, ExporterTemporalityPreferenceModel.class);
     STABLE_PROPERTIES.put(
@@ -72,6 +80,8 @@ public class OtlpGrpcMetricExporterModel {
   @Nullable private List<NameStringValuePairModel> headers;
   @Nullable private String headersList;
   @Nullable private String compression;
+  @Nullable private Integer maxRequestSize;
+  @Nullable private Integer maxResponseSize;
   @Nullable private Integer timeout;
   @Nullable private ExporterTemporalityPreferenceModel temporalityPreference;
   @Nullable private ExporterDefaultHistogramAggregationModel defaultHistogramAggregation;
@@ -180,6 +190,53 @@ public class OtlpGrpcMetricExporterModel {
   @JsonProperty(COMPRESSION)
   public OtlpGrpcMetricExporterModel setCompression(String compression) {
     this.compression = compression;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export request message in bytes, before compression.
+   *
+   * <p>Value must be non-negative. A value of 0 indicates no limit (infinity) and is not
+   * recommended.
+   *
+   * <p>If omitted or null, 67108864 (64 MiB) is used.
+   */
+  @JsonProperty(MAX_REQUEST_SIZE)
+  @Nullable
+  public Integer getMaxRequestSize() {
+    if (maxRequestSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_REQUEST_SIZE, extensionProperties, Integer.class);
+    }
+    return maxRequestSize;
+  }
+
+  @JsonProperty(MAX_REQUEST_SIZE)
+  public OtlpGrpcMetricExporterModel setMaxRequestSize(Integer maxRequestSize) {
+    this.maxRequestSize = maxRequestSize;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export response in bytes, after decompression.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 4194304 (4 MiB) is used.
+   */
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  @Nullable
+  public Integer getMaxResponseSize() {
+    if (maxResponseSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_RESPONSE_SIZE, extensionProperties, Integer.class);
+    }
+    return maxResponseSize;
+  }
+
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  public OtlpGrpcMetricExporterModel setMaxResponseSize(Integer maxResponseSize) {
+    this.maxResponseSize = maxResponseSize;
     return this;
   }
 
@@ -299,6 +356,10 @@ public class OtlpGrpcMetricExporterModel {
         + headersList
         + ", compression="
         + compression
+        + ", maxRequestSize="
+        + maxRequestSize
+        + ", maxResponseSize="
+        + maxResponseSize
         + ", timeout="
         + timeout
         + ", temporalityPreference="
@@ -323,6 +384,10 @@ public class OtlpGrpcMetricExporterModel {
     h ^= (this.getHeadersList() == null) ? 0 : this.getHeadersList().hashCode();
     h *= 1000003;
     h ^= (this.getCompression() == null) ? 0 : this.getCompression().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxRequestSize() == null) ? 0 : this.getMaxRequestSize().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxResponseSize() == null) ? 0 : this.getMaxResponseSize().hashCode();
     h *= 1000003;
     h ^= (this.getTimeout() == null) ? 0 : this.getTimeout().hashCode();
     h *= 1000003;
@@ -355,6 +420,12 @@ public class OtlpGrpcMetricExporterModel {
           && (this.getCompression() == null
               ? that.getCompression() == null
               : this.getCompression().equals(that.getCompression()))
+          && (this.getMaxRequestSize() == null
+              ? that.getMaxRequestSize() == null
+              : this.getMaxRequestSize().equals(that.getMaxRequestSize()))
+          && (this.getMaxResponseSize() == null
+              ? that.getMaxResponseSize() == null
+              : this.getMaxResponseSize().equals(that.getMaxResponseSize()))
           && (this.getTimeout() == null
               ? that.getTimeout() == null
               : this.getTimeout().equals(that.getTimeout()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpExporterModel.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHtt
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.ENDPOINT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.HEADERS;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.HEADERS_LIST;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.MAX_REQUEST_SIZE;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.MAX_RESPONSE_SIZE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.TIMEOUT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpExporterModel.TLS;
 
@@ -28,7 +30,17 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ENDPOINT, TLS, HEADERS, HEADERS_LIST, COMPRESSION, TIMEOUT, ENCODING})
+@JsonPropertyOrder({
+  ENDPOINT,
+  TLS,
+  HEADERS,
+  HEADERS_LIST,
+  COMPRESSION,
+  MAX_REQUEST_SIZE,
+  MAX_RESPONSE_SIZE,
+  TIMEOUT,
+  ENCODING
+})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
 public class OtlpHttpExporterModel {
 
@@ -37,6 +49,8 @@ public class OtlpHttpExporterModel {
   static final String HEADERS = "headers";
   static final String HEADERS_LIST = "headers_list";
   static final String COMPRESSION = "compression";
+  static final String MAX_REQUEST_SIZE = "max_request_size";
+  static final String MAX_RESPONSE_SIZE = "max_response_size";
   static final String TIMEOUT = "timeout";
   static final String ENCODING = "encoding";
 
@@ -48,6 +62,8 @@ public class OtlpHttpExporterModel {
     STABLE_PROPERTIES.put(TLS, HttpTlsModel.class);
     STABLE_PROPERTIES.put(HEADERS_LIST, String.class);
     STABLE_PROPERTIES.put(COMPRESSION, String.class);
+    STABLE_PROPERTIES.put(MAX_REQUEST_SIZE, Integer.class);
+    STABLE_PROPERTIES.put(MAX_RESPONSE_SIZE, Integer.class);
     STABLE_PROPERTIES.put(TIMEOUT, Integer.class);
     STABLE_PROPERTIES.put(ENCODING, OtlpHttpEncodingModel.class);
   }
@@ -59,6 +75,8 @@ public class OtlpHttpExporterModel {
   @Nullable private List<NameStringValuePairModel> headers;
   @Nullable private String headersList;
   @Nullable private String compression;
+  @Nullable private Integer maxRequestSize;
+  @Nullable private Integer maxResponseSize;
   @Nullable private Integer timeout;
   @Nullable private OtlpHttpEncodingModel encoding;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
@@ -171,6 +189,53 @@ public class OtlpHttpExporterModel {
   }
 
   /**
+   * Configure the maximum size of each export request body in bytes, before compression.
+   *
+   * <p>Value must be non-negative. A value of 0 indicates no limit (infinity) and is not
+   * recommended.
+   *
+   * <p>If omitted or null, 67108864 (64 MiB) is used.
+   */
+  @JsonProperty(MAX_REQUEST_SIZE)
+  @Nullable
+  public Integer getMaxRequestSize() {
+    if (maxRequestSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_REQUEST_SIZE, extensionProperties, Integer.class);
+    }
+    return maxRequestSize;
+  }
+
+  @JsonProperty(MAX_REQUEST_SIZE)
+  public OtlpHttpExporterModel setMaxRequestSize(Integer maxRequestSize) {
+    this.maxRequestSize = maxRequestSize;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export response in bytes, after decompression.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 4194304 (4 MiB) is used.
+   */
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  @Nullable
+  public Integer getMaxResponseSize() {
+    if (maxResponseSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_RESPONSE_SIZE, extensionProperties, Integer.class);
+    }
+    return maxResponseSize;
+  }
+
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  public OtlpHttpExporterModel setMaxResponseSize(Integer maxResponseSize) {
+    this.maxResponseSize = maxResponseSize;
+    return this;
+  }
+
+  /**
    * Configure max time (in milliseconds) to wait for each export.
    *
    * <p>Value must be non-negative. A value of 0 indicates no limit (infinity).
@@ -251,6 +316,10 @@ public class OtlpHttpExporterModel {
         + headersList
         + ", compression="
         + compression
+        + ", maxRequestSize="
+        + maxRequestSize
+        + ", maxResponseSize="
+        + maxResponseSize
         + ", timeout="
         + timeout
         + ", encoding="
@@ -273,6 +342,10 @@ public class OtlpHttpExporterModel {
     h ^= (this.getHeadersList() == null) ? 0 : this.getHeadersList().hashCode();
     h *= 1000003;
     h ^= (this.getCompression() == null) ? 0 : this.getCompression().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxRequestSize() == null) ? 0 : this.getMaxRequestSize().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxResponseSize() == null) ? 0 : this.getMaxResponseSize().hashCode();
     h *= 1000003;
     h ^= (this.getTimeout() == null) ? 0 : this.getTimeout().hashCode();
     h *= 1000003;
@@ -300,6 +373,12 @@ public class OtlpHttpExporterModel {
           && (this.getCompression() == null
               ? that.getCompression() == null
               : this.getCompression().equals(that.getCompression()))
+          && (this.getMaxRequestSize() == null
+              ? that.getMaxRequestSize() == null
+              : this.getMaxRequestSize().equals(that.getMaxRequestSize()))
+          && (this.getMaxResponseSize() == null
+              ? that.getMaxResponseSize() == null
+              : this.getMaxResponseSize().equals(that.getMaxResponseSize()))
           && (this.getTimeout() == null
               ? that.getTimeout() == null
               : this.getTimeout().equals(that.getTimeout()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpMetricExporterModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/OtlpHttpMetricExporterModel.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHtt
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.ENDPOINT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.HEADERS;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.HEADERS_LIST;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.MAX_REQUEST_SIZE;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.MAX_RESPONSE_SIZE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.TEMPORALITY_PREFERENCE;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.TIMEOUT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OtlpHttpMetricExporterModel.TLS;
@@ -36,6 +38,8 @@ import javax.annotation.Nullable;
   HEADERS,
   HEADERS_LIST,
   COMPRESSION,
+  MAX_REQUEST_SIZE,
+  MAX_RESPONSE_SIZE,
   TIMEOUT,
   ENCODING,
   TEMPORALITY_PREFERENCE,
@@ -49,6 +53,8 @@ public class OtlpHttpMetricExporterModel {
   static final String HEADERS = "headers";
   static final String HEADERS_LIST = "headers_list";
   static final String COMPRESSION = "compression";
+  static final String MAX_REQUEST_SIZE = "max_request_size";
+  static final String MAX_RESPONSE_SIZE = "max_response_size";
   static final String TIMEOUT = "timeout";
   static final String ENCODING = "encoding";
   static final String TEMPORALITY_PREFERENCE = "temporality_preference";
@@ -62,6 +68,8 @@ public class OtlpHttpMetricExporterModel {
     STABLE_PROPERTIES.put(TLS, HttpTlsModel.class);
     STABLE_PROPERTIES.put(HEADERS_LIST, String.class);
     STABLE_PROPERTIES.put(COMPRESSION, String.class);
+    STABLE_PROPERTIES.put(MAX_REQUEST_SIZE, Integer.class);
+    STABLE_PROPERTIES.put(MAX_RESPONSE_SIZE, Integer.class);
     STABLE_PROPERTIES.put(TIMEOUT, Integer.class);
     STABLE_PROPERTIES.put(ENCODING, OtlpHttpEncodingModel.class);
     STABLE_PROPERTIES.put(TEMPORALITY_PREFERENCE, ExporterTemporalityPreferenceModel.class);
@@ -76,6 +84,8 @@ public class OtlpHttpMetricExporterModel {
   @Nullable private List<NameStringValuePairModel> headers;
   @Nullable private String headersList;
   @Nullable private String compression;
+  @Nullable private Integer maxRequestSize;
+  @Nullable private Integer maxResponseSize;
   @Nullable private Integer timeout;
   @Nullable private OtlpHttpEncodingModel encoding;
   @Nullable private ExporterTemporalityPreferenceModel temporalityPreference;
@@ -185,6 +195,53 @@ public class OtlpHttpMetricExporterModel {
   @JsonProperty(COMPRESSION)
   public OtlpHttpMetricExporterModel setCompression(String compression) {
     this.compression = compression;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export request body in bytes, before compression.
+   *
+   * <p>Value must be non-negative. A value of 0 indicates no limit (infinity) and is not
+   * recommended.
+   *
+   * <p>If omitted or null, 67108864 (64 MiB) is used.
+   */
+  @JsonProperty(MAX_REQUEST_SIZE)
+  @Nullable
+  public Integer getMaxRequestSize() {
+    if (maxRequestSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_REQUEST_SIZE, extensionProperties, Integer.class);
+    }
+    return maxRequestSize;
+  }
+
+  @JsonProperty(MAX_REQUEST_SIZE)
+  public OtlpHttpMetricExporterModel setMaxRequestSize(Integer maxRequestSize) {
+    this.maxRequestSize = maxRequestSize;
+    return this;
+  }
+
+  /**
+   * Configure the maximum size of each export response in bytes, after decompression.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 4194304 (4 MiB) is used.
+   */
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  @Nullable
+  public Integer getMaxResponseSize() {
+    if (maxResponseSize == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          MAX_RESPONSE_SIZE, extensionProperties, Integer.class);
+    }
+    return maxResponseSize;
+  }
+
+  @JsonProperty(MAX_RESPONSE_SIZE)
+  public OtlpHttpMetricExporterModel setMaxResponseSize(Integer maxResponseSize) {
+    this.maxResponseSize = maxResponseSize;
     return this;
   }
 
@@ -333,6 +390,10 @@ public class OtlpHttpMetricExporterModel {
         + headersList
         + ", compression="
         + compression
+        + ", maxRequestSize="
+        + maxRequestSize
+        + ", maxResponseSize="
+        + maxResponseSize
         + ", timeout="
         + timeout
         + ", encoding="
@@ -359,6 +420,10 @@ public class OtlpHttpMetricExporterModel {
     h ^= (this.getHeadersList() == null) ? 0 : this.getHeadersList().hashCode();
     h *= 1000003;
     h ^= (this.getCompression() == null) ? 0 : this.getCompression().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxRequestSize() == null) ? 0 : this.getMaxRequestSize().hashCode();
+    h *= 1000003;
+    h ^= (this.getMaxResponseSize() == null) ? 0 : this.getMaxResponseSize().hashCode();
     h *= 1000003;
     h ^= (this.getTimeout() == null) ? 0 : this.getTimeout().hashCode();
     h *= 1000003;
@@ -393,6 +458,12 @@ public class OtlpHttpMetricExporterModel {
           && (this.getCompression() == null
               ? that.getCompression() == null
               : this.getCompression().equals(that.getCompression()))
+          && (this.getMaxRequestSize() == null
+              ? that.getMaxRequestSize() == null
+              : this.getMaxRequestSize().equals(that.getMaxRequestSize()))
+          && (this.getMaxResponseSize() == null
+              ? that.getMaxResponseSize() == null
+              : this.getMaxResponseSize().equals(that.getMaxResponseSize()))
           && (this.getTimeout() == null
               ? that.getTimeout() == null
               : this.getTimeout().equals(that.getTimeout()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SamplerModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SamplerModel.java
@@ -7,6 +7,7 @@ package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model;
 
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel.ALWAYS_OFF;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel.ALWAYS_ON;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel.ALWAYS_RECORD;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel.PARENT_BASED;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel.TRACE_ID_RATIO_BASED;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.SamplerModelAccessor.EXPERIMENTAL_PROPERTIES;
@@ -24,12 +25,13 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ALWAYS_OFF, ALWAYS_ON, PARENT_BASED, TRACE_ID_RATIO_BASED})
+@JsonPropertyOrder({ALWAYS_OFF, ALWAYS_ON, ALWAYS_RECORD, PARENT_BASED, TRACE_ID_RATIO_BASED})
 @Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
 public class SamplerModel {
 
   static final String ALWAYS_OFF = "always_off";
   static final String ALWAYS_ON = "always_on";
+  static final String ALWAYS_RECORD = "always_record";
   static final String PARENT_BASED = "parent_based";
   static final String TRACE_ID_RATIO_BASED = "trace_id_ratio_based";
 
@@ -39,6 +41,7 @@ public class SamplerModel {
     STABLE_PROPERTIES = new HashMap<>();
     STABLE_PROPERTIES.put(ALWAYS_OFF, AlwaysOffSamplerModel.class);
     STABLE_PROPERTIES.put(ALWAYS_ON, AlwaysOnSamplerModel.class);
+    STABLE_PROPERTIES.put(ALWAYS_RECORD, AlwaysRecordSamplerModel.class);
     STABLE_PROPERTIES.put(PARENT_BASED, ParentBasedSamplerModel.class);
     STABLE_PROPERTIES.put(TRACE_ID_RATIO_BASED, TraceIdRatioBasedSamplerModel.class);
   }
@@ -47,6 +50,7 @@ public class SamplerModel {
 
   @Nullable private AlwaysOffSamplerModel alwaysOff;
   @Nullable private AlwaysOnSamplerModel alwaysOn;
+  @Nullable private AlwaysRecordSamplerModel alwaysRecord;
   @Nullable private ParentBasedSamplerModel parentBased;
   @Nullable private TraceIdRatioBasedSamplerModel traceIdRatioBased;
   private Map<String, Object> extensionProperties = new LinkedHashMap<String, Object>();
@@ -90,6 +94,27 @@ public class SamplerModel {
   @JsonProperty(ALWAYS_ON)
   public SamplerModel setAlwaysOn(AlwaysOnSamplerModel alwaysOn) {
     this.alwaysOn = alwaysOn;
+    return this;
+  }
+
+  /**
+   * Configure sampler to be always_record.
+   *
+   * <p>If omitted, ignore.
+   */
+  @JsonProperty(ALWAYS_RECORD)
+  @Nullable
+  public AlwaysRecordSamplerModel getAlwaysRecord() {
+    if (alwaysRecord == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          ALWAYS_RECORD, extensionProperties, AlwaysRecordSamplerModel.class);
+    }
+    return alwaysRecord;
+  }
+
+  @JsonProperty(ALWAYS_RECORD)
+  public SamplerModel setAlwaysRecord(AlwaysRecordSamplerModel alwaysRecord) {
+    this.alwaysRecord = alwaysRecord;
     return this;
   }
 
@@ -159,6 +184,8 @@ public class SamplerModel {
         + alwaysOff
         + ", alwaysOn="
         + alwaysOn
+        + ", alwaysRecord="
+        + alwaysRecord
         + ", parentBased="
         + parentBased
         + ", traceIdRatioBased="
@@ -175,6 +202,8 @@ public class SamplerModel {
     h ^= (this.getAlwaysOff() == null) ? 0 : this.getAlwaysOff().hashCode();
     h *= 1000003;
     h ^= (this.getAlwaysOn() == null) ? 0 : this.getAlwaysOn().hashCode();
+    h *= 1000003;
+    h ^= (this.getAlwaysRecord() == null) ? 0 : this.getAlwaysRecord().hashCode();
     h *= 1000003;
     h ^= (this.getParentBased() == null) ? 0 : this.getParentBased().hashCode();
     h *= 1000003;
@@ -197,6 +226,9 @@ public class SamplerModel {
           && (this.getAlwaysOn() == null
               ? that.getAlwaysOn() == null
               : this.getAlwaysOn().equals(that.getAlwaysOn()))
+          && (this.getAlwaysRecord() == null
+              ? that.getAlwaysRecord() == null
+              : this.getAlwaysRecord().equals(that.getAlwaysRecord()))
           && (this.getParentBased() == null
               ? that.getParentBased() == null
               : this.getParentBased().equals(that.getParentBased()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanLimitsModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/SpanLimitsModel.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model;
 
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanLimitsModel.ATTRIBUTE_COUNT_LIMIT;
+import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanLimitsModel.ATTRIBUTE_VALUE_DEPTH_LIMIT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanLimitsModel.ATTRIBUTE_VALUE_LENGTH_LIMIT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanLimitsModel.EVENT_ATTRIBUTE_COUNT_LIMIT;
 import static io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanLimitsModel.EVENT_COUNT_LIMIT;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
   ATTRIBUTE_VALUE_LENGTH_LIMIT,
+  ATTRIBUTE_VALUE_DEPTH_LIMIT,
   ATTRIBUTE_COUNT_LIMIT,
   EVENT_COUNT_LIMIT,
   LINK_COUNT_LIMIT,
@@ -38,6 +40,7 @@ import javax.annotation.Nullable;
 public class SpanLimitsModel {
 
   static final String ATTRIBUTE_VALUE_LENGTH_LIMIT = "attribute_value_length_limit";
+  static final String ATTRIBUTE_VALUE_DEPTH_LIMIT = "attribute_value_depth_limit";
   static final String ATTRIBUTE_COUNT_LIMIT = "attribute_count_limit";
   static final String EVENT_COUNT_LIMIT = "event_count_limit";
   static final String LINK_COUNT_LIMIT = "link_count_limit";
@@ -49,6 +52,7 @@ public class SpanLimitsModel {
   static {
     STABLE_PROPERTIES = new HashMap<>();
     STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_LENGTH_LIMIT, Integer.class);
+    STABLE_PROPERTIES.put(ATTRIBUTE_VALUE_DEPTH_LIMIT, Integer.class);
     STABLE_PROPERTIES.put(ATTRIBUTE_COUNT_LIMIT, Integer.class);
     STABLE_PROPERTIES.put(EVENT_COUNT_LIMIT, Integer.class);
     STABLE_PROPERTIES.put(LINK_COUNT_LIMIT, Integer.class);
@@ -59,6 +63,7 @@ public class SpanLimitsModel {
   private static final boolean ALLOWS_ADDITIONAL_PROPERTIES = false;
 
   @Nullable private Integer attributeValueLengthLimit;
+  @Nullable private Integer attributeValueDepthLimit;
   @Nullable private Integer attributeCountLimit;
   @Nullable private Integer eventCountLimit;
   @Nullable private Integer linkCountLimit;
@@ -86,6 +91,35 @@ public class SpanLimitsModel {
   @JsonProperty(ATTRIBUTE_VALUE_LENGTH_LIMIT)
   public SpanLimitsModel setAttributeValueLengthLimit(Integer attributeValueLengthLimit) {
     this.attributeValueLengthLimit = attributeValueLengthLimit;
+    return this;
+  }
+
+  /**
+   * Configure the maximum attribute value depth for nested array and map values. Overrides
+   * .attribute_limits.attribute_value_depth_limit.
+   *
+   * <p>Depth starts at 1 for the top-level attribute value and increments when descending into
+   * array elements or map values.
+   *
+   * <p>Array or map values deeper than the limit are replaced with an empty value.
+   *
+   * <p>Value must be positive.
+   *
+   * <p>If omitted or null, 64 is used.
+   */
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  @Nullable
+  public Integer getAttributeValueDepthLimit() {
+    if (attributeValueDepthLimit == null) {
+      return ExtensionPropertyUtil.getGraduated(
+          ATTRIBUTE_VALUE_DEPTH_LIMIT, extensionProperties, Integer.class);
+    }
+    return attributeValueDepthLimit;
+  }
+
+  @JsonProperty(ATTRIBUTE_VALUE_DEPTH_LIMIT)
+  public SpanLimitsModel setAttributeValueDepthLimit(Integer attributeValueDepthLimit) {
+    this.attributeValueDepthLimit = attributeValueDepthLimit;
     return this;
   }
 
@@ -226,6 +260,8 @@ public class SpanLimitsModel {
     return "SpanLimitsModel{"
         + "attributeValueLengthLimit="
         + attributeValueLengthLimit
+        + ", attributeValueDepthLimit="
+        + attributeValueDepthLimit
         + ", attributeCountLimit="
         + attributeCountLimit
         + ", eventCountLimit="
@@ -249,6 +285,11 @@ public class SpanLimitsModel {
         (this.getAttributeValueLengthLimit() == null)
             ? 0
             : this.getAttributeValueLengthLimit().hashCode();
+    h *= 1000003;
+    h ^=
+        (this.getAttributeValueDepthLimit() == null)
+            ? 0
+            : this.getAttributeValueDepthLimit().hashCode();
     h *= 1000003;
     h ^= (this.getAttributeCountLimit() == null) ? 0 : this.getAttributeCountLimit().hashCode();
     h *= 1000003;
@@ -280,6 +321,9 @@ public class SpanLimitsModel {
       return (this.getAttributeValueLengthLimit() == null
               ? that.getAttributeValueLengthLimit() == null
               : this.getAttributeValueLengthLimit().equals(that.getAttributeValueLengthLimit()))
+          && (this.getAttributeValueDepthLimit() == null
+              ? that.getAttributeValueDepthLimit() == null
+              : this.getAttributeValueDepthLimit().equals(that.getAttributeValueDepthLimit()))
           && (this.getAttributeCountLimit() == null
               ? that.getAttributeCountLimit() == null
               : this.getAttributeCountLimit().equals(that.getAttributeCountLimit()))

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalInstrumentationModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalInstrumentationModel.java
@@ -34,7 +34,7 @@ public class ExperimentalInstrumentationModel {
   /**
    * Configure general SemConv options that may apply to multiple languages and instrumentations.
    *
-   * <p>Instrumenation may merge general config options with the language specific configuration at
+   * <p>Instrumentation may merge general config options with the language specific configuration at
    * .instrumentation.<language>.
    *
    * <p>If omitted, default values as described in ExperimentalGeneralInstrumentation are used.

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalViewMatchingModeModel.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/ExperimentalViewMatchingModeModel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("io.opentelemetry.gradle.DeclarativeConfigPojoGenerator")
+public enum ExperimentalViewMatchingModeModel {
+  INDEPENDENT("independent"),
+  COMPOSABLE("composable");
+  private final String value;
+  private static final Map<String, ExperimentalViewMatchingModeModel> CONSTANTS =
+      new HashMap<String, ExperimentalViewMatchingModeModel>();
+
+  static {
+    for (ExperimentalViewMatchingModeModel c : values()) {
+      CONSTANTS.put(c.value, c);
+    }
+  }
+
+  ExperimentalViewMatchingModeModel(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
+
+  @JsonValue
+  public String value() {
+    return this.value;
+  }
+
+  @JsonCreator
+  public static ExperimentalViewMatchingModeModel fromValue(String value) {
+    ExperimentalViewMatchingModeModel constant = CONSTANTS.get(value);
+    if (constant == null) {
+      throw new IllegalArgumentException(value);
+    } else {
+      return constant;
+    }
+  }
+}

--- a/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/MeterProviderModelAccessor.java
+++ b/sdk-extensions/declarative-config/src/main/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/model/internal/MeterProviderModelAccessor.java
@@ -24,12 +24,14 @@ public final class MeterProviderModelAccessor {
   private MeterProviderModelAccessor() {}
 
   static final String METER_CONFIGURATOR = "meter_configurator/development";
+  static final String VIEW_MATCHING_MODE = "view_matching_mode/development";
 
   public static final Map<String, Class<?>> EXPERIMENTAL_PROPERTIES;
 
   static {
     EXPERIMENTAL_PROPERTIES = new HashMap<>();
     EXPERIMENTAL_PROPERTIES.put(METER_CONFIGURATOR, ExperimentalMeterConfiguratorModel.class);
+    EXPERIMENTAL_PROPERTIES.put(VIEW_MATCHING_MODE, ExperimentalViewMatchingModeModel.class);
   }
 
   @Nullable
@@ -44,6 +46,21 @@ public final class MeterProviderModelAccessor {
       MeterProviderModel model, ExperimentalMeterConfiguratorModel value) {
     requireNonNull(value, "value");
     model.setExtensionProperty(METER_CONFIGURATOR, value);
+    return model;
+  }
+
+  @Nullable
+  public static ExperimentalViewMatchingModeModel getViewMatchingMode(MeterProviderModel model) {
+    return ExtensionPropertyUtil.get(
+        VIEW_MATCHING_MODE,
+        model.getExtensionProperties(),
+        ExperimentalViewMatchingModeModel.class);
+  }
+
+  public static MeterProviderModel setViewMatchingMode(
+      MeterProviderModel model, ExperimentalViewMatchingModeModel value) {
+    requireNonNull(value, "value");
+    model.setExtensionProperty(VIEW_MATCHING_MODE, value);
     return model;
   }
 }

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationCreateTest.java
@@ -130,7 +130,7 @@ class DeclarativeConfigurationCreateTest {
     // exporter with OTLP exporter, following by invalid batch exporter which references invalid
     // exporter "foo".
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -157,7 +157,7 @@ class DeclarativeConfigurationCreateTest {
   @Test
   void parseAndCreate_EmptyComponentProviderConfig() {
     String yaml =
-        "file_format: \"1.1\"\n"
+        "file_format: \"1.2\"\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - test:\n"
@@ -175,7 +175,7 @@ class DeclarativeConfigurationCreateTest {
   @Test
   void create_ModelCustomizer() {
     OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
-    model.setFileFormat("1.1");
+    model.setFileFormat("1.2");
     model.setTracerProvider(
         new TracerProviderModel()
             .setProcessors(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationParseTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/DeclarativeConfigurationParseTest.java
@@ -51,7 +51,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void parse_nullValuesParsedToEmptyObjects() {
     String objectPlaceholderString =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -69,7 +69,7 @@ class DeclarativeConfigurationParseTest {
             new ByteArrayInputStream(objectPlaceholderString.getBytes(StandardCharsets.UTF_8)));
 
     String noOjbectPlaceholderString =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -451,7 +451,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void read_WithEnvironmentVariables() {
     String yaml =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -472,7 +472,7 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .setFileFormat("1.0")
+                .setFileFormat("1.2")
                 .setTracerProvider(
                     new TracerProviderModel()
                         .setProcessors(
@@ -497,7 +497,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void read_WithSystemProperties() {
     String yaml =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - batch:\n"
@@ -518,7 +518,7 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .setFileFormat("1.0")
+                .setFileFormat("1.2")
                 .setTracerProvider(
                     new TracerProviderModel()
                         .setProcessors(
@@ -543,7 +543,7 @@ class DeclarativeConfigurationParseTest {
   @Test
   void read_WithMixedEnvVarsAndSystemProperties() {
     String yaml =
-        "file_format: \"1.0\"\n"
+        "file_format: \"1.2\"\n"
             + "resource:\n"
             + "  attributes:\n"
             + "    - name: service.name\n"
@@ -562,7 +562,7 @@ class DeclarativeConfigurationParseTest {
     assertThat(model)
         .isEqualTo(
             new OpenTelemetryConfigurationModel()
-                .setFileFormat("1.0")
+                .setFileFormat("1.2")
                 .setResource(
                     new ResourceModel()
                         .setAttributes(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/OpenTelemetryConfigurationFactoryTest.java
@@ -136,9 +136,9 @@ class OpenTelemetryConfigurationFactoryTest {
         Arguments.argumentSet("1.0-rc.2 valid", "1.0-rc.2", true),
         Arguments.argumentSet("1.0-rc.3 valid", "1.0-rc.3", true),
         Arguments.argumentSet("1.0 valid", "1.0", true),
+        Arguments.argumentSet("1.1 valid", "1.1", true),
         Arguments.argumentSet("1.2 valid", "1.2", true),
-        Arguments.argumentSet("1.12 valid", "1.12", true),
-        Arguments.argumentSet("1.1 valid", "1.1", true));
+        Arguments.argumentSet("1.12 valid", "1.12", true));
   }
 
   @Test
@@ -152,13 +152,13 @@ class OpenTelemetryConfigurationFactoryTest {
     cleanup.addCloseable(sdk);
 
     logCapturer.assertContains(
-        "Configuration file_format '1.0-rc.3' does not exactly match expected version '1.1'");
+        "Configuration file_format '1.0-rc.3' does not exactly match expected version '1.2'");
   }
 
   @Test
   void create_FileFormatExactMatch_NoWarning() {
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().setFileFormat("1.1");
+        new OpenTelemetryConfigurationModel().setFileFormat("1.2");
 
     ExtendedOpenTelemetrySdk sdk =
         OpenTelemetryConfigurationFactory.getInstance().create(model, context).getSdk();
@@ -171,7 +171,7 @@ class OpenTelemetryConfigurationFactoryTest {
   void create_Defaults() {
     List<Closeable> closeables = new ArrayList<>();
     OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel().setFileFormat("1.1");
+        new OpenTelemetryConfigurationModel().setFileFormat("1.2");
     OpenTelemetrySdk expectedSdk =
         OpenTelemetrySdkBuilderUtil.setConfigProvider(
                 OpenTelemetrySdk.builder(),
@@ -192,7 +192,7 @@ class OpenTelemetryConfigurationFactoryTest {
     List<Closeable> closeables = new ArrayList<>();
     OpenTelemetryConfigurationModel model =
         new OpenTelemetryConfigurationModel()
-            .setFileFormat("1.1")
+            .setFileFormat("1.2")
             .setDisabled(true)
             // Logger provider configuration should be ignored since SDK is disabled
             .setLoggerProvider(
@@ -235,7 +235,7 @@ class OpenTelemetryConfigurationFactoryTest {
 
     OpenTelemetryConfigurationModel model =
         new OpenTelemetryConfigurationModel()
-            .setFileFormat("1.1")
+            .setFileFormat("1.2")
             .setPropagator(
                 new PropagatorModel().setCompositeList("tracecontext,baggage,b3multi,b3"))
             .setResource(

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactoryTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/SamplerFactoryTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.component.SamplerComponentProvider;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AlwaysOffSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AlwaysOnSamplerModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AlwaysRecordSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ParentBasedSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.TraceIdRatioBasedSamplerModel;
@@ -26,6 +27,7 @@ import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.Exper
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalComposableSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalJaegerRemoteSamplerModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.SamplerModelAccessor;
+import io.opentelemetry.sdk.extension.incubator.trace.samplers.AlwaysRecordSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
 import io.opentelemetry.sdk.extension.trace.jaeger.sampler.JaegerRemoteSampler;
@@ -66,7 +68,7 @@ class SamplerFactoryTest {
     Sampler sampler = SamplerFactory.getInstance().create(model, context);
     cleanup.addCloseables(closeables);
 
-    assertThat(sampler.toString()).isEqualTo(expectedSampler.toString());
+    assertThat(sampler.getDescription()).isEqualTo(expectedSampler.getDescription());
   }
 
   private static Stream<Arguments> createArguments() {
@@ -123,6 +125,16 @@ class SamplerFactoryTest {
                 .setLocalParentSampled(Sampler.traceIdRatioBased(0.4d))
                 .setLocalParentNotSampled(Sampler.traceIdRatioBased(0.5d))
                 .build()),
+        Arguments.argumentSet(
+            "always_record",
+            new SamplerModel()
+                .setAlwaysRecord(
+                    new AlwaysRecordSamplerModel()
+                        .setRoot(
+                            new SamplerModel()
+                                .setTraceIdRatioBased(
+                                    new TraceIdRatioBasedSamplerModel().setRatio(0.1d)))),
+            AlwaysRecordSampler.create(Sampler.traceIdRatioBased(0.1d))),
         Arguments.argumentSet(
             "jaeger_remote",
             SamplerModelAccessor.setJaegerRemote(
@@ -212,6 +224,10 @@ class SamplerFactoryTest {
                 new ExperimentalComposableSamplerModel()
                     .setParentThreshold(new ExperimentalComposableParentThresholdSamplerModel())),
             "parent threshold sampler root is required but is null"),
+        Arguments.argumentSet(
+            "always_record missing root",
+            new SamplerModel().setAlwaysRecord(new AlwaysRecordSamplerModel()),
+            "always_record sampler .root is required"),
         Arguments.argumentSet(
             "unknown component provider",
             new SamplerModel()

--- a/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/YamlDeclarativeConfigPropertiesTest.java
+++ b/sdk-extensions/declarative-config/src/test/java/io/opentelemetry/sdk/autoconfigure/declarativeconfig/YamlDeclarativeConfigPropertiesTest.java
@@ -29,7 +29,7 @@ class YamlDeclarativeConfigPropertiesTest {
   LogCapturer logs = LogCapturer.create().captureForType(YamlDeclarativeConfigProperties.class);
 
   private static final String extendedSchema =
-      "file_format: \"1.0\"\n"
+      "file_format: \"1.2\"\n"
           + "disabled: false\n"
           + "\n"
           + "resource:\n"
@@ -76,7 +76,7 @@ class YamlDeclarativeConfigPropertiesTest {
   @Test
   void configurationSchema() {
     // Validate can read declarative configuration schema properties
-    assertThat(structuredConfigProps.getString("file_format")).isEqualTo("1.0");
+    assertThat(structuredConfigProps.getString("file_format")).isEqualTo("1.2");
     DeclarativeConfigProperties resourceProps = structuredConfigProps.getStructured("resource");
     assertThat(resourceProps).isNotNull();
     List<DeclarativeConfigProperties> resourceAttributesList =


### PR DESCRIPTION
Unblocks https://github.com/open-telemetry/opentelemetry-java/pull/8446 by giving a non-programmatic config solution to overriding default request/response sizes, since [v1.2.0](https://github.com/open-telemetry/opentelemetry-configuration/releases/tag/v1.2.0) has new config options for this: https://github.com/open-telemetry/opentelemetry-configuration/pull/700

Only non-generated code changes:

- SamplerFactory
- SamplerFactoryTest
- build.gradle.kts