### PR TITLE
Skip W3C multi-tenant tracestate keys when converting to OpenCensus

### DIFF
--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/SpanConverter.java
@@ -84,7 +84,14 @@ final class SpanConverter {
 
   static Tracestate mapTracestate(TraceState traceState) {
     Tracestate.Builder tracestateBuilder = Tracestate.builder();
-    traceState.forEach(tracestateBuilder::set);
+    traceState.forEach(
+        (key, value) -> {
+          // OpenCensus does not accept the W3C multi-tenant key format (tenant-id@system-id) that
+          // OpenTelemetry allows. Drop such entries instead of failing the whole conversion.
+          if (key.indexOf('@') < 0) {
+            tracestateBuilder.set(key, value);
+          }
+        });
     return tracestateBuilder.build();
   }
 

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/OpenTelemetryTextFormatImplTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/OpenTelemetryTextFormatImplTest.java
@@ -132,4 +132,22 @@ class OpenTelemetryTextFormatImplTest {
     SpanContext extractedSpanContext = textFormatImpl.extract(carrier, GETTER);
     assertThat(extractedSpanContext).isEqualTo(SPAN_CONTEXT);
   }
+
+  @Test
+  void testExtractWithW3cDropsMultiTenantTracestateKeys() {
+    OpenTelemetryTextFormatImpl textFormatImpl =
+        new OpenTelemetryTextFormatImpl(W3CTraceContextPropagator.getInstance());
+    Map<String, String> carrier = new LinkedHashMap<>();
+    carrier.put("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
+    carrier.put("tracestate", "fw529a3039@dt=fw4,congo=t61rcWkgMzE");
+
+    SpanContext extractedSpanContext = textFormatImpl.extract(carrier, GETTER);
+
+    assertThat(extractedSpanContext.getTraceId().toLowerBase16())
+        .isEqualTo("0af7651916cd43dd8448eb211c80319c");
+    assertThat(extractedSpanContext.getSpanId().toLowerBase16()).isEqualTo("b7ad6b7169203331");
+    assertThat(extractedSpanContext.getTraceOptions().isSampled()).isTrue();
+    assertThat(extractedSpanContext.getTracestate().getEntries()).hasSize(1);
+    assertThat(extractedSpanContext.getTracestate().get("congo")).isEqualTo("t61rcWkgMzE");
+  }
 }

--- a/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/SpanConverterTest.java
+++ b/opencensus-shim/src/test/java/io/opentelemetry/opencensusshim/SpanConverterTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.Tracestate;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -43,5 +44,31 @@ class SpanConverterTest {
     assertThat(context.getTraceOptions().isSampled()).isTrue();
     assertThat(context.getTracestate().getEntries().size()).isEqualTo(1);
     assertThat(context.getTracestate().get(traceStateKey)).isEqualTo(traceStateValue);
+  }
+
+  @Test
+  void testFromOtelSpanDropsMultiTenantTracestateKeys() {
+    String traceIdHex = RANDOM_IDS_GENERATOR.generateTraceId();
+    String spanIdHex = RANDOM_IDS_GENERATOR.generateSpanId();
+
+    Span otelSpan = Mockito.mock(Span.class);
+    when(otelSpan.getSpanContext())
+        .thenReturn(
+            io.opentelemetry.api.trace.SpanContext.create(
+                traceIdHex,
+                spanIdHex,
+                TraceFlags.getSampled(),
+                TraceState.builder()
+                    .put("congo", "t61rcWkgMzE")
+                    // W3C multi-tenant key, valid in OpenTelemetry but rejected by OpenCensus
+                    .put("fw529a3039@dt", "fw4")
+                    .build()));
+
+    io.opencensus.trace.Span ocSpan = SpanConverter.fromOtelSpan(otelSpan);
+
+    Tracestate tracestate = ocSpan.getContext().getTracestate();
+    assertThat(tracestate.getEntries()).hasSize(1);
+    assertThat(tracestate.get("congo")).isEqualTo("t61rcWkgMzE");
+    assertThat(tracestate.get("fw529a3039@dt")).isNull();
   }
 }


### PR DESCRIPTION
Fixes #8808

## Description

- `SpanConverter.mapTracestate(TraceState)` passed every entry to `Tracestate.Builder.set`, which throws `IllegalArgumentException: Invalid key fw529a3039@dt` for W3C multi-tenant keys (`tenant-id@system-id`).
- Once such a key arrived in an incoming `tracestate` header, `Tracer.getCurrentSpan()`, `spanBuilder(...).startSpan()` and `TextFormat.extract(...)` through the shim all failed.
- The `@` form is the only asymmetry between OpenTelemetry `ArrayBasedTraceStateBuilder.isKeyValid` and OpenCensus `Tracestate.validateKey` (length, value and 32-entry rules match), so entries whose key contains `@` are now skipped. This mirrors the OpenCensus to OpenTelemetry direction, where `TraceStateBuilder.put` already drops entries it cannot represent.
- The delegate OpenTelemetry span keeps the full tracestate; only the OpenCensus view loses the entry.
- Related: W3C Trace Context key format https://www.w3.org/TR/trace-context/#key, OpenCensus compatibility spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opencensus.md

## Testing done

- Added `SpanConverterTest#testFromOtelSpanDropsMultiTenantTracestateKeys` and `OpenTelemetryTextFormatImplTest#testExtractWithW3cDropsMultiTenantTracestateKeys` (header `tracestate: fw529a3039@dt=fw4,congo=t61rcWkgMzE`); both assert only `congo=t61rcWkgMzE` remains and fail with `IllegalArgumentException: Invalid key fw529a3039@dt` when the fix is reverted.
- `./gradlew :opencensus-shim:check` passed (65 tests).
- No CHANGELOG entry (generated at release time); alpha artifact, no apidiff.

