### PR TITLE
Fix createTracerShim example in the OpenTracing shim README

### DIFF
--- a/opentracing-shim/README.md
+++ b/opentracing-shim/README.md
@@ -17,7 +17,7 @@ There are 2 ways to expose an OpenTracing tracer:
     ```
 2. From a specific `TracerProvider`, text map propagator (`TextMapPropagator`), and http propagator (`TextMapPropagator`):
     ```java
-    Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry, textMapPropagator, httpPropagator);
+    Tracer tracer = OpenTracingShim.createTracerShim(tracerProvider, textMapPropagator, httpPropagator);
     ```
 
 Optionally register the tracer as the OpenTracing GlobalTracer:


### PR DESCRIPTION
## Description

- The second usage example in `opentracing-shim/README.md` calls `OpenTracingShim.createTracerShim(openTelemetry, textMapPropagator, httpPropagator)`, but the only three-argument overload is `createTracerShim(TracerProvider provider, TextMapPropagator textMapPropagator, TextMapPropagator httpPropagator)`, and `OpenTelemetry` does not implement `TracerProvider`, so the snippet does not compile.
- Renames the first argument in the snippet to `tracerProvider`, matching the surrounding prose ("From a specific `TracerProvider`, ...") and the overload signature.
- The snippet has been wrong since it was added in #5145; the overload already took a `TracerProvider` at that time (#4988).

## Testing done

- Docs-only, test-exempt: no test added.
- Verified the corrected snippet against `OpenTracingShim.createTracerShim(TracerProvider, TextMapPropagator, TextMapPropagator)` in `OpenTracingShim.java`.

