### PR TITLE
Suppress test logs from SdkMeterProviderMetricsTest

### DIFF
--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderMetricsTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/SdkMeterProviderMetricsTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.internal.testing.slf4j.SuppressLogger;
 import io.opentelemetry.sdk.common.internal.SemConvAttributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricProducer;
@@ -64,6 +65,7 @@ class SdkMeterProviderMetricsTest {
   }
 
   @Test
+  @SuppressLogger(PeriodicMetricReader.class)
   void collectionFailureIsRecordedWithErrorType() {
     InMemoryMetricExporter metricExporter = InMemoryMetricExporter.create();
     AtomicBoolean shouldFail = new AtomicBoolean(true);


### PR DESCRIPTION
Suppresses build output logs of the form:

```
> Task :sdk:metrics:test

SdkMeterProviderMetricsTest > collectionFailureIsRecordedWithErrorType() STANDARD_ERROR
    [Test worker] WARN io.opentelemetry.sdk.metrics.export.PeriodicMetricReader - Exporter threw an Exception
    java.lang.IllegalStateException: boom
        at io.opentelemetry.sdk.metrics.SdkMeterProviderMetricsTest.lambda$collectionFailureIsRecordedWithErrorType$4(SdkMeterProviderMetricsTest.java:75)
        at io.opentelemetry.sdk.metrics.SdkMeterProvider$SdkCollectionRegistration.collectAllMetrics(SdkMeterProvider.java:262)
        at io.opentelemetry.sdk.metrics.export.PeriodicMetricReader$Scheduled.doRun(PeriodicMetricReader.java:277)
        at io.opentelemetry.sdk.metrics.export.PeriodicMetricReader.forceFlush(PeriodicMetricReader.java:111)
        at io.opentelemetry.sdk.metrics.SdkMeterProvider.forceFlush(SdkMeterProvider.java:152)
        at io.opentelemetry.sdk.metrics.SdkMeterProviderMetricsTest.collectionFailureIsRecordedWithErrorType(SdkMeterProviderMetricsTest.java:85)
```