### PR TITLE
Suppress OSGI test org.apache.aries.spifly.level info logs

### DIFF
--- a/integration-tests/osgi/build.gradle.kts
+++ b/integration-tests/osgi/build.gradle.kts
@@ -102,10 +102,14 @@ fun registerOsgiSuite(
 
   val runee = "JavaSE-${java.toolchain.languageVersion.get()}"
   val inputBndrun = layout.buildDirectory.file("bndrun/$suiteName.bndrun")
+  // Suppresses noisy INFO logs from Apache Aries SPI Fly's BaseActivator (one line per SPI
+  // provider registration per bundle). Passed to the forked test JVM via bndrun's -runvm.
+  val loggingConfig = layout.projectDirectory.file("logging.properties").asFile
   val generateBndrunTask = tasks.register("${suiteName}GenerateBndrun") {
     inputs.property("bsn", bsn)
     inputs.property("runee", runee)
     inputs.property("extraRunrequires", extraRunrequires)
+    inputs.file(loggingConfig)
     outputs.file(inputBndrun)
     doLast {
       val extraEntries = extraRunrequires.joinToString("") { ",\\\n|  bnd.identity;id='$it'" }
@@ -114,6 +118,7 @@ fun registerOsgiSuite(
         |-tester: biz.aQute.tester.junit-platform
         |-runfw: org.apache.felix.framework
         |-runee: $runee
+        |-runvm: -Djava.util.logging.config.file="${loggingConfig.absolutePath}"
         |
         |-runrequires: \
         |  bnd.identity;id='$bsn',\

--- a/integration-tests/osgi/logging.properties
+++ b/integration-tests/osgi/logging.properties
@@ -1,0 +1,3 @@
+# Suppress noisy INFO logs from Apache Aries SPI Fly which logs a line for every SPI provider it
+# registers per bundle. These are emitted via java.util.logging.
+org.apache.aries.spifly.level = WARNING


### PR DESCRIPTION
Suppresses noisy build output logs like below:

```
> Task :integration-tests:osgi:otlpHttpOkHttpTestingBundle
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpMetricExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpSpanExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpLogRecordExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcMetricExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcSpanExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcLogRecordExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpLogRecordExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpMetricExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpSpanExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.sender.jdk.internal.JdkHttpSenderProvider of service io.opentelemetry.sdk.common.export.HttpSenderProvider in bundle opentelemetry-exporter-sender-jdk
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.OtTraceConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.internal.B3ComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.internal.B3MultiComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.integrationtest.osgi.TestAutoConfigurationCustomizerProvider of service io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider in bundle opentelemetry-osgi-testing-autoconfigure
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.integrationtest.osgi.TestMetricReaderProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ConfigurableMetricReaderProvider in bundle opentelemetry-osgi-testing-autoconfigure
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.integrationtest.osgi.TestSamplerProvider of service io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider in bundle opentelemetry-osgi-testing-autoconfigure
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.sdk.autoconfigure.EnvironmentResourceProvider of service io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider in bundle opentelemetry-sdk-extension-autoconfigure
Sep 09, 2026 11:29:20 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider aQute.tester.bundle.engine.BundleEngine of service org.junit.platform.engine.TestEngine in bundle biz.aQute.tester.junit-platform
> Task :integration-tests:osgi:autoconfigureDeclarativeConfigResolve
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpMetricExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpSpanExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpHttpLogRecordExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcMetricExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcSpanExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpGrpcLogRecordExporterComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpLogRecordExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpMetricExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.otlp.internal.OtlpSpanExporterProvider of service io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider in bundle opentelemetry-exporter-otlp
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.exporter.sender.jdk.internal.JdkHttpSenderProvider of service io.opentelemetry.sdk.common.export.HttpSenderProvider in bundle opentelemetry-exporter-sender-jdk
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.B3ConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.B3MultiConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.JaegerConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.OtTraceConfigurablePropagator of service io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.internal.B3ComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.extension.trace.propagation.internal.B3MultiComponentProvider of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-extension-trace-propagators
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.integrationtest.osgi.TestDeclarativeConfigurationCustomizerProvider of service io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider in bundle opentelemetry-osgi-testing-autoconfigureDeclarativeConfig
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.sdk.autoconfigure.EnvironmentResourceProvider of service io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider in bundle opentelemetry-sdk-extension-autoconfigure
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.sdk.autoconfigure.declarativeconfig.ServiceResourceDetector of service io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider in bundle opentelemetry-sdk-extension-declarative-config
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider io.opentelemetry.sdk.extension.incubator.resources.ServiceInstanceIdResourceProvider of service io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider in bundle opentelemetry-sdk-extension-incubator
Sep 09, 2026 11:29:21 AM org.apache.aries.spifly.BaseActivator log
INFO: Registered provider aQute.tester.bundle.engine.BundleEngine of service org.junit.platform.engine.TestEngine in bundle biz.aQute.tester.junit-platform
```