### PR TITLE
Set original_payload_format to "jfr" in the JFR export example

### DIFF
--- a/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExportExample.java
+++ b/opentelemetry-jfr-profiles-shim/src/main/java/io/opentelemetry/sdk/profiles/jfr/JfrExportExample.java
@@ -91,7 +91,7 @@ public class JfrExportExample {
         0,
         profileId,
         0,
-        "format",
+        "jfr",
         ByteBuffer.wrap(Files.readAllBytes(jfrFilePath)),
         Collections.emptyList());
   }


### PR DESCRIPTION
Fixes #8807

## Description

- `JfrExportExample.convertJfrFile()` attaches the raw `.jfr` file bytes as `originalPayload` but passes the literal `"format"` as `originalPayloadFormat`; this changes it to `"jfr"`.
- The `ProfileData.getOriginalPayloadFormat()` Javadoc requires the field when `original_payload` is present and defers to semantic conventions for its values; the `profiles.proto` comment on `original_payload_format` gives `jfr` as its example, and the [specification profiles README](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/profiles/README.md) lists `pprof`, `jfr` and `linux_perf` as known values.
- `"format"` is the placeholder from the exporter test fixture `FakeTelemetryUtil`, unchanged since the module was added in #8207.
- Related: #8349 replaced the `ValueTypeData.create(0, 0)` placeholder in the same call but left this argument.

## Testing done

- No test added: the change is a single constant literal, and the module has no test source set (same as #8349, which changed this method without tests).
- `./gradlew :opentelemetry-jfr-profiles-shim:check` — BUILD SUCCESSFUL (compileJava, checkstyleMain and spotlessCheck passed; `test` reported NO-SOURCE).

