### PR TITLE
Propagate baggage to the parent context in SpanBuilderShim

### DIFF
--- a/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/io/opentelemetry/opentracingshim/SpanBuilderShim.java
@@ -197,8 +197,9 @@ final class SpanBuilderShim implements SpanBuilder {
       builder.setNoParent();
       baggage = Baggage.empty();
     } else if (mainParent != null) {
-      builder.setParent(Context.root().with(io.opentelemetry.api.trace.Span.wrap(mainParent)));
       baggage = getAllBaggage(allParents);
+      builder.setParent(
+          Context.root().with(io.opentelemetry.api.trace.Span.wrap(mainParent)).with(baggage));
     } else {
       // No explicit parent Span, but extracted baggage may be available.
       baggage = Baggage.current();

--- a/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
+++ b/opentracing-shim/src/test/java/io/opentelemetry/opentracingshim/SpanBuilderShimTest.java
@@ -19,8 +19,10 @@ import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -31,6 +33,7 @@ import io.opentracing.noop.NoopSpan;
 import io.opentracing.tag.Tags;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -223,6 +226,50 @@ class SpanBuilderShimTest {
         assertThat("value1").isEqualTo(childSpan.getBaggageItem("key1"));
         assertThat(getBaggageMap(parentSpan.context().baggageItems()))
             .isEqualTo(getBaggageMap(childSpan.context().baggageItems()));
+      } finally {
+        childSpan.finish();
+      }
+    } finally {
+      parentSpan.finish();
+    }
+  }
+
+  @Test
+  void baggage_explicitParent_inParentContext() {
+    AtomicReference<Baggage> parentContextBaggage = new AtomicReference<>();
+    SdkTracerProvider tracerSdkFactory =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(
+                new SpanProcessor() {
+                  @Override
+                  public void onStart(Context parentContext, ReadWriteSpan span) {
+                    parentContextBaggage.set(Baggage.fromContext(parentContext));
+                  }
+
+                  @Override
+                  public boolean isStartRequired() {
+                    return true;
+                  }
+
+                  @Override
+                  public void onEnd(ReadableSpan span) {}
+
+                  @Override
+                  public boolean isEndRequired() {
+                    return false;
+                  }
+                })
+            .build();
+    Tracer tracer = tracerSdkFactory.get("SpanShimTest");
+
+    SpanShim parentSpan = (SpanShim) new SpanBuilderShim(tracer, SPAN_NAME).start();
+    try {
+      parentSpan.setBaggageItem("key1", "value1");
+
+      SpanShim childSpan =
+          (SpanShim) new SpanBuilderShim(tracer, SPAN_NAME).asChildOf(parentSpan).start();
+      try {
+        assertThat(parentContextBaggage.get().getEntryValue("key1")).isEqualTo("value1");
       } finally {
         childSpan.finish();
       }


### PR DESCRIPTION
Fixes #7677

## Description

- When an OpenTracing span builder has an explicit parent (`asChildOf` / `addReference`), `SpanBuilderShim.start()` set the parent `Context` with only the wrapped parent `Span`, leaving out the baggage merged from the references.
- As a result, the `parentContext` the SDK hands to `Sampler.shouldSample` and `SpanProcessor.onStart` never carried any baggage, even though the resulting `SpanShim` did.
- This change computes the merged baggage first and puts it into the parent `Context` alongside the parent `Span`.
- Matches what the module already does on the implicit-parent path (`SpanShim.storeInContext` adds `span` and `baggage` to the context) and in `Propagation.injectTextMap`.
- The no-parent and implicit-parent branches, link handling, and the baggage passed to `SpanShim` are unchanged.
- Related: #4916 (introduced merging baggage from all references).

## Testing done

- Added `SpanBuilderShimTest#baggage_explicitParent_inParentContext`: a `SpanProcessor` captures `Baggage.fromContext(parentContext)` in `onStart`; with the fix reverted it fails with `expected: "value1" but was: null`, with the fix it passes.
- `./gradlew :opentracing-shim:check` — 85 tests passed.
- `SpanBuilderShim` is package-private; no `docs/apidiffs` change.

