### PR TITLE
Update OpenCensus shim metrics docs to use registerMetricProducer

### DIFF
--- a/opencensus-shim/README.md
+++ b/opencensus-shim/README.md
@@ -26,13 +26,14 @@ Applications only need to set up OpenTelemetry exporters, not OpenCensus.
 
 To allow the shim to work for metrics, add the shim as a dependency.
 
-Applications also need to attach OpenCensus metrics to their metric readers on registration.
+Applications also need to register the OpenCensus metric producer with the meter provider.
 
 ```java
 PeriodicMetricReader reader = ...
 SdkMeterProvider.builder()
-    .registerMetricReader(OpenCensusMetrics.attachTo(reader))
-    .buildAndRegisterGlobal();
+    .registerMetricReader(reader)
+    .registerMetricProducer(OpenCensusMetricProducer.create())
+    .build();
 ```
 
 For example, if a logging exporter were configured, the following would be
@@ -41,6 +42,7 @@ added:
 ```java
 LoggingMetricExporter metricExporter = LoggingMetricExporter.create();
 SdkMeterProvider.builder()
-    .registerMetricReader(OpenCensusMetrics.attachTo(PeriodicMetricReader.create(metricExporter)))
+    .registerMetricReader(PeriodicMetricReader.create(metricExporter))
+    .registerMetricProducer(OpenCensusMetricProducer.create())
     .build();
 ```

--- a/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenCensusMetricProducer.java
+++ b/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/OpenCensusMetricProducer.java
@@ -35,8 +35,8 @@ public final class OpenCensusMetricProducer implements MetricProducer {
   }
 
   /**
-   * Constructs a new {@link OpenCensusMetricProducer} that reports against the given {@link
-   * Resource}.
+   * Constructs a new {@link OpenCensusMetricProducer} that reads from the global OpenCensus {@link
+   * MetricProducerManager}.
    *
    * @deprecated OpenCensus compatibility is deprecated in the OpenTelemetry specification (see <a
    *     href="https://github.com/open-telemetry/opentelemetry-specification/pull/5138">#5138</a>).


### PR DESCRIPTION
Fixes #8811

## Description

- The "Metrics" examples in `opencensus-shim/README.md` still call `OpenCensusMetrics.attachTo(reader)`; that class was removed in #5835 (2023-09), so the snippets do not compile.
- The first example also called `SdkMeterProviderBuilder.buildAndRegisterGlobal()`, which was removed in #3990 and only exists on `OpenTelemetrySdkBuilder`.
- Both examples now use `registerMetricReader(reader).registerMetricProducer(OpenCensusMetricProducer.create()).build()`, as in `OpenCensusMetricsTest` and the class Javadoc; the intro sentence was reworded to match.
- The Javadoc of `OpenCensusMetricProducer.create()` described a `Resource` parameter it has not taken since #5835; it now says the producer reads from the global OpenCensus `MetricProducerManager`. The `@deprecated` block is unchanged.
- Related: #5835, #3990

## Testing done

- Docs-only (README and one Javadoc sentence), test-exempt: no test added.
- `./gradlew :opencensus-shim:check` passed (63 tests; spotless, ErrorProne/NullAway, checkstyle).
- The new snippet is the same call chain as `OpenCensusMetricsTest#capturesOpenCensusAndOtelMetrics`, which compiles and passes.
- No CHANGELOG entry (generated at release time); alpha artifact, no apidiff.

